### PR TITLE
Fix admin member detail interactions

### DIFF
--- a/miniprogram/pages/admin/member-detail/index.js
+++ b/miniprogram/pages/admin/member-detail/index.js
@@ -18,9 +18,9 @@ Page({
     levelIndex: 0,
     currentLevelName: '',
     roleOptions: [
-      { value: 'member', label: '会员' },
-      { value: 'admin', label: '管理员' },
-      { value: 'developer', label: '开发' }
+      { value: 'member', label: '会员', checked: false, disabled: true },
+      { value: 'admin', label: '管理员', checked: false },
+      { value: 'developer', label: '开发', checked: false }
     ],
     form: {
       nickName: '',
@@ -72,6 +72,11 @@ Page({
       0
     );
     const currentLevel = levels[levelIndex] || levels[0] || { _id: '', name: '' };
+    const roles = ensureMemberRole(member.roles);
+    const roleOptions = (this.data.roleOptions || []).map((option) => ({
+      ...option,
+      checked: roles.includes(option.value)
+    }));
     this.setData({
       member,
       levels,
@@ -85,8 +90,9 @@ Page({
         cashBalance: this.formatYuan(member.cashBalance ?? member.balance ?? 0),
         stoneBalance: String(member.stoneBalance ?? 0),
         levelId: member.levelId || currentLevel._id || '',
-        roles: ensureMemberRole(member.roles)
-      }
+        roles
+      },
+      roleOptions
     });
   },
 
@@ -108,11 +114,15 @@ Page({
   },
 
   handleRolesChange(event) {
-    const roles = event.detail.value || [];
-    if (!roles.includes('member')) {
-      roles.push('member');
-    }
-    this.setData({ 'form.roles': roles });
+    const roles = ensureMemberRole(event.detail.value || []);
+    const roleOptions = (this.data.roleOptions || []).map((option) => ({
+      ...option,
+      checked: roles.includes(option.value)
+    }));
+    this.setData({
+      'form.roles': roles,
+      roleOptions
+    });
   },
 
   async handleSubmit() {
@@ -138,6 +148,8 @@ Page({
       this.setData({ saving: false });
     }
   },
+
+  noop() {},
 
   showRechargeDialog() {
     this.setData({ rechargeVisible: true, rechargeAmount: '' });

--- a/miniprogram/pages/admin/member-detail/index.wxml
+++ b/miniprogram/pages/admin/member-detail/index.wxml
@@ -76,9 +76,7 @@
     </view>
     <view class="form-item">
       <view class="form-label">当前境界</view>
-      <picker mode="selector" range="{{levels}}" range-key="name" value="{{levelIndex}}" bindchange="handleLevelChange">
-        <view class="picker-value">{{currentLevelName || '请选择境界'}}</view>
-      </picker>
+      <view class="readonly-value">{{currentLevelName || '—'}}</view>
     </view>
     <view class="form-item">
       <view class="form-label">角色权限</view>
@@ -86,11 +84,12 @@
         <label
           wx:for="{{roleOptions}}"
           wx:key="value"
-          class="role-option"
+          class="role-option {{item.checked ? 'checked' : ''}}"
         >
           <checkbox
             value="{{item.value}}"
-            checked="{{form.roles.indexOf(item.value) !== -1}}"
+            checked="{{item.checked}}"
+            disabled="{{item.disabled}}"
           />
           <text class="role-label">{{item.label}}</text>
         </label>
@@ -104,7 +103,7 @@
 <view wx:if="{{loading}}" class="loading">加载会员资料...</view>
 
 <view wx:if="{{rechargeVisible}}" class="dialog-mask" bindtap="hideRechargeDialog">
-  <view class="dialog" catchtap="">
+  <view class="dialog" catchtap="noop" catchtouchmove="noop">
     <view class="dialog-title">充值到账户余额</view>
     <view class="dialog-body">
       <view class="dialog-tip">金额单位：元（保留两位小数）</view>

--- a/miniprogram/pages/admin/member-detail/index.wxss
+++ b/miniprogram/pages/admin/member-detail/index.wxss
@@ -26,6 +26,7 @@ page {
   font-size: 32rpx;
   font-weight: 600;
   margin-bottom: 20rpx;
+  color: #f8fafc;
 }
 
 .toolbar {
@@ -81,6 +82,14 @@ page {
   color: #f8fafc;
 }
 
+.readonly-value {
+  padding: 20rpx;
+  border-radius: 16rpx;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.92);
+  color: #f8fafc;
+}
+
 .role-group {
   display: flex;
   gap: 20rpx;
@@ -94,6 +103,11 @@ page {
   background: rgba(30, 41, 59, 0.6);
   border-radius: 16rpx;
   border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.role-option.checked {
+  background: rgba(96, 165, 250, 0.16);
+  border-color: rgba(96, 165, 250, 0.6);
 }
 
 .role-label {


### PR DESCRIPTION
## Summary
- prevent the admin recharge dialog from closing when the amount field gains focus
- make the cultivation level read-only and improve the section title contrast
- ensure role selections update correctly and reflect their state in the UI

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d826c326708330a07ac4599e57ab8f