### PR TITLE
Restore immersive full screen layout

### DIFF
--- a/miniprogram/app.wxss
+++ b/miniprogram/app.wxss
@@ -2,8 +2,6 @@ page {
   background: #f5f5f5;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', sans-serif;
   box-sizing: border-box;
-  padding-top: constant(safe-area-inset-top);
-  padding-top: env(safe-area-inset-top);
 }
 
 .container {

--- a/miniprogram/components/custom-nav/custom-nav.js
+++ b/miniprogram/components/custom-nav/custom-nav.js
@@ -24,7 +24,7 @@ Component({
     statusBarHeight: 0,
     navHeight: 64,
     navBarHeight: 44,
-    navPlaceholderHeight: 44,
+    navPlaceholderHeight: 64,
     showBack: false,
     canNavigateBack: false
   },
@@ -43,7 +43,7 @@ Component({
         statusBarHeight,
         navHeight,
         navBarHeight: navBarHeight > 0 ? navBarHeight : 44,
-        navPlaceholderHeight: navHeight > statusBarHeight ? navHeight - statusBarHeight : navHeight,
+        navPlaceholderHeight: navHeight > 0 ? navHeight : 64,
         showBack,
         canNavigateBack
       });


### PR DESCRIPTION
## Summary
- remove the global safe-area padding so page content can extend under the status bar for immersive layout
- expand the custom navigation placeholder height to reserve space for the entire system navigation area

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d614bd7c048330a51d21fcb496928b