### PR TITLE
Improve navigation fallback and stabilize member realtime

### DIFF
--- a/miniprogram/components/custom-nav/custom-nav.js
+++ b/miniprogram/components/custom-nav/custom-nav.js
@@ -57,7 +57,15 @@ Component({
       if (canNavigateBack) {
         wx.navigateBack({ delta: 1 });
       } else {
-        wx.reLaunch({ url: '/pages/index/index' });
+        const indexPageIndex = pages.findIndex((page) => page.route === 'pages/index/index');
+        if (indexPageIndex >= 0) {
+          const delta = pages.length - 1 - indexPageIndex;
+          if (delta > 0) {
+            wx.navigateBack({ delta });
+            return;
+          }
+        }
+        wx.redirectTo({ url: '/pages/index/index' });
       }
     }
   }

--- a/miniprogram/services/member-realtime.js
+++ b/miniprogram/services/member-realtime.js
@@ -1,10 +1,37 @@
 import { MemberService } from './api';
 
+const MAX_WATCH_RESTART_ATTEMPTS = 5;
+const WATCH_RETRY_DELAY = 2000;
+const WATCH_SUSPEND_DURATION = 60000;
+const MANUAL_REFRESH_INTERVAL = 15000;
+
 const listeners = new Set();
 let watcher = null;
 let activeMemberId = '';
 let ensurePromise = null;
 let restartTimer = null;
+let restartAttempts = 0;
+let watcherSuspendedUntil = 0;
+let manualRefreshTimer = null;
+let manualRefreshPromise = null;
+
+function getDatabaseInstance() {
+  const canUseDatabase = wx.cloud && typeof wx.cloud.database === 'function';
+  if (!canUseDatabase) {
+    return null;
+  }
+  try {
+    if (typeof getApp === 'function') {
+      const app = getApp();
+      if (app && app.globalData && app.globalData.env) {
+        return wx.cloud.database({ env: app.globalData.env });
+      }
+    }
+  } catch (error) {
+    console.error('[member-realtime] resolve database failed', error);
+  }
+  return wx.cloud.database();
+}
 
 function notify(event) {
   listeners.forEach((listener) => {
@@ -29,6 +56,53 @@ function setGlobalMember(member) {
   }
 }
 
+function notifyMemberSnapshot(member) {
+  if (!member) {
+    return;
+  }
+  setGlobalMember(member);
+  notify({ type: 'memberSnapshot', member });
+}
+
+function stopManualRefresh() {
+  if (manualRefreshTimer) {
+    clearInterval(manualRefreshTimer);
+    manualRefreshTimer = null;
+  }
+}
+
+function refreshMemberSnapshot() {
+  if (!activeMemberId) {
+    return Promise.resolve();
+  }
+  if (manualRefreshPromise) {
+    return manualRefreshPromise;
+  }
+  manualRefreshPromise = MemberService.getMember()
+    .then((member) => {
+      if (member) {
+        notifyMemberSnapshot(member);
+      }
+    })
+    .catch((error) => {
+      console.error('[member-realtime] manual refresh failed', error);
+    })
+    .finally(() => {
+      manualRefreshPromise = null;
+    });
+  return manualRefreshPromise;
+}
+
+function startManualRefresh() {
+  if (manualRefreshTimer || !activeMemberId) {
+    return;
+  }
+  refreshMemberSnapshot();
+  manualRefreshTimer = setInterval(() => {
+    refreshMemberSnapshot();
+  }, MANUAL_REFRESH_INTERVAL);
+}
+
 function stopWatcher() {
   if (watcher && typeof watcher.close === 'function') {
     try {
@@ -40,44 +114,73 @@ function stopWatcher() {
   watcher = null;
 }
 
-function scheduleRestart() {
-  if (restartTimer) return;
+function disableWatcherTemporarily(error) {
+  if (restartTimer) {
+    clearTimeout(restartTimer);
+    restartTimer = null;
+  }
+  watcherSuspendedUntil = Date.now() + WATCH_SUSPEND_DURATION;
+  startManualRefresh();
+  console.warn('[member-realtime] realtime suspended after repeated failures', error);
+  restartTimer = setTimeout(() => {
+    restartTimer = null;
+    watcherSuspendedUntil = 0;
+    restartAttempts = 0;
+    startWatcher();
+  }, WATCH_SUSPEND_DURATION);
+}
+
+function scheduleRestart(error) {
+  if (restartTimer || !activeMemberId) {
+    return;
+  }
+  if (restartAttempts >= MAX_WATCH_RESTART_ATTEMPTS) {
+    disableWatcherTemporarily(error);
+    return;
+  }
   restartTimer = setTimeout(() => {
     restartTimer = null;
     startWatcher();
-  }, 2000);
+  }, WATCH_RETRY_DELAY);
 }
 
 function startWatcher() {
   if (!activeMemberId || watcher) {
     return;
   }
-  if (!wx.cloud || typeof wx.cloud.database !== 'function') {
+  if (watcherSuspendedUntil && watcherSuspendedUntil > Date.now()) {
+    startManualRefresh();
     return;
   }
+  const db = getDatabaseInstance();
+  if (!db) {
+    return;
+  }
+  stopManualRefresh();
   try {
-    watcher = wx
-      .cloud
-      .database()
+    watcher = db
       .collection('members')
       .doc(activeMemberId)
       .watch({
         onChange(snapshot) {
+          restartAttempts = 0;
           if (!snapshot) {
             return;
           }
           notify({ type: 'memberChanged', snapshot });
         },
         onError(error) {
+          restartAttempts += 1;
           console.error('[member-realtime] watch error', error);
           stopWatcher();
-          scheduleRestart();
+          scheduleRestart(error);
         }
       });
   } catch (error) {
+    restartAttempts += 1;
     console.error('[member-realtime] start watcher failed', error);
     stopWatcher();
-    scheduleRestart();
+    scheduleRestart(error);
   }
 }
 
@@ -90,14 +193,17 @@ export function setActiveMember(member) {
     return;
   }
   activeMemberId = memberId;
-  setGlobalMember(member);
-  notify({ type: 'memberSnapshot', member });
+  restartAttempts = 0;
+  notifyMemberSnapshot(member);
   startWatcher();
 }
 
 export function ensureWatcher() {
   if (activeMemberId) {
     startWatcher();
+    if (watcherSuspendedUntil && watcherSuspendedUntil > Date.now()) {
+      startManualRefresh();
+    }
     return Promise.resolve(activeMemberId);
   }
   if (ensurePromise) {
@@ -130,4 +236,7 @@ export function subscribe(listener) {
 
 export function clearListeners() {
   listeners.clear();
+  if (!listeners.size) {
+    stopManualRefresh();
+  }
 }


### PR DESCRIPTION
## Summary
- avoid relaunching the whole app when falling back to the home page and prefer redirecting or navigating back to an existing index page
- harden the member realtime watcher with retry limits, temporary suspension, and a manual refresh fallback to reduce repeated websocket failures in devtools

## Testing
- not run (WeChat Mini Program environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8e22fe7288330b1bc2fde86121d6d