### PR TITLE
Handle non-numeric values in formatCurrency

### DIFF
--- a/miniprogram/utils/format.js
+++ b/miniprogram/utils/format.js
@@ -1,5 +1,16 @@
 export const formatCurrency = (amount = 0) => {
-  return `¥${(amount / 100).toFixed(2)}`;
+  const numeric =
+    typeof amount === 'number'
+      ? amount
+      : typeof amount === 'string'
+      ? Number(amount)
+      : 0;
+
+  if (!Number.isFinite(numeric)) {
+    return '¥0.00';
+  }
+
+  return `¥${(numeric / 100).toFixed(2)}`;
 };
 
 export const formatDate = (date) => {


### PR DESCRIPTION
## Summary
- make formatCurrency resilient to non-numeric input by coercing values and defaulting to ¥0.00 when invalid

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d63498dcf88330baf336f3944ff5f5