### PR TITLE
feat: onboard new members with profile modal

### DIFF
--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -655,11 +655,13 @@ function formatDate(value) {
   if (!date || Number.isNaN(date.getTime())) {
     return '';
   }
-  const y = date.getFullYear();
-  const m = `${date.getMonth() + 1}`.padStart(2, '0');
-  const d = `${date.getDate()}`.padStart(2, '0');
-  const hh = `${date.getHours()}`.padStart(2, '0');
-  const mm = `${date.getMinutes()}`.padStart(2, '0');
+  const utcTimestamp = date.getTime() + date.getTimezoneOffset() * 60 * 1000;
+  const beijing = new Date(utcTimestamp + 8 * 60 * 60 * 1000);
+  const y = beijing.getUTCFullYear();
+  const m = `${beijing.getUTCMonth() + 1}`.padStart(2, '0');
+  const d = `${beijing.getUTCDate()}`.padStart(2, '0');
+  const hh = `${beijing.getUTCHours()}`.padStart(2, '0');
+  const mm = `${beijing.getUTCMinutes()}`.padStart(2, '0');
   return `${y}-${m}-${d} ${hh}:${mm}`;
 }
 

--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -99,4 +99,47 @@
       </view>
     </view>
   </view>
+
+  <view wx:if="{{showOnboarding}}" class="onboarding-modal">
+    <view class="modal-mask"></view>
+    <view class="onboarding-content">
+      <view class="onboarding-header">
+        <view class="onboarding-title">完善仙缘信息</view>
+        <view class="onboarding-subtitle">首次入门请留下道号与联系方式</view>
+      </view>
+      <view class="onboarding-section">
+        <view class="onboarding-label">道号</view>
+        <input
+          class="onboarding-input"
+          value="{{onboarding.nickName}}"
+          placeholder="请输入您的昵称"
+          maxlength="20"
+          bindinput="handleNicknameInput"
+        />
+        <button class="onboarding-action" bindtap="handleRequestUserProfile">使用微信昵称</button>
+      </view>
+      <view class="onboarding-section">
+        <view class="onboarding-label">手机号</view>
+        <input
+          class="onboarding-input"
+          value="{{onboarding.mobile}}"
+          placeholder="请输入手机号"
+          type="number"
+          maxlength="11"
+          bindinput="handlePhoneInput"
+        />
+        <button
+          class="onboarding-action"
+          open-type="getPhoneNumber"
+          bindgetphonenumber="handleGetPhoneNumber"
+        >获取手机号</button>
+      </view>
+      <button
+        class="onboarding-submit"
+        loading="{{onboardingSubmitting}}"
+        disabled="{{onboardingSubmitting}}"
+        bindtap="handleOnboardingConfirm"
+      >确认并开启旅程</button>
+    </view>
+  </view>
 </view>

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -415,3 +415,93 @@ page {
   text-align: center;
   padding: 24rpx 0;
 }
+
+.onboarding-modal {
+  position: absolute;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.onboarding-content {
+  position: relative;
+  width: 600rpx;
+  border-radius: 36rpx;
+  background: rgba(18, 26, 68, 0.95);
+  border: 1rpx solid rgba(147, 168, 255, 0.45);
+  padding: 48rpx 42rpx 40rpx;
+  box-sizing: border-box;
+  color: #f5f5ff;
+  box-shadow: 0 32rpx 64rpx rgba(8, 12, 44, 0.65);
+}
+
+.onboarding-header {
+  text-align: center;
+  margin-bottom: 32rpx;
+}
+
+.onboarding-title {
+  font-size: 34rpx;
+  font-weight: 600;
+  letter-spacing: 4rpx;
+}
+
+.onboarding-subtitle {
+  margin-top: 12rpx;
+  font-size: 24rpx;
+  color: rgba(218, 225, 255, 0.75);
+}
+
+.onboarding-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16rpx;
+  margin-bottom: 32rpx;
+}
+
+.onboarding-label {
+  font-size: 26rpx;
+  color: rgba(214, 223, 255, 0.82);
+}
+
+.onboarding-input {
+  height: 88rpx;
+  padding: 0 24rpx;
+  border-radius: 24rpx;
+  background: rgba(28, 40, 98, 0.9);
+  border: 1rpx solid rgba(137, 155, 255, 0.45);
+  color: #ffffff;
+  font-size: 28rpx;
+  box-sizing: border-box;
+}
+
+.onboarding-input::placeholder {
+  color: rgba(200, 210, 255, 0.5);
+}
+
+.onboarding-action {
+  height: 80rpx;
+  margin-top: 4rpx;
+  border-radius: 999rpx;
+  background: linear-gradient(90deg, rgba(102, 131, 255, 0.92), rgba(173, 132, 255, 0.92));
+  color: #ffffff;
+  font-size: 26rpx;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.onboarding-submit {
+  margin-top: 8rpx;
+  height: 88rpx;
+  border-radius: 999rpx;
+  background: linear-gradient(90deg, #7b5bff, #b07bff);
+  color: #ffffff;
+  font-size: 28rpx;
+}
+
+.onboarding-submit[disabled] {
+  background: rgba(123, 91, 255, 0.5);
+}

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -32,6 +32,22 @@ export const MemberService = {
   },
   async getRights() {
     return callCloud(CLOUD_FUNCTIONS.MEMBER, { action: 'rights' });
+  },
+  async completeProfile(profile = {}, options = {}) {
+    const payload = {
+      action: 'completeProfile',
+      profile
+    };
+    if (options.phoneCloudId) {
+      payload.phone = wx.cloud.CloudID(options.phoneCloudId);
+    }
+    if (options.phoneCode) {
+      payload.phoneCode = options.phoneCode;
+    }
+    if (options.phoneNumber) {
+      payload.phoneNumber = options.phoneNumber;
+    }
+    return callCloud(CLOUD_FUNCTIONS.MEMBER, payload);
   }
 };
 


### PR DESCRIPTION
## Summary
- prompt new members with an onboarding modal to capture nickname and mobile data before entering the mini program
- add a completeProfile member cloud action that records the provided profile details and resolves phone numbers via CloudID or code
- render registration timestamps in the Beijing timezone for admin views

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8e559846c833098fbc7b1dbe943d3