### PR TITLE
Restore immersive custom navigation spacing

### DIFF
--- a/miniprogram/app.js
+++ b/miniprogram/app.js
@@ -16,6 +16,50 @@ App({
       traceUser: true
     });
 
+    this.setupSystemMetrics();
     this.globalData.ready = true;
+  },
+
+  setupSystemMetrics() {
+    try {
+      const systemInfo = wx.getSystemInfoSync();
+      const menuButtonRect = wx.getMenuButtonBoundingClientRect
+        ? wx.getMenuButtonBoundingClientRect()
+        : null;
+
+      const statusBarHeight = systemInfo.statusBarHeight || 0;
+      let navHeight = statusBarHeight + 44;
+
+      if (menuButtonRect) {
+        const gap = menuButtonRect.top - statusBarHeight;
+        const navBarHeight = menuButtonRect.height + Math.max(gap, 0) * 2;
+        navHeight = statusBarHeight + navBarHeight;
+      }
+
+      const bottomInset = systemInfo.safeArea
+        ? Math.max(systemInfo.screenHeight - systemInfo.safeArea.bottom, 0)
+        : 0;
+
+      this.globalData.customNav = {
+        statusBarHeight,
+        navHeight,
+        menuButtonRect
+      };
+
+      this.globalData.safeArea = {
+        top: statusBarHeight,
+        bottom: bottomInset
+      };
+    } catch (error) {
+      this.globalData.customNav = {
+        statusBarHeight: 0,
+        navHeight: 64,
+        menuButtonRect: null
+      };
+      this.globalData.safeArea = {
+        top: 0,
+        bottom: 0
+      };
+    }
   }
 });

--- a/miniprogram/components/custom-nav/custom-nav.js
+++ b/miniprogram/components/custom-nav/custom-nav.js
@@ -1,0 +1,65 @@
+const app = getApp();
+
+Component({
+  options: {
+    addGlobalClass: true
+  },
+
+  properties: {
+    title: {
+      type: String,
+      value: ''
+    },
+    enableBack: {
+      type: Boolean,
+      value: true
+    },
+    theme: {
+      type: String,
+      value: 'light'
+    }
+  },
+
+  data: {
+    statusBarHeight: 0,
+    navHeight: 64,
+    navBarHeight: 44,
+    navPlaceholderHeight: 64,
+    showBack: false,
+    canNavigateBack: false
+  },
+
+  lifetimes: {
+    attached() {
+      const { customNav = {}, safeArea = {} } = app.globalData || {};
+      const statusBarHeight = customNav.statusBarHeight ?? safeArea.top ?? 0;
+      const navHeight = customNav.navHeight || (statusBarHeight + 44);
+      const navBarHeight = navHeight - statusBarHeight;
+      const navPlaceholderHeight = navHeight > 0 ? navHeight : navBarHeight;
+      const pages = getCurrentPages();
+      const canNavigateBack = pages.length > 1;
+      const showBack = !!this.data.enableBack;
+
+      this.setData({
+        statusBarHeight,
+        navHeight,
+        navBarHeight: navBarHeight > 0 ? navBarHeight : 44,
+        navPlaceholderHeight: navPlaceholderHeight > 0 ? navPlaceholderHeight : 44,
+        showBack,
+        canNavigateBack
+      });
+    }
+  },
+
+  methods: {
+    handleBack() {
+      const pages = getCurrentPages();
+      const canNavigateBack = pages.length > 1 || this.data.canNavigateBack;
+      if (canNavigateBack) {
+        wx.navigateBack({ delta: 1 });
+      } else {
+        wx.reLaunch({ url: '/pages/index/index' });
+      }
+    }
+  }
+});

--- a/miniprogram/components/custom-nav/custom-nav.json
+++ b/miniprogram/components/custom-nav/custom-nav.json
@@ -1,0 +1,3 @@
+{
+  "component": true
+}

--- a/miniprogram/components/custom-nav/custom-nav.wxml
+++ b/miniprogram/components/custom-nav/custom-nav.wxml
@@ -1,0 +1,12 @@
+<view class="custom-nav {{theme}}" style="height: {{navHeight}}px; padding-top: {{statusBarHeight}}px;">
+  <view class="nav-content" style="height: {{navBarHeight}}px;">
+    <view class="back-button" wx:if="{{showBack}}" bindtap="handleBack">
+      <text class="back-icon">‹</text>
+    </view>
+    <view class="nav-title">{{title}}</view>
+    <view class="nav-extra">
+      <slot name="actions"></slot>
+    </view>
+  </view>
+</view>
+<view class="nav-placeholder" style="height: {{navPlaceholderHeight}}px;"></view>

--- a/miniprogram/components/custom-nav/custom-nav.wxss
+++ b/miniprogram/components/custom-nav/custom-nav.wxss
@@ -1,0 +1,81 @@
+.custom-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 999;
+  box-sizing: border-box;
+  backdrop-filter: blur(18rpx);
+}
+
+.custom-nav .nav-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  width: 100%;
+}
+
+.custom-nav .nav-title {
+  font-size: 32rpx;
+  font-weight: 600;
+}
+
+.custom-nav .back-button {
+  position: absolute;
+  left: 32rpx;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 64rpx;
+  height: 64rpx;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.custom-nav .back-icon {
+  font-size: 44rpx;
+}
+
+.custom-nav .nav-extra {
+  position: absolute;
+  right: 32rpx;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 16rpx;
+}
+
+.custom-nav.light {
+  background: rgba(255, 255, 255, 0.95);
+  color: #0f244a;
+  border-bottom: 1rpx solid rgba(15, 36, 74, 0.06);
+}
+
+.custom-nav.light .back-button {
+  background: rgba(15, 36, 74, 0.06);
+}
+
+.custom-nav.light .back-icon {
+  color: #0f244a;
+}
+
+.custom-nav.dark {
+  background: linear-gradient(135deg, rgba(12, 18, 46, 0.92), rgba(36, 28, 84, 0.88));
+  color: #f5f7ff;
+  border-bottom: 1rpx solid rgba(137, 155, 255, 0.28);
+}
+
+.custom-nav.dark .back-button {
+  background: rgba(245, 247, 255, 0.1);
+}
+
+.custom-nav.dark .back-icon {
+  color: #f5f7ff;
+}
+
+.nav-placeholder {
+  width: 100%;
+}

--- a/miniprogram/pages/admin/index.wxml
+++ b/miniprogram/pages/admin/index.wxml
@@ -1,3 +1,4 @@
+<custom-nav title="管理员中心" theme="dark"></custom-nav>
 <view class="admin-home">
   <view class="intro">
     <view class="title">管理员入口</view>

--- a/miniprogram/pages/admin/member-detail/index.json
+++ b/miniprogram/pages/admin/member-detail/index.json
@@ -1,3 +1,7 @@
 {
-  "navigationBarTitleText": "会员资料"
+  "navigationBarTitleText": "会员资料",
+  "navigationStyle": "custom",
+  "usingComponents": {
+    "custom-nav": "/components/custom-nav/custom-nav"
+  }
 }

--- a/miniprogram/pages/admin/member-detail/index.wxml
+++ b/miniprogram/pages/admin/member-detail/index.wxml
@@ -1,3 +1,4 @@
+<custom-nav title="会员资料" theme="dark"></custom-nav>
 <view class="member-detail" wx:if="{{!loading}}">
   <view class="section">
     <view class="section-title">账号信息</view>

--- a/miniprogram/pages/admin/members/index.json
+++ b/miniprogram/pages/admin/members/index.json
@@ -1,3 +1,7 @@
 {
-  "navigationBarTitleText": "会员列表"
+  "navigationBarTitleText": "会员列表",
+  "navigationStyle": "custom",
+  "usingComponents": {
+    "custom-nav": "/components/custom-nav/custom-nav"
+  }
 }

--- a/miniprogram/pages/admin/members/index.wxml
+++ b/miniprogram/pages/admin/members/index.wxml
@@ -1,3 +1,4 @@
+<custom-nav title="会员列表" theme="dark"></custom-nav>
 <view class="admin-members">
   <view class="search-bar">
     <input

--- a/miniprogram/pages/avatar/avatar.json
+++ b/miniprogram/pages/avatar/avatar.json
@@ -1,5 +1,4 @@
 {
-  "navigationBarTitleText": "管理员中心",
   "navigationStyle": "custom",
   "usingComponents": {
     "custom-nav": "/components/custom-nav/custom-nav"

--- a/miniprogram/pages/avatar/avatar.wxml
+++ b/miniprogram/pages/avatar/avatar.wxml
@@ -1,3 +1,4 @@
+<custom-nav title="形象装扮"></custom-nav>
 <view class="container">
   <view class="card">
     <view class="section-title">虚拟形象</view>

--- a/miniprogram/pages/index/index.json
+++ b/miniprogram/pages/index/index.json
@@ -1,5 +1,4 @@
 {
-  "navigationBarTitleText": "管理员中心",
   "navigationStyle": "custom",
   "usingComponents": {
     "custom-nav": "/components/custom-nav/custom-nav"

--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -3,6 +3,8 @@
   <view class="mist-layer mist-layer--one"></view>
   <view class="mist-layer mist-layer--two"></view>
 
+  <custom-nav title="会员中心" enable-back="{{false}}" theme="dark"></custom-nav>
+
   <view class="content" wx:if="{{!loading}}">
     <view class="top-bar">
       <view class="profile-card" bindtap="handleProfileTap">

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -59,6 +59,7 @@ page {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  gap: 48rpx;
   min-height: 100vh;
   min-height: calc(100vh - constant(safe-area-inset-top) - constant(safe-area-inset-bottom));
   min-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
@@ -261,7 +262,7 @@ page {
 }
 
 .bottom-nav {
-  margin-top: 48rpx;
+  margin-top: auto;
   padding: 18rpx 24rpx;
   border-radius: 36rpx;
   background: rgba(21, 32, 84, 0.85);

--- a/miniprogram/pages/membership/membership.json
+++ b/miniprogram/pages/membership/membership.json
@@ -1,5 +1,4 @@
 {
-  "navigationBarTitleText": "管理员中心",
   "navigationStyle": "custom",
   "usingComponents": {
     "custom-nav": "/components/custom-nav/custom-nav"

--- a/miniprogram/pages/membership/membership.wxml
+++ b/miniprogram/pages/membership/membership.wxml
@@ -1,3 +1,4 @@
+<custom-nav title="修仙等级"></custom-nav>
 <view class="container">
   <view wx:if="{{loading}}" class="card">
     <text>加载中...</text>

--- a/miniprogram/pages/reservation/reservation.json
+++ b/miniprogram/pages/reservation/reservation.json
@@ -1,5 +1,4 @@
 {
-  "navigationBarTitleText": "管理员中心",
   "navigationStyle": "custom",
   "usingComponents": {
     "custom-nav": "/components/custom-nav/custom-nav"

--- a/miniprogram/pages/reservation/reservation.wxml
+++ b/miniprogram/pages/reservation/reservation.wxml
@@ -1,3 +1,4 @@
+<custom-nav title="预约包房"></custom-nav>
 <view class="container">
   <view class="card filter-card">
     <view class="section-title">选择日期与时段</view>

--- a/miniprogram/pages/rights/rights.json
+++ b/miniprogram/pages/rights/rights.json
@@ -1,5 +1,4 @@
 {
-  "navigationBarTitleText": "管理员中心",
   "navigationStyle": "custom",
   "usingComponents": {
     "custom-nav": "/components/custom-nav/custom-nav"

--- a/miniprogram/pages/rights/rights.wxml
+++ b/miniprogram/pages/rights/rights.wxml
@@ -1,3 +1,4 @@
+<custom-nav title="会员权益"></custom-nav>
 <view class="container">
   <view wx:if="{{loading}}" class="card">
     <text>权益加载中...</text>

--- a/miniprogram/pages/tasks/tasks.json
+++ b/miniprogram/pages/tasks/tasks.json
@@ -1,5 +1,4 @@
 {
-  "navigationBarTitleText": "管理员中心",
   "navigationStyle": "custom",
   "usingComponents": {
     "custom-nav": "/components/custom-nav/custom-nav"

--- a/miniprogram/pages/tasks/tasks.wxml
+++ b/miniprogram/pages/tasks/tasks.wxml
@@ -1,3 +1,4 @@
+<custom-nav title="日常任务"></custom-nav>
 <view class="container">
   <view class="card">
     <view class="section-title">任务列表</view>

--- a/miniprogram/pages/wallet/wallet.json
+++ b/miniprogram/pages/wallet/wallet.json
@@ -1,5 +1,4 @@
 {
-  "navigationBarTitleText": "管理员中心",
   "navigationStyle": "custom",
   "usingComponents": {
     "custom-nav": "/components/custom-nav/custom-nav"

--- a/miniprogram/pages/wallet/wallet.wxml
+++ b/miniprogram/pages/wallet/wallet.wxml
@@ -1,3 +1,4 @@
+<custom-nav title="灵石钱包"></custom-nav>
 <view class="container">
   <view class="card">
     <view class="section-title">账户余额</view>


### PR DESCRIPTION
## Summary
- ensure the custom navigation placeholder matches the full safe-area height so content no longer hides beneath the status bar
- opt all member and admin pages into the custom navigation style to keep the immersive full-screen layout consistent

## Testing
- not run (WeChat Mini Program environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68d608984f8c8330ada5527ba50199d7