### PR TITLE
Adjust recharge experience scaling to 1:100

### DIFF
--- a/cloudfunctions/bootstrap/index.js
+++ b/cloudfunctions/bootstrap/index.js
@@ -29,6 +29,7 @@ async function seedCollection(name, dataList) {
 }
 
 const subLevelLabels = ['一层', '二层', '三层', '四层', '五层', '六层', '七层', '八层', '九层', '圆满'];
+const EXPERIENCE_PER_YUAN = 100;
 
 const realmConfigs = [
   {
@@ -475,7 +476,7 @@ function buildMembershipLevels() {
         realmDescription: realm.description,
         subLevel,
         subLevelLabel: label,
-        threshold: thresholdYuan * 100,
+        threshold: Math.round(thresholdYuan * EXPERIENCE_PER_YUAN),
         discount,
         order,
         virtualRewards: [],

--- a/cloudfunctions/wallet/index.js
+++ b/cloudfunctions/wallet/index.js
@@ -8,8 +8,13 @@ const _ = db.command;
 const COLLECTIONS = {
   MEMBERS: 'members',
   TRANSACTIONS: 'walletTransactions',
-  RESERVATIONS: 'reservations'
+  RESERVATIONS: 'reservations',
+  MEMBER_RIGHTS: 'memberRights',
+  MEMBERSHIP_LEVELS: 'membershipLevels',
+  MEMBERSHIP_RIGHTS: 'membershipRights'
 };
+
+const EXPERIENCE_PER_YUAN = 100;
 
 exports.main = async (event, context) => {
   const { OPENID } = cloud.getWXContext();
@@ -20,6 +25,8 @@ exports.main = async (event, context) => {
       return getSummary(OPENID);
     case 'createRecharge':
       return createRecharge(OPENID, event.amount);
+    case 'completeRecharge':
+      return completeRecharge(OPENID, event.transactionId);
     case 'balancePay':
       return payWithBalance(OPENID, event.orderId, event.amount);
     default:
@@ -93,6 +100,67 @@ async function createRecharge(openid, amount) {
   };
 }
 
+async function completeRecharge(openid, transactionId) {
+  if (!transactionId) {
+    throw new Error('充值记录不存在');
+  }
+
+  let result = { success: true, message: '充值成功' };
+  await db.runTransaction(async (transaction) => {
+    const transactionRef = transaction.collection(COLLECTIONS.TRANSACTIONS).doc(transactionId);
+    const transactionDoc = await transactionRef.get().catch(() => null);
+    if (!transactionDoc || !transactionDoc.data) {
+      throw new Error('充值记录不存在');
+    }
+    const record = transactionDoc.data;
+    if (record.memberId !== openid) {
+      throw new Error('无权操作该充值记录');
+    }
+    if (record.type !== 'recharge') {
+      throw new Error('记录类型错误');
+    }
+    if (record.status === 'success') {
+      result = { success: true, message: '充值已完成' };
+      return;
+    }
+
+    const amount = record.amount || 0;
+    const experienceGain = calculateExperienceGain(amount);
+
+    await transactionRef.update({
+      data: {
+        status: 'success',
+        updatedAt: new Date()
+      }
+    });
+
+    const memberUpdate = {
+      balance: _.inc(amount),
+      updatedAt: new Date()
+    };
+    if (experienceGain > 0) {
+      memberUpdate.experience = _.inc(experienceGain);
+    }
+
+    await transaction.collection(COLLECTIONS.MEMBERS).doc(openid).update({
+      data: memberUpdate
+    });
+
+    result = {
+      success: true,
+      message: '充值成功',
+      amount,
+      experienceGain
+    };
+  });
+
+  if (result.success) {
+    await syncMemberLevel(openid);
+  }
+
+  return result;
+}
+
 async function payWithBalance(openid, orderId, amount) {
   if (!amount || amount <= 0) {
     throw new Error('扣款金额无效');
@@ -134,7 +202,89 @@ async function payWithBalance(openid, orderId, amount) {
 }
 
 const transactionTypeLabel = {
-  recharge: '充值',
+  recharge: '充',
   spend: '消费',
   reward: '奖励'
 };
+
+function calculateExperienceGain(amountFen) {
+  if (!amountFen || amountFen <= 0) {
+    return 0;
+  }
+  return Math.max(0, Math.round((amountFen * EXPERIENCE_PER_YUAN) / 100));
+}
+
+async function syncMemberLevel(openid) {
+  const [memberDoc, levelsSnapshot] = await Promise.all([
+    db.collection(COLLECTIONS.MEMBERS).doc(openid).get().catch(() => null),
+    db.collection(COLLECTIONS.MEMBERSHIP_LEVELS).orderBy('order', 'asc').get()
+  ]);
+  if (!memberDoc || !memberDoc.data) return;
+  const member = memberDoc.data;
+  const levels = levelsSnapshot.data || [];
+  if (!levels.length) return;
+  const targetLevel = resolveLevelByExperience(member.experience || 0, levels);
+  if (!targetLevel || targetLevel._id === member.levelId) {
+    return;
+  }
+  await db
+    .collection(COLLECTIONS.MEMBERS)
+    .doc(openid)
+    .update({
+      data: {
+        levelId: targetLevel._id,
+        updatedAt: new Date()
+      }
+    });
+  await grantLevelRewards(openid, targetLevel);
+}
+
+function resolveLevelByExperience(exp, levels) {
+  let target = levels[0];
+  levels.forEach((lvl) => {
+    if (exp >= lvl.threshold) {
+      target = lvl;
+    }
+  });
+  return target;
+}
+
+async function grantLevelRewards(openid, level) {
+  const rewards = level.rewards || [];
+  if (!rewards.length) return;
+  const masterSnapshot = await db.collection(COLLECTIONS.MEMBERSHIP_RIGHTS).get();
+  const masterMap = {};
+  masterSnapshot.data.forEach((item) => {
+    masterMap[item._id] = item;
+  });
+  const rightsCollection = db.collection(COLLECTIONS.MEMBER_RIGHTS);
+  const now = new Date();
+  for (const reward of rewards) {
+    const right = masterMap[reward.rightId];
+    if (!right) continue;
+    const existing = await rightsCollection
+      .where({ memberId: openid, rightId: reward.rightId, levelId: level._id })
+      .count();
+    const quantity = reward.quantity || 1;
+    if (existing.total >= quantity) continue;
+    const validUntil = right.validDays
+      ? new Date(now.getTime() + right.validDays * 24 * 60 * 60 * 1000)
+      : null;
+    for (let i = existing.total; i < quantity; i += 1) {
+      await rightsCollection.add({
+        data: {
+          memberId: openid,
+          rightId: reward.rightId,
+          levelId: level._id,
+          status: 'active',
+          issuedAt: now,
+          validUntil,
+          meta: {
+            fromLevel: level._id,
+            rewardName: reward.description || right.name
+          }
+        }
+      });
+    }
+  }
+}

--- a/miniprogram/pages/wallet/wallet.js
+++ b/miniprogram/pages/wallet/wallet.js
@@ -54,9 +54,15 @@ Page({
       }
       wx.requestPayment({
         ...result.payment,
-        success: () => {
-          wx.showToast({ title: '充值成功', icon: 'success' });
-          this.fetchSummary();
+        success: async () => {
+          try {
+            await WalletService.completeRecharge(result.transactionId);
+            wx.showToast({ title: '充值成功', icon: 'success' });
+          } catch (error) {
+            wx.showToast({ title: '充值状态更新失败', icon: 'none' });
+          } finally {
+            this.fetchSummary();
+          }
         },
         fail: () => {
           wx.showToast({ title: '支付已取消', icon: 'none' });

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -79,6 +79,12 @@ export const WalletService = {
       amount
     });
   },
+  async completeRecharge(transactionId) {
+    return callCloud(CLOUD_FUNCTIONS.WALLET, {
+      action: 'completeRecharge',
+      transactionId
+    });
+  },
   async payWithBalance(orderId, amount) {
     return callCloud(CLOUD_FUNCTIONS.WALLET, {
       action: 'balancePay',


### PR DESCRIPTION
## Summary
- introduce a shared 1:100 experience-per-yuan ratio when seeding membership level thresholds
- add a wallet cloud function action that finalizes recharge orders, applies scaled experience, and synchronizes member levels
- update the mini program wallet page and API client to call the new completion endpoint after payment succeeds

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d57e0135a88330a7f8c01f24993fa8