### PR TITLE
fix: normalize roles to expose admin entry

### DIFF
--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -1,0 +1,238 @@
+const cloud = require('wx-server-sdk');
+
+cloud.init({ env: cloud.DYNAMIC_CURRENT_ENV });
+
+const db = cloud.database();
+const _ = db.command;
+
+const COLLECTIONS = {
+  MEMBERS: 'members',
+  LEVELS: 'membershipLevels'
+};
+
+const ADMIN_ROLES = ['admin', 'developer'];
+
+function normalizeRoles(rawRoles) {
+  if (Array.isArray(rawRoles)) {
+    const cleaned = rawRoles
+      .filter((role) => typeof role === 'string' && role.trim())
+      .map((role) => role.trim());
+    return cleaned.length ? Array.from(new Set(cleaned)) : ['member'];
+  }
+  if (typeof rawRoles === 'string' && rawRoles.trim()) {
+    return [rawRoles.trim()];
+  }
+  return ['member'];
+}
+
+exports.main = async (event) => {
+  const { OPENID } = cloud.getWXContext();
+  const action = event.action || 'listMembers';
+
+  switch (action) {
+    case 'listMembers':
+      return listMembers(OPENID, event.keyword || '', event.page || 1, event.pageSize || 20);
+    case 'getMemberDetail':
+      return getMemberDetail(OPENID, event.memberId);
+    case 'updateMember':
+      return updateMember(OPENID, event.memberId, event.updates || {});
+    default:
+      throw new Error(`Unknown action: ${action}`);
+  }
+};
+
+async function ensureAdmin(openid) {
+  if (!openid) {
+    throw new Error('未获取到用户身份');
+  }
+  const doc = await db
+    .collection(COLLECTIONS.MEMBERS)
+    .doc(openid)
+    .get()
+    .catch(() => null);
+  const member = doc && doc.data;
+  if (!member) {
+    throw new Error('账号不存在');
+  }
+  const roles = normalizeRoles(member.roles);
+  if (roles !== member.roles) {
+    await db
+      .collection(COLLECTIONS.MEMBERS)
+      .doc(openid)
+      .update({
+        data: { roles, updatedAt: new Date() }
+      })
+      .catch(() => {});
+  }
+  member.roles = roles;
+  const hasAdminRole = roles.some((role) => ADMIN_ROLES.includes(role));
+  if (!hasAdminRole) {
+    throw new Error('无权访问管理员功能');
+  }
+  return member;
+}
+
+async function listMembers(openid, keyword, page, pageSize) {
+  await ensureAdmin(openid);
+  const limit = Math.min(Math.max(pageSize, 1), 50);
+  const skip = Math.max(page - 1, 0) * limit;
+
+  const regex = keyword
+    ? db.RegExp({
+        regexp: keyword,
+        options: 'i'
+      })
+    : null;
+
+  let baseQuery = db.collection(COLLECTIONS.MEMBERS);
+  if (regex) {
+    baseQuery = baseQuery.where(
+      _.or([
+        { nickName: regex },
+        { mobile: regex },
+        { _id: regex }
+      ])
+    );
+  }
+
+  const [snapshot, countResult, levels] = await Promise.all([
+    baseQuery
+      .orderBy('createdAt', 'desc')
+      .skip(skip)
+      .limit(limit)
+      .get(),
+    baseQuery.count(),
+    loadLevels()
+  ]);
+
+  const levelMap = buildLevelMap(levels);
+  const members = snapshot.data.map((member) => decorateMemberRecord(member, levelMap));
+  return {
+    members,
+    total: countResult.total,
+    page,
+    pageSize: limit
+  };
+}
+
+async function getMemberDetail(openid, memberId) {
+  await ensureAdmin(openid);
+  if (!memberId) {
+    throw new Error('缺少会员编号');
+  }
+  return fetchMemberDetail(memberId);
+}
+
+async function updateMember(openid, memberId, updates) {
+  await ensureAdmin(openid);
+  if (!memberId) {
+    throw new Error('缺少会员编号');
+  }
+  const payload = buildUpdatePayload(updates);
+  if (!Object.keys(payload).length) {
+    return fetchMemberDetail(memberId);
+  }
+  payload.updatedAt = new Date();
+  await db
+    .collection(COLLECTIONS.MEMBERS)
+    .doc(memberId)
+    .update({
+      data: payload
+    });
+  return fetchMemberDetail(memberId);
+}
+
+async function fetchMemberDetail(memberId) {
+  const [memberDoc, levels] = await Promise.all([
+    db
+      .collection(COLLECTIONS.MEMBERS)
+      .doc(memberId)
+      .get()
+      .catch(() => null),
+    loadLevels()
+  ]);
+  if (!memberDoc || !memberDoc.data) {
+    throw new Error('会员不存在');
+  }
+  const levelMap = buildLevelMap(levels);
+  return {
+    member: decorateMemberRecord(memberDoc.data, levelMap),
+    levels: levels.map((level) => ({
+      _id: level._id,
+      name: level.displayName || level.name,
+      order: level.order
+    }))
+  };
+}
+
+async function loadLevels() {
+  const snapshot = await db.collection(COLLECTIONS.LEVELS).orderBy('order', 'asc').get();
+  return snapshot.data || [];
+}
+
+function buildLevelMap(levels) {
+  const map = {};
+  (levels || []).forEach((level) => {
+    map[level._id] = level;
+  });
+  return map;
+}
+
+function decorateMemberRecord(member, levelMap) {
+  const level = member.levelId ? levelMap[member.levelId] : null;
+  const roles = normalizeRoles(member.roles);
+  return {
+    _id: member._id,
+    nickName: member.nickName || '',
+    avatarUrl: member.avatarUrl || '',
+    mobile: member.mobile || '',
+    balance: Number(member.balance || 0),
+    experience: Number(member.experience || 0),
+    levelId: member.levelId || '',
+    levelName: level ? level.displayName || level.name : '',
+    roles,
+    createdAt: formatDate(member.createdAt),
+    updatedAt: formatDate(member.updatedAt),
+    avatarConfig: member.avatarConfig || {}
+  };
+}
+
+function buildUpdatePayload(updates) {
+  const payload = {};
+  if (Object.prototype.hasOwnProperty.call(updates, 'nickName')) {
+    payload.nickName = updates.nickName || '';
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, 'mobile')) {
+    payload.mobile = updates.mobile || '';
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, 'levelId')) {
+    payload.levelId = updates.levelId || '';
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, 'experience')) {
+    const experience = Number(updates.experience || 0);
+    payload.experience = Number.isFinite(experience) ? experience : 0;
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, 'balance')) {
+    const balance = Number(updates.balance || 0);
+    payload.balance = Number.isFinite(balance) ? balance : 0;
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, 'roles')) {
+    const roles = normalizeRoles(updates.roles).filter((role) => ['member', 'admin', 'developer'].includes(role));
+    payload.roles = roles.length ? roles : ['member'];
+  }
+  return payload;
+}
+
+function formatDate(value) {
+  if (!value) return '';
+  if (typeof value === 'string') return value;
+  if (value instanceof Date) return value.toISOString();
+  if (value && typeof value.toDate === 'function') {
+    try {
+      return value.toDate().toISOString();
+    } catch (err) {
+      return '';
+    }
+  }
+  return '';
+}

--- a/cloudfunctions/admin/package.json
+++ b/cloudfunctions/admin/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "admin",
+  "version": "1.0.0",
+  "description": "管理员功能云函数",
+  "main": "index.js",
+  "dependencies": {
+    "wx-server-sdk": "latest"
+  }
+}

--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -6,7 +6,10 @@
     "pages/tasks/tasks",
     "pages/reservation/reservation",
     "pages/wallet/wallet",
-    "pages/avatar/avatar"
+    "pages/avatar/avatar",
+    "pages/admin/index",
+    "pages/admin/members/index",
+    "pages/admin/member-detail/index"
   ],
   "window": {
     "backgroundTextStyle": "light",

--- a/miniprogram/pages/admin/index.js
+++ b/miniprogram/pages/admin/index.js
@@ -1,0 +1,18 @@
+Page({
+  data: {
+    quickActions: [
+      {
+        icon: '👥',
+        label: '会员列表',
+        description: '查看与管理会员资料',
+        url: '/pages/admin/members/index'
+      }
+    ]
+  },
+
+  handleActionTap(event) {
+    const { url } = event.currentTarget.dataset;
+    if (!url) return;
+    wx.navigateTo({ url });
+  }
+});

--- a/miniprogram/pages/admin/index.json
+++ b/miniprogram/pages/admin/index.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "管理员中心"
+}

--- a/miniprogram/pages/admin/index.wxml
+++ b/miniprogram/pages/admin/index.wxml
@@ -1,0 +1,23 @@
+<view class="admin-home">
+  <view class="intro">
+    <view class="title">管理员入口</view>
+    <view class="subtitle">快速访问后台常用功能</view>
+  </view>
+
+  <view class="action-grid">
+    <view
+      wx:for="{{quickActions}}"
+      wx:key="label"
+      class="action-card"
+      data-url="{{item.url}}"
+      bindtap="handleActionTap"
+    >
+      <view class="action-icon">{{item.icon}}</view>
+      <view class="action-info">
+        <view class="action-label">{{item.label}}</view>
+        <view class="action-desc">{{item.description}}</view>
+      </view>
+      <view class="action-arrow">›</view>
+    </view>
+  </view>
+</view>

--- a/miniprogram/pages/admin/index.wxss
+++ b/miniprogram/pages/admin/index.wxss
@@ -1,0 +1,66 @@
+.admin-home {
+  min-height: 100vh;
+  background: #0f172a;
+  padding: 32rpx;
+  color: #e2e8f0;
+}
+
+.intro {
+  margin-bottom: 32rpx;
+}
+
+.title {
+  font-size: 36rpx;
+  font-weight: 600;
+  margin-bottom: 8rpx;
+}
+
+.subtitle {
+  font-size: 28rpx;
+  color: #94a3b8;
+}
+
+.action-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 24rpx;
+}
+
+.action-card {
+  display: flex;
+  align-items: center;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 20rpx;
+  padding: 24rpx;
+  backdrop-filter: blur(12px);
+}
+
+.action-card:active {
+  opacity: 0.8;
+}
+
+.action-icon {
+  font-size: 48rpx;
+  margin-right: 24rpx;
+}
+
+.action-info {
+  flex: 1;
+}
+
+.action-label {
+  font-size: 32rpx;
+  font-weight: 600;
+  margin-bottom: 4rpx;
+}
+
+.action-desc {
+  font-size: 26rpx;
+  color: #94a3b8;
+}
+
+.action-arrow {
+  font-size: 40rpx;
+  color: #64748b;
+}

--- a/miniprogram/pages/admin/member-detail/index.js
+++ b/miniprogram/pages/admin/member-detail/index.js
@@ -1,0 +1,136 @@
+import { AdminService } from '../../../services/api';
+
+function ensureMemberRole(roles) {
+  const list = Array.isArray(roles) ? [...new Set(roles)] : [];
+  if (!list.includes('member')) {
+    list.push('member');
+  }
+  return list;
+}
+
+Page({
+  data: {
+    memberId: '',
+    loading: true,
+    saving: false,
+    member: null,
+    levels: [],
+    levelIndex: 0,
+    currentLevelName: '',
+    roleOptions: [
+      { value: 'member', label: '会员' },
+      { value: 'admin', label: '管理员' },
+      { value: 'developer', label: '开发' }
+    ],
+    form: {
+      nickName: '',
+      mobile: '',
+      experience: '',
+      balance: '',
+      levelId: '',
+      roles: []
+    }
+  },
+
+  onLoad(options) {
+    const { id } = options;
+    if (!id) {
+      wx.showToast({ title: '缺少会员编号', icon: 'none' });
+      return;
+    }
+    this.setData({ memberId: id });
+    this.loadMember(id);
+  },
+
+  onPullDownRefresh() {
+    if (!this.data.memberId) return;
+    this.loadMember(this.data.memberId).finally(() => {
+      wx.stopPullDownRefresh();
+    });
+  },
+
+  async loadMember(memberId) {
+    this.setData({ loading: true });
+    try {
+      const detail = await AdminService.getMemberDetail(memberId);
+      this.applyDetail(detail);
+    } catch (error) {
+      console.error('[admin:member:detail]', error);
+      this.setData({ loading: false });
+      wx.showToast({ title: error.errMsg || error.message || '加载失败', icon: 'none' });
+    }
+  },
+
+  applyDetail(detail) {
+    if (!detail || !detail.member) return;
+    const { member, levels = [] } = detail;
+    const levelIndex = Math.max(
+      levels.findIndex((level) => level._id === member.levelId),
+      0
+    );
+    const currentLevel = levels[levelIndex] || levels[0] || { _id: '', name: '' };
+    this.setData({
+      member,
+      levels,
+      levelIndex,
+      currentLevelName: currentLevel.name || '',
+      loading: false,
+      form: {
+        nickName: member.nickName || '',
+        mobile: member.mobile || '',
+        experience: String(member.experience ?? 0),
+        balance: String(member.balance ?? 0),
+        levelId: member.levelId || currentLevel._id || '',
+        roles: ensureMemberRole(member.roles)
+      }
+    });
+  },
+
+  handleInputChange(event) {
+    const { field } = event.currentTarget.dataset;
+    if (!field) return;
+    this.setData({ [`form.${field}`]: event.detail.value });
+  },
+
+  handleLevelChange(event) {
+    const index = Number(event.detail.value);
+    const level = this.data.levels[index];
+    if (!level) return;
+    this.setData({
+      levelIndex: index,
+      currentLevelName: level.name || '',
+      'form.levelId': level._id
+    });
+  },
+
+  handleRolesChange(event) {
+    const roles = event.detail.value || [];
+    if (!roles.includes('member')) {
+      roles.push('member');
+    }
+    this.setData({ 'form.roles': roles });
+  },
+
+  async handleSubmit() {
+    if (this.data.saving) return;
+    this.setData({ saving: true });
+    try {
+      const payload = {
+        nickName: (this.data.form.nickName || '').trim(),
+        mobile: (this.data.form.mobile || '').trim(),
+        experience: Number(this.data.form.experience || 0),
+        balance: Number(this.data.form.balance || 0),
+        levelId: this.data.form.levelId,
+        roles: ensureMemberRole(this.data.form.roles)
+      };
+      const detail = await AdminService.updateMember(this.data.memberId, payload);
+      this.applyDetail(detail);
+      wx.showToast({ title: '保存成功', icon: 'success' });
+    } catch (error) {
+      console.error('[admin:member:update]', error);
+      wx.showToast({ title: error.errMsg || error.message || '保存失败', icon: 'none' });
+    } finally {
+      this.setData({ saving: false });
+    }
+  }
+});

--- a/miniprogram/pages/admin/member-detail/index.json
+++ b/miniprogram/pages/admin/member-detail/index.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "会员资料"
+}

--- a/miniprogram/pages/admin/member-detail/index.wxml
+++ b/miniprogram/pages/admin/member-detail/index.wxml
@@ -1,0 +1,89 @@
+<view class="member-detail" wx:if="{{!loading}}">
+  <view class="section">
+    <view class="section-title">账号信息</view>
+    <view class="info-row">
+      <view class="info-label">会员 ID</view>
+      <view class="info-value">{{member._id}}</view>
+    </view>
+    <view class="info-row">
+      <view class="info-label">注册时间</view>
+      <view class="info-value">{{member.createdAt || '—'}}</view>
+    </view>
+    <view class="info-row">
+      <view class="info-label">最近更新</view>
+      <view class="info-value">{{member.updatedAt || '—'}}</view>
+    </view>
+  </view>
+
+  <view class="section">
+    <view class="section-title">基础资料</view>
+    <view class="form-item">
+      <view class="form-label">昵称</view>
+      <input
+        class="form-input"
+        value="{{form.nickName}}"
+        placeholder="请输入昵称"
+        data-field="nickName"
+        bindinput="handleInputChange"
+      />
+    </view>
+    <view class="form-item">
+      <view class="form-label">手机号</view>
+      <input
+        class="form-input"
+        value="{{form.mobile}}"
+        placeholder="请输入手机号"
+        data-field="mobile"
+        bindinput="handleInputChange"
+      />
+    </view>
+    <view class="form-item">
+      <view class="form-label">修为值</view>
+      <input
+        class="form-input"
+        type="number"
+        value="{{form.experience}}"
+        placeholder="请输入修为值"
+        data-field="experience"
+        bindinput="handleInputChange"
+      />
+    </view>
+    <view class="form-item">
+      <view class="form-label">灵石余额</view>
+      <input
+        class="form-input"
+        type="number"
+        value="{{form.balance}}"
+        placeholder="请输入余额"
+        data-field="balance"
+        bindinput="handleInputChange"
+      />
+    </view>
+    <view class="form-item">
+      <view class="form-label">当前境界</view>
+      <picker mode="selector" range="{{levels}}" range-key="name" value="{{levelIndex}}" bindchange="handleLevelChange">
+        <view class="picker-value">{{currentLevelName || '请选择境界'}}</view>
+      </picker>
+    </view>
+    <view class="form-item">
+      <view class="form-label">角色权限</view>
+      <checkbox-group class="role-group" bindchange="handleRolesChange">
+        <label
+          wx:for="{{roleOptions}}"
+          wx:key="value"
+          class="role-option"
+        >
+          <checkbox
+            value="{{item.value}}"
+            checked="{{form.roles.indexOf(item.value) !== -1}}"
+          />
+          <text class="role-label">{{item.label}}</text>
+        </label>
+      </checkbox-group>
+    </view>
+  </view>
+
+  <button class="submit" type="primary" loading="{{saving}}" bindtap="handleSubmit">保存修改</button>
+</view>
+
+<view wx:if="{{loading}}" class="loading">加载会员资料...</view>

--- a/miniprogram/pages/admin/member-detail/index.wxss
+++ b/miniprogram/pages/admin/member-detail/index.wxss
@@ -1,0 +1,98 @@
+.member-detail {
+  min-height: 100vh;
+  padding: 32rpx;
+  background: #0b1120;
+  color: #e2e8f0;
+}
+
+.section {
+  background: rgba(15, 23, 42, 0.85);
+  border-radius: 20rpx;
+  padding: 28rpx;
+  margin-bottom: 24rpx;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  backdrop-filter: blur(12px);
+}
+
+.section-title {
+  font-size: 32rpx;
+  font-weight: 600;
+  margin-bottom: 20rpx;
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 26rpx;
+  color: #94a3b8;
+  margin-bottom: 12rpx;
+}
+
+.info-value {
+  color: #e2e8f0;
+}
+
+.form-item {
+  margin-bottom: 24rpx;
+}
+
+.form-label {
+  font-size: 26rpx;
+  color: #94a3b8;
+  margin-bottom: 12rpx;
+}
+
+.form-input {
+  width: 100%;
+  padding: 20rpx;
+  border-radius: 16rpx;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.8);
+  color: #f8fafc;
+}
+
+.picker-value {
+  padding: 20rpx;
+  border-radius: 16rpx;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.8);
+  color: #f8fafc;
+}
+
+.role-group {
+  display: flex;
+  gap: 20rpx;
+  flex-wrap: wrap;
+}
+
+.role-option {
+  display: flex;
+  align-items: center;
+  padding: 12rpx 20rpx;
+  background: rgba(30, 41, 59, 0.6);
+  border-radius: 16rpx;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.role-label {
+  margin-left: 12rpx;
+  font-size: 26rpx;
+}
+
+.submit {
+  margin-top: 12rpx;
+  background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+  border: none;
+  color: #fff;
+  border-radius: 20rpx;
+}
+
+.loading {
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0b1120;
+  color: #94a3b8;
+  font-size: 28rpx;
+}

--- a/miniprogram/pages/admin/members/index.js
+++ b/miniprogram/pages/admin/members/index.js
@@ -1,0 +1,87 @@
+import { AdminService } from '../../../services/api';
+
+const PAGE_SIZE = 20;
+const DEFAULT_AVATAR =
+  'data:image/svg+xml;base64,' +
+  'PHN2ZyB3aWR0aD0iMTIwIiBoZWlnaHQ9IjEyMCIgdmlld0JveD0iMCAwIDEyMCAxMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPGRlZi' +
+  'xzPgogICAgPGxpbmVhckdyYWRpZW50IGlkPSJiZyIgeDE9IjUwJSIgeTE9IjAlIiB4Mj0iNTAlIiB5Mj0iMTAwJSI+CiAgICAgIDxzdG9wIG9mZnNldD0iMCUiIHN0' +
+  'b3AtY29sb3I9IiMxZTMyNTIiIHN0b3Atb3BhY2l0eT0iMC44Ii8+CiAgICAgIDxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzE0MjA0MCIgc3RvcC1vcG' +
+  'FjaXR5PSIwLjkiLz4KICAgIDwvbGluZWFyR3JhZGllbnQ+CiAgICA8bGluZWFyR3JhZGllbnQgaWQ9ImZhY2UiIHgxPSIwJSIgeTE9IjAlIiB4Mj0iMTAwJSIgeTI9' +
+  'IjAlIj4KICAgICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2Y4OTI1YyIgc3RvcC1vcGFjaXR5PSIwLjgiLz4KICAgICAgPHN0b3Agb2Zmc2V0PSIxMD' +
+  'AlIiBzdG9wLWNvbG9yPSIjZjE0ZjdiIiBzdG9wLW9wYWNpdHk9IjAuNiIvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICA8L2RlZnM+CiAgPGNpcmNsZSBjeD0iNjAi' +
+  'IGN5PSI2MCIgcj0iNTgiIGZpbGw9InVybCgjYmcpIi8+CiAgPGNpcmNsZSBjeD0iNjAiIGN5PSI0OCIgcj0iMjIiIGZpbGw9IiNmZmYiLz4KICA8cGF0aCBkPSJNM' +
+  'zAgOTAgUTYwIDcwIDkwIDkwIiBmaWxsPSJub25lIiBzdHJva2U9InVybCgjZmFjZSkiIHN0cm9rZS13aWR0aD0iMTAiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgo' +
+  '8L3N2Zz4=';
+
+Page({
+  data: {
+    keyword: '',
+    members: [],
+    loading: false,
+    total: 0,
+    page: 1,
+    pageSize: PAGE_SIZE,
+    finished: false,
+    error: '',
+    defaultAvatar: DEFAULT_AVATAR
+  },
+
+  onLoad() {
+    this.fetchMembers(true);
+  },
+
+  onPullDownRefresh() {
+    this.fetchMembers(true).finally(() => {
+      wx.stopPullDownRefresh();
+    });
+  },
+
+  onReachBottom() {
+    if (this.data.loading || this.data.finished) return;
+    this.fetchMembers();
+  },
+
+  handleKeywordInput(event) {
+    this.setData({ keyword: event.detail.value || '' });
+  },
+
+  handleSearch() {
+    this.fetchMembers(true);
+  },
+
+  async fetchMembers(reset = false) {
+    const nextPage = reset ? 1 : this.data.page;
+    this.setData({ loading: true, error: '' });
+    try {
+      const response = await AdminService.listMembers({
+        keyword: this.data.keyword.trim(),
+        page: nextPage,
+        pageSize: this.data.pageSize
+      });
+      const incoming = response.members || [];
+      const merged = reset ? incoming : [...this.data.members, ...incoming];
+      const total = response.total || merged.length;
+      const finished = merged.length >= total || incoming.length < this.data.pageSize;
+      this.setData({
+        members: merged,
+        total,
+        page: nextPage + 1,
+        finished,
+        loading: false
+      });
+    } catch (error) {
+      console.error('[admin:members:list]', error);
+      this.setData({
+        loading: false,
+        error: error.errMsg || error.message || '加载失败'
+      });
+      wx.showToast({ title: '加载失败，请稍后重试', icon: 'none' });
+    }
+  },
+
+  handleMemberTap(event) {
+    const { id } = event.currentTarget.dataset;
+    if (!id) return;
+    wx.navigateTo({ url: `/pages/admin/member-detail/index?id=${id}` });
+  }
+});

--- a/miniprogram/pages/admin/members/index.json
+++ b/miniprogram/pages/admin/members/index.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "会员列表"
+}

--- a/miniprogram/pages/admin/members/index.wxml
+++ b/miniprogram/pages/admin/members/index.wxml
@@ -1,0 +1,39 @@
+<view class="admin-members">
+  <view class="search-bar">
+    <input
+      class="search-input"
+      value="{{keyword}}"
+      bindinput="handleKeywordInput"
+      confirm-type="search"
+      bindconfirm="handleSearch"
+      placeholder="搜索昵称 / 手机 / OpenID"
+    />
+    <button class="search-button" bindtap="handleSearch">搜索</button>
+  </view>
+
+  <view wx:if="{{loading && !members.length}}" class="loading">加载中...</view>
+  <view wx:elif="{{!members.length}}" class="empty">未找到相关会员</view>
+
+  <view wx:else class="member-list">
+    <view
+      wx:for="{{members}}"
+      wx:key="_id"
+      class="member-item"
+      data-id="{{item._id}}"
+      bindtap="handleMemberTap"
+    >
+      <image class="member-avatar" src="{{item.avatarUrl || defaultAvatar}}" mode="aspectFill"></image>
+      <view class="member-info">
+        <view class="member-name">{{item.nickName || '未命名会员'}}</view>
+        <view class="member-meta">
+          <text>ID：{{item._id}}</text>
+          <text wx:if="{{item.mobile}}"> · 手机：{{item.mobile}}</text>
+        </view>
+        <view class="member-status">境界：{{item.levelName || '未设置'}} · 角色：{{item.roles.join(' / ')}}</view>
+      </view>
+      <view class="member-arrow">›</view>
+    </view>
+    <view wx:if="{{loading && members.length}}" class="loading-inline">继续加载中...</view>
+    <view wx:if="{{finished && members.length}}" class="end">没有更多数据了</view>
+  </view>
+</view>

--- a/miniprogram/pages/admin/members/index.wxss
+++ b/miniprogram/pages/admin/members/index.wxss
@@ -1,0 +1,99 @@
+.admin-members {
+  min-height: 100vh;
+  padding: 24rpx 32rpx;
+  background: #0b1120;
+  color: #e2e8f0;
+}
+
+.search-bar {
+  display: flex;
+  align-items: center;
+  gap: 16rpx;
+  margin-bottom: 24rpx;
+}
+
+.search-input {
+  flex: 1;
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 16rpx;
+  padding: 20rpx 24rpx;
+  color: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.search-button {
+  background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+  color: #fff;
+  border: none;
+  border-radius: 16rpx;
+  padding: 16rpx 32rpx;
+  font-size: 28rpx;
+}
+
+.loading,
+.empty,
+.end {
+  text-align: center;
+  padding: 48rpx 0;
+  color: #94a3b8;
+}
+
+.member-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16rpx;
+}
+
+.member-item {
+  display: flex;
+  align-items: center;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 20rpx;
+  padding: 24rpx;
+  backdrop-filter: blur(12px);
+}
+
+.member-item:active {
+  opacity: 0.85;
+}
+
+.member-avatar {
+  width: 96rpx;
+  height: 96rpx;
+  border-radius: 50%;
+  margin-right: 24rpx;
+  background: #1e293b;
+}
+
+.member-info {
+  flex: 1;
+}
+
+.member-name {
+  font-size: 32rpx;
+  font-weight: 600;
+  margin-bottom: 8rpx;
+}
+
+.member-meta {
+  font-size: 26rpx;
+  color: #94a3b8;
+  margin-bottom: 6rpx;
+}
+
+.member-status {
+  font-size: 26rpx;
+  color: #cbd5f5;
+}
+
+.member-arrow {
+  font-size: 40rpx;
+  color: #64748b;
+}
+
+.loading-inline {
+  text-align: center;
+  padding: 24rpx 0;
+  color: #94a3b8;
+}

--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -1,6 +1,26 @@
 import { MemberService, TaskService } from '../../services/api';
 import { formatCurrency } from '../../utils/format';
 
+function normalizeRoles(rawRoles) {
+  if (Array.isArray(rawRoles)) {
+    return rawRoles.filter((role) => typeof role === 'string' && role.trim()).map((role) => role.trim());
+  }
+  if (typeof rawRoles === 'string' && rawRoles.trim()) {
+    return [rawRoles.trim()];
+  }
+  return [];
+}
+
+const BASE_NAV_ITEMS = [
+  { icon: '💳', label: '境界等级', url: '/pages/membership/membership' },
+  { icon: '🎁', label: '权益宝库', url: '/pages/rights/rights' },
+  { icon: '📅', label: '灵阁预订', url: '/pages/reservation/reservation' },
+  { icon: '💰', label: '灵石钱包', url: '/pages/wallet/wallet' },
+  { icon: '🧙‍♀️', label: '捏脸塑形', url: '/pages/avatar/avatar' }
+];
+
+const ADMIN_ALLOWED_ROLES = ['admin', 'developer'];
+
 const BACKGROUND_IMAGE =
   'data:image/svg+xml;base64,' +
   'PHN2ZyB3aWR0aD0iNzIwIiBoZWlnaHQ9IjEyODAiIHZpZXdCb3g9IjAgMCA3MjAgMTI4MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZGVm' +
@@ -46,6 +66,15 @@ const DEFAULT_AVATAR =
   'BmaWxsPSIjZmNlMWMyIi8+CiAgPHBhdGggZD0iTTQwIDEzMCBRODAgMTAwIDEyMCAxMzAiIGZpbGw9IiNmMGY0ZmYiIHN0cm9rZT0iI2Q5ZGVmZiIgc3Ryb2tlLXdpZHRo' +
   'PSI0Ii8+Cjwvc3ZnPg==';
 
+function resolveNavItems(member) {
+  const roles = normalizeRoles(member && member.roles);
+  const navItems = [...BASE_NAV_ITEMS];
+  if (roles.some((role) => ADMIN_ALLOWED_ROLES.includes(role))) {
+    navItems.push({ icon: '🛡️', label: '管理员', url: '/pages/admin/index' });
+  }
+  return navItems;
+}
+
 Page({
   data: {
     member: null,
@@ -62,13 +91,7 @@ Page({
       { icon: '🎉', label: '灵境盛典', url: '/pages/rights/rights' },
       { icon: '🔥', label: '冲榜比武' }
     ],
-    navItems: [
-      { icon: '💳', label: '境界等级', url: '/pages/membership/membership' },
-      { icon: '🎁', label: '权益宝库', url: '/pages/rights/rights' },
-      { icon: '📅', label: '灵阁预订', url: '/pages/reservation/reservation' },
-      { icon: '💰', label: '灵石钱包', url: '/pages/wallet/wallet' },
-      { icon: '🧙‍♀️', label: '捏脸塑形', url: '/pages/avatar/avatar' }
-    ]
+    navItems: [...BASE_NAV_ITEMS]
   },
 
   onLoad() {
@@ -92,7 +115,8 @@ Page({
         member,
         progress,
         tasks: tasks.slice(0, 3),
-        loading: false
+        loading: false,
+        navItems: resolveNavItems(member)
       });
     } catch (err) {
       this.setData({ loading: false });

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -105,3 +105,27 @@ export const AvatarService = {
     });
   }
 };
+
+export const AdminService = {
+  async listMembers({ keyword = '', page = 1, pageSize = 20 } = {}) {
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, {
+      action: 'listMembers',
+      keyword,
+      page,
+      pageSize
+    });
+  },
+  async getMemberDetail(memberId) {
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, {
+      action: 'getMemberDetail',
+      memberId
+    });
+  },
+  async updateMember(memberId, updates) {
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, {
+      action: 'updateMember',
+      memberId,
+      updates
+    });
+  }
+};

--- a/miniprogram/services/config.js
+++ b/miniprogram/services/config.js
@@ -4,6 +4,7 @@ export const CLOUD_FUNCTIONS = {
   RESERVATION: 'reservation',
   WALLET: 'wallet',
   AVATAR: 'avatar',
+  ADMIN: 'admin',
   BOOTSTRAP: 'bootstrap'
 };
 


### PR DESCRIPTION
## Summary
- normalize stored role data in member/admin cloud functions to preserve admin privileges
- expose the admin navigation shortcut even when legacy accounts store a single role string
- sanitize role updates in the admin portal so data stays consistent

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d58329e4508330bc19ba08ed2d605a