### PR TITLE
fix: normalize stones summary formatting

### DIFF
--- a/miniprogram/pages/stones/stones.js
+++ b/miniprogram/pages/stones/stones.js
@@ -5,6 +5,128 @@ import {
 } from '../../services/member-realtime';
 import { formatDate, formatStones, formatStoneChange } from '../../utils/format';
 
+function toNumeric(value, fallback = 0) {
+  if (value == null || value === '') {
+    return fallback;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : fallback;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return fallback;
+    }
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+
+  if (typeof value === 'object') {
+    if ('value' in value) {
+      return toNumeric(value.value, fallback);
+    }
+    if ('amount' in value) {
+      return toNumeric(value.amount, fallback);
+    }
+  }
+
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function unwrapSummary(summary) {
+  if (!summary || typeof summary !== 'object') {
+    return null;
+  }
+  if (summary.result && typeof summary.result === 'object') {
+    return summary.result;
+  }
+  return summary;
+}
+
+function formatSourceLabel(source) {
+  if (!source) return '';
+  if (source === 'task') return '任务奖励';
+  if (source === 'adjust') return '后台调整';
+  if (source === 'spend') return '商城消费';
+  if (source === 'manual') return '运营发放';
+  return source;
+}
+
+function decorateTransaction(txn = {}) {
+  const normalized = typeof txn === 'object' && txn ? txn : {};
+  const change = toNumeric(normalized.change ?? normalized.amount ?? 0, 0);
+  const amount = toNumeric(normalized.amount ?? change, change);
+  const createdAt = normalized.createdAt || normalized.timestamp || '';
+  const type = normalized.type || (change >= 0 ? 'earn' : 'spend');
+  const typeLabel = normalized.typeLabel || (change >= 0 ? '获得' : '消耗');
+  const amountClass = change > 0 ? 'income' : change < 0 ? 'expense' : '';
+
+  return {
+    _id: normalized._id || normalized.id || `${type}-${createdAt || 'unknown'}-${amount}`,
+    ...normalized,
+    amount,
+    change,
+    type,
+    typeLabel,
+    createdAt,
+    source: normalized.source || '',
+    description: normalized.description || '',
+    sourceLabel: formatSourceLabel(normalized.source),
+    dateText: createdAt ? formatDate(createdAt) : '',
+    changeText: formatStoneChange(change),
+    amountClass
+  };
+}
+
+function calculateTotals(transactions) {
+  if (!Array.isArray(transactions) || !transactions.length) {
+    return { earned: 0, spent: 0 };
+  }
+
+  return transactions.reduce(
+    (acc, txn) => {
+      const amount = toNumeric(txn.change ?? txn.amount ?? 0, 0);
+      if (amount > 0) {
+        acc.earned += amount;
+      } else if (amount < 0) {
+        acc.spent += Math.abs(amount);
+      }
+      return acc;
+    },
+    { earned: 0, spent: 0 }
+  );
+}
+
+function decorateSummary(summary) {
+  const payload = unwrapSummary(summary) || {};
+
+  const stoneBalance = toNumeric(payload.stoneBalance ?? payload.balance, 0);
+  const balance = toNumeric(payload.balance ?? payload.stoneBalance, stoneBalance);
+  const rawEarned = toNumeric(payload.totalEarned, 0);
+  const rawSpent = toNumeric(payload.totalSpent, 0);
+  const rawTransactions = Array.isArray(payload.transactions) ? payload.transactions : [];
+  const transactions = rawTransactions.map((item) => decorateTransaction(item));
+
+  const fallbackTotals = calculateTotals(transactions);
+  const totalEarned = rawEarned > 0 ? rawEarned : fallbackTotals.earned;
+  const totalSpent = rawSpent > 0 ? rawSpent : fallbackTotals.spent;
+
+  return {
+    ...payload,
+    stoneBalance,
+    balance,
+    totalEarned,
+    totalSpent,
+    balanceText: formatStones(stoneBalance || balance || 0),
+    earnedText: formatStones(totalEarned),
+    spentText: formatStones(totalSpent),
+    transactions
+  };
+}
+
 Page({
   data: {
     loading: true,
@@ -58,7 +180,8 @@ Page({
     }
     try {
       const summary = await StoneService.summary();
-      this.setData({ summary, loading: false });
+      const normalizedSummary = decorateSummary(summary);
+      this.setData({ summary: normalizedSummary, loading: false });
     } catch (error) {
       console.error('[stones:summary]', error);
       this.setData({ loading: false });
@@ -69,18 +192,5 @@ Page({
       this.pendingFetchSummary = false;
       this.fetchSummary({ showLoading: false });
     }
-  },
-
-  formatDate,
-  formatStones,
-  formatStoneChange,
-
-  formatSource(source) {
-    if (!source) return '';
-    if (source === 'task') return '任务奖励';
-    if (source === 'adjust') return '后台调整';
-    if (source === 'spend') return '商城消费';
-    if (source === 'manual') return '运营发放';
-    return source;
   }
 });

--- a/miniprogram/pages/stones/stones.wxml
+++ b/miniprogram/pages/stones/stones.wxml
@@ -4,8 +4,8 @@
     <view class="section-title">灵石余额</view>
     <view wx:if="{{loading}}">加载中...</view>
     <view wx:elif="{{summary}}">
-      <view class="balance">{{formatStones(summary.stoneBalance || summary.balance || 0)}}</view>
-      <view class="meta">累计获得：{{formatStones(summary.totalEarned || 0)}} · 累计消耗：{{formatStones(summary.totalSpent || 0)}}</view>
+      <view class="balance">{{summary.balanceText}}</view>
+      <view class="meta">累计获得：{{summary.earnedText}} · 累计消耗：{{summary.spentText}}</view>
       <view class="tip">灵石仅用于虚拟道具，不可折现或兑换现金。</view>
     </view>
   </view>
@@ -19,12 +19,12 @@
         <view>
           <view class="txn-title">{{item.typeLabel}}</view>
           <view class="txn-meta">
-            <text wx:if="{{formatSource(item.source)}}">{{formatSource(item.source)}} · </text>
-            <text>{{formatDate(item.createdAt)}}</text>
+            <text wx:if="{{item.sourceLabel}}">{{item.sourceLabel}} · </text>
+            <text>{{item.dateText}}</text>
           </view>
           <view class="txn-desc" wx:if="{{item.description}}">{{item.description}}</view>
         </view>
-        <view class="txn-amount {{item.amount > 0 ? 'income' : item.amount < 0 ? 'expense' : ''}}">{{formatStoneChange(item.change || item.amount)}}</view>
+        <view class="txn-amount {{item.amountClass}}">{{item.changeText}}</view>
       </view>
     </view>
   </view>


### PR DESCRIPTION
## Summary
- unwrap and normalize stone summary payloads before binding to the page state
- decorate transaction entries with formatted dates, change text, and source labels for direct display
- surface formatted balance, earned, and spent labels via the summary object consumed by the template

## Testing
- not run (mini program environment not available)

------
https://chatgpt.com/codex/tasks/task_e_68d837b777908330828e709a7d8cdb8e