### PR TITLE
Adjust top activity icon spacing

### DIFF
--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -130,7 +130,7 @@ page {
   flex-wrap: nowrap;
   justify-content: flex-end;
   align-items: center;
-  gap: 8rpx;
+  gap: 12rpx;
 }
 
 .activity-item {


### PR DESCRIPTION
## Summary
- slightly increase spacing between the top activity icons for better separation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d61f3e09008330be81d1dda700e2a7