### PR TITLE
Ensure member pages refresh when revisited

### DIFF
--- a/miniprogram/pages/admin/charge/index.js
+++ b/miniprogram/pages/admin/charge/index.js
@@ -80,11 +80,20 @@ Page({
     viewingOrderId: ''
   },
 
-  async onLoad(options = {}) {
+  onLoad(options = {}) {
     const orderId = options.orderId ? decodeURIComponent(options.orderId) : '';
     if (orderId) {
       this.setData({ viewingOrderId: orderId });
-      await this.loadExistingOrder(orderId);
+    }
+  },
+
+  onShow() {
+    if (this.data.viewingOrderId) {
+      this.loadExistingOrder(this.data.viewingOrderId);
+      return;
+    }
+    if (this.data.currentOrder && this.data.currentOrder._id) {
+      this.handleRefresh();
     }
   },
 

--- a/miniprogram/pages/admin/member-detail/index.js
+++ b/miniprogram/pages/admin/member-detail/index.js
@@ -42,7 +42,13 @@ Page({
       return;
     }
     this.setData({ memberId: id });
-    this.loadMember(id);
+  },
+
+  onShow() {
+    if (!this.data.memberId) {
+      return;
+    }
+    this.loadMember(this.data.memberId);
   },
 
   onPullDownRefresh() {

--- a/miniprogram/pages/admin/members/index.js
+++ b/miniprogram/pages/admin/members/index.js
@@ -26,7 +26,7 @@ Page({
     defaultAvatar: DEFAULT_AVATAR
   },
 
-  onLoad() {
+  onShow() {
     this.fetchMembers(true);
   },
 

--- a/miniprogram/pages/admin/orders/index.js
+++ b/miniprogram/pages/admin/orders/index.js
@@ -81,7 +81,7 @@ Page({
     refreshing: false
   },
 
-  onLoad() {
+  onShow() {
     this.loadOrders({ reset: true });
   },
 

--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -129,12 +129,7 @@ Page({
   },
 
   onLoad() {
-    const now = new Date();
-    const formatNumber = (value) => (value < 10 ? `0${value}` : `${value}`);
-    this.setData({
-      today: `${now.getFullYear()} · ${formatNumber(now.getMonth() + 1)} · ${formatNumber(now.getDate())}`
-    });
-    this.bootstrap();
+    this.updateToday();
   },
 
   onShow() {
@@ -146,6 +141,8 @@ Page({
         timingFunc: 'easeIn'
       }
     });
+    this.updateToday();
+    this.bootstrap();
   },
 
   onHide() {
@@ -195,6 +192,14 @@ Page({
         progressStyle: buildWidthStyle(width)
       });
     }
+  },
+
+  updateToday() {
+    const now = new Date();
+    const formatNumber = (value) => (value < 10 ? `0${value}` : `${value}`);
+    this.setData({
+      today: `${now.getFullYear()} · ${formatNumber(now.getMonth() + 1)} · ${formatNumber(now.getDate())}`
+    });
   },
 
   formatCurrency,

--- a/miniprogram/pages/reservation/reservation.js
+++ b/miniprogram/pages/reservation/reservation.js
@@ -22,6 +22,9 @@ Page({
     if (options && options.rightId) {
       this.setData({ rightId: options.rightId });
     }
+  },
+
+  onShow() {
     this.fetchRooms();
   },
 

--- a/miniprogram/pages/stones/stones.js
+++ b/miniprogram/pages/stones/stones.js
@@ -1,4 +1,8 @@
 import { StoneService } from '../../services/api';
+import {
+  ensureWatcher as ensureMemberWatcher,
+  subscribe as subscribeMemberRealtime
+} from '../../services/member-realtime';
 import { formatDate, formatStones, formatStoneChange } from '../../utils/format';
 
 Page({
@@ -8,11 +12,50 @@ Page({
   },
 
   onShow() {
+    this.attachMemberRealtime();
+    ensureMemberWatcher().catch(() => {
+      // ignore; fetchSummary will surface any issues
+    });
     this.fetchSummary();
   },
 
-  async fetchSummary() {
-    this.setData({ loading: true });
+  onHide() {
+    this.detachMemberRealtime();
+  },
+
+  onUnload() {
+    this.detachMemberRealtime();
+  },
+
+  attachMemberRealtime() {
+    if (this.unsubscribeMemberRealtime) {
+      return;
+    }
+    this.unsubscribeMemberRealtime = subscribeMemberRealtime((event) => {
+      if (!event || event.type !== 'memberChanged') {
+        return;
+      }
+      this.fetchSummary({ showLoading: false });
+    });
+  },
+
+  detachMemberRealtime() {
+    if (this.unsubscribeMemberRealtime) {
+      this.unsubscribeMemberRealtime();
+      this.unsubscribeMemberRealtime = null;
+    }
+  },
+
+  async fetchSummary(options = {}) {
+    if (this.fetchingSummary) {
+      this.pendingFetchSummary = true;
+      return;
+    }
+    this.fetchingSummary = true;
+    const showLoading = options.showLoading !== false;
+    if (showLoading) {
+      this.setData({ loading: true });
+    }
     try {
       const summary = await StoneService.summary();
       this.setData({ summary, loading: false });
@@ -20,6 +63,11 @@ Page({
       console.error('[stones:summary]', error);
       this.setData({ loading: false });
       wx.showToast({ title: error.errMsg || '加载失败', icon: 'none' });
+    }
+    this.fetchingSummary = false;
+    if (this.pendingFetchSummary) {
+      this.pendingFetchSummary = false;
+      this.fetchSummary({ showLoading: false });
     }
   },
 

--- a/miniprogram/services/member-realtime.js
+++ b/miniprogram/services/member-realtime.js
@@ -1,0 +1,133 @@
+import { MemberService } from './api';
+
+const listeners = new Set();
+let watcher = null;
+let activeMemberId = '';
+let ensurePromise = null;
+let restartTimer = null;
+
+function notify(event) {
+  listeners.forEach((listener) => {
+    try {
+      listener(event);
+    } catch (error) {
+      console.error('[member-realtime] listener error', error);
+    }
+  });
+}
+
+function setGlobalMember(member) {
+  try {
+    if (typeof getApp === 'function') {
+      const app = getApp();
+      if (app && app.globalData) {
+        app.globalData.memberInfo = member;
+      }
+    }
+  } catch (error) {
+    console.error('[member-realtime] set global member failed', error);
+  }
+}
+
+function stopWatcher() {
+  if (watcher && typeof watcher.close === 'function') {
+    try {
+      watcher.close();
+    } catch (error) {
+      console.error('[member-realtime] close watcher failed', error);
+    }
+  }
+  watcher = null;
+}
+
+function scheduleRestart() {
+  if (restartTimer) return;
+  restartTimer = setTimeout(() => {
+    restartTimer = null;
+    startWatcher();
+  }, 2000);
+}
+
+function startWatcher() {
+  if (!activeMemberId || watcher) {
+    return;
+  }
+  if (!wx.cloud || typeof wx.cloud.database !== 'function') {
+    return;
+  }
+  try {
+    watcher = wx
+      .cloud
+      .database()
+      .collection('members')
+      .doc(activeMemberId)
+      .watch({
+        onChange(snapshot) {
+          if (!snapshot) {
+            return;
+          }
+          notify({ type: 'memberChanged', snapshot });
+        },
+        onError(error) {
+          console.error('[member-realtime] watch error', error);
+          stopWatcher();
+          scheduleRestart();
+        }
+      });
+  } catch (error) {
+    console.error('[member-realtime] start watcher failed', error);
+    stopWatcher();
+    scheduleRestart();
+  }
+}
+
+export function setActiveMember(member) {
+  if (!member || typeof member !== 'object') {
+    return;
+  }
+  const memberId = member._id || member.id;
+  if (!memberId) {
+    return;
+  }
+  activeMemberId = memberId;
+  setGlobalMember(member);
+  notify({ type: 'memberSnapshot', member });
+  startWatcher();
+}
+
+export function ensureWatcher() {
+  if (activeMemberId) {
+    startWatcher();
+    return Promise.resolve(activeMemberId);
+  }
+  if (ensurePromise) {
+    return ensurePromise;
+  }
+  ensurePromise = MemberService.getMember()
+    .then((member) => {
+      setActiveMember(member);
+      return activeMemberId;
+    })
+    .catch((error) => {
+      console.error('[member-realtime] ensure watcher failed', error);
+      throw error;
+    })
+    .finally(() => {
+      ensurePromise = null;
+    });
+  return ensurePromise;
+}
+
+export function subscribe(listener) {
+  if (typeof listener !== 'function') {
+    return () => {};
+  }
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function clearListeners() {
+  listeners.clear();
+}


### PR DESCRIPTION
## Summary
- refresh the home dashboard data whenever it becomes visible and keep the date display current
- reload reservation availability on return so members see the latest rooms without manual refresh
- ensure admin management views (members, orders, member detail, charge orders) automatically re-fetch data when revisited

## Testing
- not run (WeChat mini program)


------
https://chatgpt.com/codex/tasks/task_e_68d82d6e3ab48330a30bae5b60a82025