### PR TITLE
Fix sitemap configuration for preview

### DIFF
--- a/miniprogram/sitemap.json
+++ b/miniprogram/sitemap.json
@@ -1,3 +1,8 @@
 {
-  "rules": []
+  "rules": [
+    {
+      "action": "allow",
+      "page": "*"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- populate the mini program sitemap with a default allow rule so the developer tool recognizes the required rules field

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d545b947988330982072928d6565e3