### PR TITLE
Adjust status bar colors on home page

### DIFF
--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -93,6 +93,36 @@ Page({
     this.bootstrap();
   },
 
+  onShow() {
+    wx.setNavigationBarColor({
+      frontColor: '#ffffff',
+      backgroundColor: '#050921',
+      animation: {
+        duration: 200,
+        timingFunc: 'easeIn'
+      }
+    });
+  },
+
+  onHide() {
+    this.restoreNavigationBar();
+  },
+
+  onUnload() {
+    this.restoreNavigationBar();
+  },
+
+  restoreNavigationBar() {
+    wx.setNavigationBarColor({
+      frontColor: '#000000',
+      backgroundColor: '#ffffff',
+      animation: {
+        duration: 200,
+        timingFunc: 'easeOut'
+      }
+    });
+  },
+
   async bootstrap() {
     this.setData({ loading: true });
     try {


### PR DESCRIPTION
## Summary
- set the home page navigation bar to use a white status bar font that matches the dark background
- restore the default navigation bar colors when leaving the page to avoid affecting other screens

## Testing
- not run (WeChat Mini Program environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d62ed5dd488330b3b0e334798d0787