### PR TITLE
Optimize bootstrap seeding

### DIFF
--- a/cloudfunctions/bootstrap/index.js
+++ b/cloudfunctions/bootstrap/index.js
@@ -20,15 +20,12 @@ exports.main = async () => {
 
 async function seedCollection(name, dataList) {
   const collection = db.collection(name);
-  for (const item of dataList) {
-    const doc = await collection.doc(item._id).get().catch(() => null);
-    if (!doc || !doc.data) {
-      await collection.add({ data: item });
-    } else {
+  await Promise.all(
+    dataList.map(async (item) => {
       const { _id, ...payload } = item;
-      await collection.doc(item._id).update({ data: payload });
-    }
-  }
+      await collection.doc(_id).set({ data: payload });
+    })
+  );
 }
 
 const subLevelLabels = ['一层', '二层', '三层', '四层', '五层', '六层', '七层', '八层', '九层', '圆满'];


### PR DESCRIPTION
## Summary
- replace the bootstrap data seeding logic to use doc.set for each seed entry
- run each collection's writes concurrently to avoid redundant reads and reduce execution time

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d53b5e83948330ba8dbd96f67a7119