### PR TITLE
feat: enable immersive full screen layout

### DIFF
--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -15,7 +15,8 @@
     "backgroundTextStyle": "light",
     "navigationBarBackgroundColor": "#ffffff",
     "navigationBarTitleText": "会员中心",
-    "navigationBarTextStyle": "black"
+    "navigationBarTextStyle": "black",
+    "navigationStyle": "custom"
   },
   "style": "v2",
   "sitemapLocation": "sitemap.json"

--- a/miniprogram/app.wxss
+++ b/miniprogram/app.wxss
@@ -1,10 +1,15 @@
 page {
   background: #f5f5f5;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', sans-serif;
+  box-sizing: border-box;
+  padding-top: constant(safe-area-inset-top);
+  padding-top: env(safe-area-inset-top);
 }
 
 .container {
   padding: 32rpx;
+  padding-bottom: calc(32rpx + constant(safe-area-inset-bottom));
+  padding-bottom: calc(32rpx + env(safe-area-inset-bottom));
 }
 
 .card {

--- a/miniprogram/pages/admin/index.wxss
+++ b/miniprogram/pages/admin/index.wxss
@@ -1,7 +1,15 @@
+page {
+  background: #0f172a;
+}
+
 .admin-home {
   min-height: 100vh;
-  background: #0f172a;
+  min-height: calc(100vh - constant(safe-area-inset-top) - constant(safe-area-inset-bottom));
+  min-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
   padding: 32rpx;
+  padding-bottom: calc(32rpx + constant(safe-area-inset-bottom));
+  padding-bottom: calc(32rpx + env(safe-area-inset-bottom));
+  background: #0f172a;
   color: #e2e8f0;
 }
 

--- a/miniprogram/pages/admin/member-detail/index.wxss
+++ b/miniprogram/pages/admin/member-detail/index.wxss
@@ -1,6 +1,14 @@
+page {
+  background: #0b1120;
+}
+
 .member-detail {
   min-height: 100vh;
+  min-height: calc(100vh - constant(safe-area-inset-top) - constant(safe-area-inset-bottom));
+  min-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
   padding: 32rpx;
+  padding-bottom: calc(32rpx + constant(safe-area-inset-bottom));
+  padding-bottom: calc(32rpx + env(safe-area-inset-bottom));
   background: #0b1120;
   color: #e2e8f0;
 }

--- a/miniprogram/pages/admin/members/index.wxss
+++ b/miniprogram/pages/admin/members/index.wxss
@@ -1,6 +1,14 @@
+page {
+  background: #0b1120;
+}
+
 .admin-members {
   min-height: 100vh;
+  min-height: calc(100vh - constant(safe-area-inset-top) - constant(safe-area-inset-bottom));
+  min-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
   padding: 24rpx 32rpx;
+  padding-bottom: calc(24rpx + constant(safe-area-inset-bottom));
+  padding-bottom: calc(24rpx + env(safe-area-inset-bottom));
   background: #0b1120;
   color: #e2e8f0;
 }

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -59,8 +59,12 @@ page {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 100vh;
+  min-height: 100vh;
+  min-height: calc(100vh - constant(safe-area-inset-top) - constant(safe-area-inset-bottom));
+  min-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
   padding: 48rpx 44rpx 40rpx;
+  padding-bottom: calc(40rpx + constant(safe-area-inset-bottom));
+  padding-bottom: calc(40rpx + env(safe-area-inset-bottom));
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary
- enable the custom navigation style to remove the default bar for a fully immersive experience
- add safe-area padding support in global styles and dark admin pages to match device insets
- adjust the home page layout to respect safe-area spacing around the bottom navigation

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d604e90b2883308860383fba4033eb