### PR TITLE
Fix wallet summary totals and persist recharge/spend stats

### DIFF
--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -300,6 +300,7 @@ async function rechargeMember(openid, memberId, amount) {
     await memberRef.update({
       data: {
         cashBalance: _.inc(numericAmount),
+        totalRecharge: _.inc(numericAmount),
         updatedAt: now
       }
     });

--- a/cloudfunctions/member/index.js
+++ b/cloudfunctions/member/index.js
@@ -47,6 +47,8 @@ async function initMember(openid, profile) {
     levelId: defaultLevel ? defaultLevel._id : '',
     experience: 0,
     cashBalance: 0,
+    totalRecharge: 0,
+    totalSpend: 0,
     stoneBalance: 0,
     roles: ['member'],
     createdAt: new Date(),
@@ -292,6 +294,14 @@ function normalizeAssetFields(member) {
     const cash = hasLegacyBalance ? normalized.balance : 0;
     normalized.cashBalance = cash;
     updates.cashBalance = cash;
+  }
+  if (typeof normalized.totalRecharge !== 'number' || !Number.isFinite(normalized.totalRecharge)) {
+    normalized.totalRecharge = 0;
+    updates.totalRecharge = 0;
+  }
+  if (typeof normalized.totalSpend !== 'number' || !Number.isFinite(normalized.totalSpend)) {
+    normalized.totalSpend = 0;
+    updates.totalSpend = 0;
   }
   if (typeof normalized.stoneBalance !== 'number' || !Number.isFinite(normalized.stoneBalance)) {
     normalized.stoneBalance = 0;

--- a/cloudfunctions/member/index.js
+++ b/cloudfunctions/member/index.js
@@ -288,29 +288,29 @@ function normalizeAssetFields(member) {
   if (!member) return member;
   const normalized = { ...member };
   const updates = {};
-  const hasCashBalance = typeof normalized.cashBalance === 'number' && Number.isFinite(normalized.cashBalance);
-  const hasLegacyBalance = typeof normalized.balance === 'number' && Number.isFinite(normalized.balance);
-  if (!hasCashBalance) {
-    const cash = hasLegacyBalance ? normalized.balance : 0;
-    normalized.cashBalance = cash;
-    updates.cashBalance = cash;
+  const cashBalance = coerceAmountValue(normalized.cashBalance, normalized.balance);
+  normalized.cashBalance = cashBalance;
+  if (!Object.is(cashBalance, member.cashBalance)) {
+    updates.cashBalance = cashBalance;
   }
-  if (typeof normalized.totalRecharge !== 'number' || !Number.isFinite(normalized.totalRecharge)) {
-    normalized.totalRecharge = 0;
-    updates.totalRecharge = 0;
+
+  const totalRecharge = coerceAmountValue(normalized.totalRecharge, 0);
+  normalized.totalRecharge = totalRecharge;
+  if (!Object.is(totalRecharge, member.totalRecharge)) {
+    updates.totalRecharge = totalRecharge;
   }
-  if (typeof normalized.totalSpend !== 'number' || !Number.isFinite(normalized.totalSpend)) {
-    normalized.totalSpend = 0;
-    updates.totalSpend = 0;
+
+  const totalSpend = Math.max(0, coerceAmountValue(normalized.totalSpend, 0));
+  normalized.totalSpend = totalSpend;
+  if (!Object.is(totalSpend, member.totalSpend)) {
+    updates.totalSpend = totalSpend;
   }
-  if (typeof normalized.stoneBalance !== 'number' || !Number.isFinite(normalized.stoneBalance)) {
-    normalized.stoneBalance = 0;
-    updates.stoneBalance = 0;
-  } else {
-    normalized.stoneBalance = Math.max(0, Math.floor(normalized.stoneBalance));
-    if (normalized.stoneBalance !== member.stoneBalance) {
-      updates.stoneBalance = normalized.stoneBalance;
-    }
+
+  const stoneNumeric = resolveAmountNumber(normalized.stoneBalance);
+  const stoneBalance = Number.isFinite(stoneNumeric) ? Math.max(0, Math.floor(stoneNumeric)) : 0;
+  normalized.stoneBalance = stoneBalance;
+  if (!Object.is(stoneBalance, member.stoneBalance)) {
+    updates.stoneBalance = stoneBalance;
   }
   if (Object.keys(updates).length) {
     updates.updatedAt = new Date();
@@ -322,4 +322,65 @@ function normalizeAssetFields(member) {
       .catch(() => {});
   }
   return normalized;
+}
+
+function coerceAmountValue(value, fallback = 0) {
+  const numeric = resolveAmountNumber(value);
+  if (Number.isFinite(numeric)) {
+    return Math.round(numeric);
+  }
+  const fallbackNumeric = resolveAmountNumber(fallback);
+  if (Number.isFinite(fallbackNumeric)) {
+    return Math.round(fallbackNumeric);
+  }
+  return 0;
+}
+
+function resolveAmountNumber(value) {
+  if (value == null) {
+    return NaN;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : NaN;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return 0;
+    }
+    const sanitized = trimmed.replace(/[^0-9+.,-]/g, '').replace(/,/g, '');
+    const parsed = Number(sanitized);
+    return Number.isFinite(parsed) ? parsed : NaN;
+  }
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+  if (typeof value === 'object') {
+    if (typeof value.toNumber === 'function') {
+      try {
+        const numeric = value.toNumber();
+        return Number.isFinite(numeric) ? numeric : NaN;
+      } catch (err) {
+        // ignore
+      }
+    }
+    if (typeof value.valueOf === 'function') {
+      const primitive = value.valueOf();
+      if (typeof primitive === 'number' && Number.isFinite(primitive)) {
+        return primitive;
+      }
+      const numeric = Number(primitive);
+      if (Number.isFinite(numeric)) {
+        return numeric;
+      }
+    }
+    if (typeof value.toString === 'function') {
+      const numeric = Number(value.toString());
+      if (Number.isFinite(numeric)) {
+        return numeric;
+      }
+    }
+  }
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : NaN;
 }

--- a/cloudfunctions/wallet/index.js
+++ b/cloudfunctions/wallet/index.js
@@ -4,7 +4,6 @@ cloud.init({ env: cloud.DYNAMIC_CURRENT_ENV });
 
 const db = cloud.database();
 const _ = db.command;
-const $ = _.aggregate;
 
 const COLLECTIONS = {
   MEMBERS: 'members',
@@ -44,64 +43,156 @@ exports.main = async (event, context) => {
 
 async function getSummary(openid) {
   const transactionsCollection = db.collection(COLLECTIONS.TRANSACTIONS);
-  const [memberDoc, transactionsSnapshot, rechargeAgg, spendAgg] = await Promise.all([
+  const totalsPromise = resolveEffectiveTotals(transactionsCollection, openid);
+  const [memberDoc, transactionsSnapshot, totals] = await Promise.all([
     db.collection(COLLECTIONS.MEMBERS).doc(openid).get().catch(() => null),
     transactionsCollection
       .where({ memberId: openid })
       .orderBy('createdAt', 'desc')
       .limit(20)
       .get(),
-    transactionsCollection
-      .aggregate()
-      .match({
-        memberId: openid,
-        type: 'recharge',
-        status: _.nin(EXCLUDED_TRANSACTION_STATUSES)
-      })
-      .group({
-        _id: null,
-        total: $.sum('$amount')
-      })
-      .end()
-      .catch(() => ({ list: [] })),
-    transactionsCollection
-      .aggregate()
-      .match({
-        memberId: openid,
-        type: 'spend',
-        status: _.nin(EXCLUDED_TRANSACTION_STATUSES)
-      })
-      .group({
-        _id: null,
-        total: $.sum('$amount')
-      })
-      .end()
-      .catch(() => ({ list: [] }))
+    totalsPromise
   ]);
+
   const member = memberDoc && memberDoc.data ? memberDoc.data : { cashBalance: 0 };
   const transactions = transactionsSnapshot.data || [];
-  const aggregatedRecharge = extractAggregateTotal(rechargeAgg);
-  const aggregatedSpend = Math.abs(extractAggregateTotal(spendAgg));
-  const hasStoredRecharge = Object.prototype.hasOwnProperty.call(member, 'totalRecharge');
-  const hasStoredSpend = Object.prototype.hasOwnProperty.call(member, 'totalSpend');
-  const totalRecharge = hasStoredRecharge ? resolveAmountNumber(member.totalRecharge) : aggregatedRecharge;
-  const totalSpend = hasStoredSpend ? resolveAmountNumber(member.totalSpend) : aggregatedSpend;
-  return {
-    cashBalance: resolveCashBalance(member),
-    balance: resolveCashBalance(member),
-    totalRecharge,
-    totalSpend,
-    transactions: transactions.map((txn) => ({
-      _id: txn._id,
-      type: txn.type,
-      typeLabel: transactionTypeLabel[txn.type] || '交易',
-      amount: resolveAmountNumber(txn.amount),
-      source: txn.source || '',
-      remark: txn.remark || '',
-      createdAt: resolveDate(txn.createdAt) || new Date(),
-      status: normalizeTransactionStatus(txn.status)
-    }))
+  const resolvedCashBalance = resolveCashBalance(member);
+  const storedRecharge = resolveAmountNumber(member.totalRecharge);
+  const storedSpend = resolveAmountNumber(member.totalSpend);
+  const normalizedTotals = {
+    totalRecharge: Math.max(
+      0,
+      Number.isFinite(storedRecharge) ? Math.max(storedRecharge, totals.totalRecharge) : totals.totalRecharge
+    ),
+    totalSpend: Math.max(
+      0,
+      Number.isFinite(storedSpend) ? Math.max(storedSpend, totals.totalSpend) : totals.totalSpend
+    )
   };
+
+  await persistMemberTotalsIfNeeded(openid, member, normalizedTotals);
+
+  return {
+    cashBalance: resolvedCashBalance,
+    balance: resolvedCashBalance,
+    totalRecharge: normalizedTotals.totalRecharge,
+    totalSpend: normalizedTotals.totalSpend,
+    transactions: transactions.map((txn) => {
+      const amount = resolveAmountNumber(txn.amount);
+      const status = normalizeTransactionStatus(txn.status);
+      const type = resolveTransactionType(txn.type, amount);
+      return {
+        _id: txn._id,
+        type,
+        typeLabel: transactionTypeLabel[type] || transactionTypeLabel.unknown,
+        amount,
+        source: txn.source || '',
+        remark: txn.remark || '',
+        createdAt: resolveDate(txn.createdAt) || new Date(),
+        status
+      };
+    })
+  };
+}
+
+async function resolveEffectiveTotals(collection, memberId) {
+  const pageSize = 500;
+  let offset = 0;
+  let totalRecharge = 0;
+  let totalSpend = 0;
+  let hasMore = true;
+  let guard = 0;
+
+  while (hasMore && guard < 40) {
+    const snapshot = await collection
+      .aggregate()
+      .match({ memberId })
+      .sort({ createdAt: -1 })
+      .skip(offset)
+      .limit(pageSize)
+      .project({ amount: 1, type: 1, status: 1 })
+      .end()
+      .catch(() => ({ list: [] }));
+
+    const batch = Array.isArray(snapshot.list) ? snapshot.list : [];
+    if (!batch.length) {
+      break;
+    }
+
+    batch.forEach((txn) => {
+      const amount = resolveAmountNumber(txn.amount);
+      if (!Number.isFinite(amount) || amount === 0) {
+        return;
+      }
+      const status = normalizeTransactionStatus(txn.status);
+      if (EXCLUDED_TRANSACTION_STATUSES.includes(status)) {
+        return;
+      }
+      const type = resolveTransactionType(txn.type, amount);
+      if (type === 'recharge') {
+        totalRecharge += Math.abs(amount);
+      } else if (type === 'spend') {
+        totalSpend += Math.abs(amount);
+      }
+    });
+
+    if (batch.length < pageSize) {
+      hasMore = false;
+    } else {
+      offset += pageSize;
+    }
+
+    guard += 1;
+  }
+
+  return {
+    totalRecharge: Math.round(Math.max(totalRecharge, 0)),
+    totalSpend: Math.round(Math.max(totalSpend, 0))
+  };
+}
+
+async function persistMemberTotalsIfNeeded(memberId, member, totals) {
+  if (!member || !member._id) {
+    return;
+  }
+  const hasRechargeField = Object.prototype.hasOwnProperty.call(member, 'totalRecharge');
+  const hasSpendField = Object.prototype.hasOwnProperty.call(member, 'totalSpend');
+  const currentRecharge = resolveAmountNumber(member.totalRecharge);
+  const currentSpend = resolveAmountNumber(member.totalSpend);
+  const updates = {};
+
+  if (!hasRechargeField || !Number.isFinite(currentRecharge) || Math.round(currentRecharge) !== totals.totalRecharge) {
+    updates.totalRecharge = totals.totalRecharge;
+  }
+  if (!hasSpendField || !Number.isFinite(currentSpend) || Math.round(currentSpend) !== totals.totalSpend) {
+    updates.totalSpend = totals.totalSpend;
+  }
+
+  if (Object.keys(updates).length) {
+    updates.updatedAt = new Date();
+    await db
+      .collection(COLLECTIONS.MEMBERS)
+      .doc(memberId)
+      .update({
+        data: updates
+      })
+      .catch(() => null);
+  }
+}
+
+function resolveTransactionType(type, amount) {
+  if (type) {
+    return type;
+  }
+  if (Number.isFinite(amount)) {
+    if (amount > 0) {
+      return 'recharge';
+    }
+    if (amount < 0) {
+      return 'spend';
+    }
+  }
+  return 'unknown';
 }
 
 async function createRecharge(openid, amount) {
@@ -373,9 +464,12 @@ async function confirmChargeOrder(openid, orderId) {
 }
 
 const transactionTypeLabel = {
-  recharge: '充',
+  recharge: '充值',
   spend: '消费',
-  reward: '奖励'
+  reward: '奖励',
+  refund: '退款',
+  adjust: '调整',
+  unknown: '交易'
 };
 
 function mapChargeOrder(raw, orderId, now = new Date()) {
@@ -445,13 +539,6 @@ function resolveCashBalance(member) {
     }
   }
   return 0;
-}
-
-function extractAggregateTotal(snapshot) {
-  if (!snapshot || !Array.isArray(snapshot.list) || !snapshot.list.length) {
-    return 0;
-  }
-  return resolveAmountNumber(snapshot.list[0].total);
 }
 
 function resolveAmountNumber(value) {

--- a/miniprogram/pages/wallet/wallet.wxml
+++ b/miniprogram/pages/wallet/wallet.wxml
@@ -4,8 +4,8 @@
     <view class="section-title">现金余额</view>
     <view wx:if="{{loading}}">加载中...</view>
     <view wx:elif="{{summary}}">
-      <view class="balance">{{formatCurrency(summary.cashBalance || 0)}}</view>
-      <view class="meta">累计充值：{{formatCurrency(summary.totalRecharge || 0)}} · 累计消费：{{formatCurrency(summary.totalSpend || 0)}}</view>
+      <view class="balance">{{summary.cashBalanceText}}</view>
+      <view class="meta">累计充值：{{summary.totalRechargeText}} · 累计消费：{{summary.totalSpendText}}</view>
       <button class="scan" size="mini" bindtap="handleScanCharge">扫码扣费</button>
     </view>
   </view>
@@ -29,10 +29,10 @@
       <view class="transaction" wx:for="{{summary.transactions}}" wx:key="_id">
         <view>
           <view class="txn-title">{{item.typeLabel}}</view>
-          <view class="txn-date">{{formatDate(item.createdAt)}}</view>
+          <view class="txn-date">{{item.displayDate}}</view>
           <view class="txn-remark" wx:if="{{item.remark}}">{{item.remark}}</view>
         </view>
-        <view class="txn-amount {{item.amount > 0 ? 'income' : item.amount < 0 ? 'expense' : ''}}">{{formatTxnAmount(item.amount)}}</view>
+        <view class="txn-amount {{item.amountClass}}">{{item.amountText}}</view>
       </view>
     </view>
   </view>


### PR DESCRIPTION
## Summary
- aggregate wallet transaction totals across the full history when building the wallet summary
- persist running recharge and spend totals on member records during balance updates
- normalise legacy member documents so new total fields are present for existing users

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d8135684008330bfd0b7763368cb34