### PR TITLE
feat: enhance member archive editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ cd cloudfunctions/member && npm install && cd -
   - 新注册用户默认拥有 1 次改名机会（`renameCredits`）。
   - 使用“改名卡”会将 `renameCards` 库存转换为新的改名次数，并同步累积 `renameUsed` 与 `renameHistory`。
   - 每次改名均会记录原名称、现名称、时间与来源，便于运营稽核。
+  - 管理员后台修改道号会写入 `renameHistory`，来源标记为 `admin`，且不会扣减用户的改名次数。
 - **性别（`gender`）**：支持 `male`、`female`、`unknown` 三种取值，可随时切换。
 - **头像（`avatarUrl`）**：前端默认生成 5 个渐变风格的 SVG 头像供选择，也可一键同步微信头像。
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - **在线预订与下单**：可视化包房/卡座预约，支持定金/全额支付与权益券抵扣。
 - **资产体系**：现金钱包支持充值消费流水，灵石作为虚拟货币独立结算；提供明细查询。
 - **虚拟形象（Avatar）**：QQ 秀风格的装扮系统，等级与任务可解锁服饰并分享展示。
+- **仙缘档案编辑**：会员可自助修改道号、性别与头像，支持改名次数管控及改名卡补充次数。
 
 ## 技术栈
 
@@ -66,6 +67,8 @@ cd cloudfunctions/member && npm install && cd -
 
 部署完成后，先执行一次 `bootstrap` 云函数，它会向数据库写入示例数据（等级、房间、任务等），便于演示及二次开发。
 
+> 提醒：若对会员档案逻辑做了改动（例如改名次数、头像选择等），请重新部署 `member` 云函数并上传最新小程序前端代码。
+
 ### 3. 配置小程序前端
 
 1. 在 `miniprogram/app.js` 中的 `env` 替换为你的云开发 `envId`。
@@ -81,6 +84,11 @@ cd cloudfunctions/member && npm install && cd -
 | `_id` | string | openid，云开发自动填充 |
 | `nickName` | string | 用户昵称 |
 | `mobile` | string | 绑定手机号 |
+| `gender` | string | 性别，取值 `male` / `female` / `unknown` |
+| `renameCredits` | number | 剩余改名次数，初始值为 1，可用改名卡增加 |
+| `renameCards` | number | 改名卡库存数量 |
+| `renameUsed` | number | 已经消耗的改名次数，便于审计 |
+| `renameHistory` | array | 改名记录（`previous`、`current`、`changedAt`、`source`） |
 | `levelId` | string | 当前等级 ID |
 | `experience` | number | 累积经验值（可映射到充值额） |
 | `cashBalance` | number | 现金钱包余额（单位：分，用于店内实体消费） |
@@ -89,6 +97,17 @@ cd cloudfunctions/member && npm install && cd -
 | `avatarConfig` | object | 虚拟形象配置 |
 
 > 现金钱包与灵石为两套完全独立的账户体系，当前版本不支持兑换或折现，灵石数值仅以整数形式发放与消耗。
+
+## 仙缘档案编辑
+
+- **道号（`nickName`）**：
+  - 新注册用户默认拥有 1 次改名机会（`renameCredits`）。
+  - 使用“改名卡”会将 `renameCards` 库存转换为新的改名次数，并同步累积 `renameUsed` 与 `renameHistory`。
+  - 每次改名均会记录原名称、现名称、时间与来源，便于运营稽核。
+- **性别（`gender`）**：支持 `male`、`female`、`unknown` 三种取值，可随时切换。
+- **头像（`avatarUrl`）**：前端默认生成 5 个渐变风格的 SVG 头像供选择，也可一键同步微信头像。
+
+> 如需在运营后台发放改名卡，可直接增加 `renameCards` 字段值，或结合任务/权益体系发卡；前端会在用户使用改名卡时自动调用 `redeemRenameCard` 动作同步次数。
 
 ### membershipLevels
 

--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -481,6 +481,10 @@ function buildUpdatePayload(updates, existing = {}) {
     const stones = Number(updates.stoneBalance || 0);
     payload.stoneBalance = Number.isFinite(stones) ? Math.max(0, Math.floor(stones)) : 0;
   }
+  if (Object.prototype.hasOwnProperty.call(updates, 'renameCredits')) {
+    const credits = Number(updates.renameCredits || 0);
+    payload.renameCredits = Number.isFinite(credits) ? Math.max(0, Math.floor(credits)) : 0;
+  }
   if (Object.prototype.hasOwnProperty.call(updates, 'roles')) {
     const roles = Array.isArray(updates.roles) ? updates.roles : [];
     const filtered = roles.filter((role) => ['member', 'admin', 'developer'].includes(role));

--- a/cloudfunctions/member/index.js
+++ b/cloudfunctions/member/index.js
@@ -396,15 +396,6 @@ async function ensureArchiveDefaults(member) {
     member.gender = 'unknown';
     updates.gender = 'unknown';
   }
-  const renameCredits = Number.isFinite(member.renameCredits)
-    ? Math.max(0, Math.floor(member.renameCredits))
-    : 0;
-  if (!Object.is(renameCredits, member.renameCredits)) {
-    updates.renameCredits = renameCredits;
-    member.renameCredits = renameCredits;
-  } else {
-    member.renameCredits = renameCredits;
-  }
 
   const renameUsed = Number.isFinite(member.renameUsed) ? Math.max(0, Math.floor(member.renameUsed)) : 0;
   if (!Object.is(renameUsed, member.renameUsed)) {
@@ -412,6 +403,19 @@ async function ensureArchiveDefaults(member) {
     member.renameUsed = renameUsed;
   } else {
     member.renameUsed = renameUsed;
+  }
+
+  const hasRenameCredits = Object.prototype.hasOwnProperty.call(member, 'renameCredits');
+  const rawRenameCredits = hasRenameCredits ? member.renameCredits : Math.max(0, 1 - renameUsed);
+  const numericRenameCredits = Number(rawRenameCredits);
+  const renameCredits = Number.isFinite(numericRenameCredits)
+    ? Math.max(0, Math.floor(numericRenameCredits))
+    : Math.max(0, 1 - renameUsed);
+  if (!Object.is(renameCredits, member.renameCredits)) {
+    updates.renameCredits = renameCredits;
+    member.renameCredits = renameCredits;
+  } else {
+    member.renameCredits = renameCredits;
   }
 
   const renameCards = Number.isFinite(member.renameCards) ? Math.max(0, Math.floor(member.renameCards)) : 0;

--- a/miniprogram/pages/admin/member-detail/index.js
+++ b/miniprogram/pages/admin/member-detail/index.js
@@ -79,7 +79,8 @@ Page({
       cashBalance: '',
       stoneBalance: '',
       levelId: '',
-      roles: []
+      roles: [],
+      renameCredits: ''
     },
     rechargeVisible: false,
     rechargeAmount: '',
@@ -147,7 +148,8 @@ Page({
         cashBalance: this.formatYuan(member.cashBalance ?? member.balance ?? 0),
         stoneBalance: String(member.stoneBalance ?? 0),
         levelId: member.levelId || currentLevel._id || '',
-        roles
+        roles,
+        renameCredits: String(member.renameCredits ?? 0)
       },
       roleOptions,
       renameHistory: formatRenameHistory(member.renameHistory)
@@ -194,7 +196,8 @@ Page({
         cashBalance: this.parseYuanToFen(this.data.form.cashBalance),
         stoneBalance: Number(this.data.form.stoneBalance || 0),
         levelId: this.data.form.levelId,
-        roles: ensureMemberRole(this.data.form.roles)
+        roles: ensureMemberRole(this.data.form.roles),
+        renameCredits: this.parseRenameCredits(this.data.form.renameCredits)
       };
       const detail = await AdminService.updateMember(this.data.memberId, payload);
       this.applyDetail(detail);
@@ -261,6 +264,24 @@ Page({
       const sanitized = input.trim().replace(/[^0-9.-]/g, '');
       const parsed = Number(sanitized);
       return Number.isFinite(parsed) ? Math.round(parsed * 100) : 0;
+    }
+    return 0;
+  },
+
+  parseRenameCredits(input) {
+    if (input == null || input === '') {
+      return 0;
+    }
+    if (typeof input === 'number' && Number.isFinite(input)) {
+      return Math.max(0, Math.floor(input));
+    }
+    if (typeof input === 'string') {
+      const sanitized = input.trim().replace(/[^0-9]/g, '');
+      if (!sanitized) {
+        return 0;
+      }
+      const parsed = Number(sanitized);
+      return Number.isFinite(parsed) ? Math.max(0, Math.floor(parsed)) : 0;
     }
     return 0;
   }

--- a/miniprogram/pages/admin/member-detail/index.wxml
+++ b/miniprogram/pages/admin/member-detail/index.wxml
@@ -22,7 +22,7 @@
       <button class="recharge" size="mini" bindtap="showRechargeDialog">为该会员充值</button>
     </view>
     <view class="form-item">
-      <view class="form-label">昵称</view>
+      <view class="form-label">道号</view>
       <input
         class="form-input"
         value="{{form.nickName}}"
@@ -30,6 +30,17 @@
         data-field="nickName"
         bindinput="handleInputChange"
       />
+    </view>
+    <view class="rename-meta">
+      <text>剩余改名次数：{{member.renameCredits || 0}}</text>
+      <text>已使用：{{member.renameUsed || 0}}</text>
+    </view>
+    <view wx:if="{{renameHistory.length}}" class="rename-history">
+      <view class="rename-history__title">改名记录</view>
+      <view class="rename-history__item" wx:for="{{renameHistory}}" wx:key="id">
+        <view class="rename-history__names">{{item.previous}} → {{item.current}}</view>
+        <view class="rename-history__meta">{{item.time}} · {{item.source}}</view>
+      </view>
     </view>
     <view class="form-item">
       <view class="form-label">手机号</view>

--- a/miniprogram/pages/admin/member-detail/index.wxml
+++ b/miniprogram/pages/admin/member-detail/index.wxml
@@ -31,9 +31,19 @@
         bindinput="handleInputChange"
       />
     </view>
+    <view class="form-item">
+      <view class="form-label">剩余改名次数</view>
+      <input
+        class="form-input"
+        type="number"
+        value="{{form.renameCredits}}"
+        placeholder="请输入剩余改名次数"
+        data-field="renameCredits"
+        bindinput="handleInputChange"
+      />
+    </view>
     <view class="rename-meta">
-      <text>剩余改名次数：{{member.renameCredits || 0}}</text>
-      <text>已使用：{{member.renameUsed || 0}}</text>
+      <text>已使用改名次数：{{member.renameUsed || 0}}</text>
     </view>
     <view wx:if="{{renameHistory.length}}" class="rename-history">
       <view class="rename-history__title">改名记录</view>

--- a/miniprogram/pages/admin/member-detail/index.wxss
+++ b/miniprogram/pages/admin/member-detail/index.wxss
@@ -65,6 +65,46 @@ page {
   margin-bottom: 12rpx;
 }
 
+.rename-meta {
+  display: flex;
+  gap: 24rpx;
+  margin-bottom: 20rpx;
+  font-size: 24rpx;
+  color: #cbd5f5;
+}
+
+.rename-history {
+  margin-bottom: 28rpx;
+  padding: 20rpx;
+  border-radius: 16rpx;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.rename-history__title {
+  font-size: 26rpx;
+  font-weight: 600;
+  margin-bottom: 12rpx;
+  color: #f8fafc;
+}
+
+.rename-history__item + .rename-history__item {
+  margin-top: 16rpx;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+  padding-top: 16rpx;
+}
+
+.rename-history__names {
+  font-size: 26rpx;
+  color: #e2e8f0;
+}
+
+.rename-history__meta {
+  margin-top: 6rpx;
+  font-size: 22rpx;
+  color: rgba(148, 163, 184, 0.9);
+}
+
 .form-input {
   width: 100%;
   padding: 20rpx;

--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -61,41 +61,114 @@
 
   <view wx:if="{{showProfile}}" class="profile-modal">
     <view class="modal-mask" bindtap="handleCloseProfile"></view>
-    <view class="modal-content">
+    <view class="modal-content modal-content--editor">
       <view class="modal-header">
         <view class="modal-title">仙缘档案</view>
         <view class="modal-close" bindtap="handleCloseProfile">×</view>
       </view>
-      <view class="modal-body">
-        <view class="modal-row">
-          <text class="modal-label">道号</text>
-          <text class="modal-value">{{member ? (member.nickName || '神秘仙友') : '神秘仙友'}}</text>
+      <scroll-view scroll-y="true" class="modal-body modal-body--scroll">
+        <view class="archive-section">
+          <view class="archive-section__header">
+            <view class="archive-section__title">道号</view>
+            <view class="archive-section__meta">剩余次数：{{profileEditor.renameCredits}}</view>
+          </view>
+          <view class="archive-field">
+            <input
+              class="archive-input"
+              value="{{profileEditor.nickName}}"
+              placeholder="请输入你的道号"
+              maxlength="12"
+              bindinput="handleArchiveNickname"
+            />
+          </view>
+          <view class="archive-helper">首次改名免费，后续需消耗改名次数，可使用改名卡补充。</view>
+          <button
+            wx:if="{{profileEditor.renameCards > 0}}"
+            class="archive-action"
+            size="mini"
+            loading="{{renameRedeeming}}"
+            disabled="{{renameRedeeming}}"
+            bindtap="handleUseRenameCard"
+          >使用改名卡（+1 次）</button>
         </view>
-        <view class="modal-row">
-          <text class="modal-label">当前境界</text>
-          <text class="modal-value">{{member ? (member.level ? member.level.name : '练气初期') : '练气初期'}}</text>
-        </view>
-        <view class="modal-row">
-          <text class="modal-label">修为值</text>
-          <text class="modal-value">{{memberStats.experience}}</text>
-        </view>
-        <view class="modal-row">
-          <text class="modal-label">灵石余额</text>
-          <text class="modal-value">{{memberStats.stoneBalance}}</text>
-        </view>
-        <view class="modal-row">
-          <text class="modal-label">现金余额</text>
-          <text class="modal-value">{{memberStats.cashBalance}}</text>
-        </view>
-        <view class="modal-divider"></view>
-        <view class="modal-section-title">今日任务</view>
-        <view wx:if="{{tasks.length}}" class="modal-task-list">
-          <view class="modal-task" wx:for="{{tasks}}" wx:key="_id">
-            <view class="task-name">{{item.title}}</view>
-            <view class="task-reward">{{item.rewardSummary}}</view>
+
+        <view class="archive-section">
+          <view class="archive-section__title">性别</view>
+          <view class="gender-options">
+            <view
+              class="gender-option {{profileEditor.gender === 'unknown' ? 'gender-option--active' : ''}}"
+              data-value="unknown"
+              bindtap="handleGenderSelect"
+            >保密</view>
+            <view
+              class="gender-option {{profileEditor.gender === 'male' ? 'gender-option--active' : ''}}"
+              data-value="male"
+              bindtap="handleGenderSelect"
+            >道友</view>
+            <view
+              class="gender-option {{profileEditor.gender === 'female' ? 'gender-option--active' : ''}}"
+              data-value="female"
+              bindtap="handleGenderSelect"
+            >仙子</view>
           </view>
         </view>
-        <view wx:else class="modal-empty">今日暂无任务，稍后再来查看~</view>
+
+        <view class="archive-section">
+          <view class="archive-section__header">
+            <view class="archive-section__title">头像</view>
+            <view class="archive-section__link" bindtap="handleRegenerateAvatars">换一批</view>
+          </view>
+          <view class="avatar-grid">
+            <view
+              class="avatar-option {{profileEditor.avatarUrl === item.url ? 'avatar-option--active' : ''}}"
+              wx:for="{{profileEditor.avatarOptions}}"
+              wx:key="id"
+              data-url="{{item.url}}"
+              bindtap="handleArchiveAvatarSelect"
+            >
+              <image class="avatar-option__image" src="{{item.url}}" mode="aspectFill"></image>
+              <view wx:if="{{profileEditor.avatarUrl === item.url}}" class="avatar-option__badge">使用中</view>
+            </view>
+          </view>
+          <button class="archive-action" size="mini" bindtap="handleSyncWechatAvatar">同步微信头像</button>
+        </view>
+
+        <view class="archive-section archive-section--summary">
+          <view class="archive-summary">
+            <view class="archive-summary__item">
+              <view class="archive-summary__label">当前境界</view>
+              <view class="archive-summary__value">{{member ? (member.level ? member.level.name : '练气初期') : '练气初期'}}</view>
+            </view>
+            <view class="archive-summary__item">
+              <view class="archive-summary__label">修为值</view>
+              <view class="archive-summary__value">{{memberStats.experience}}</view>
+            </view>
+            <view class="archive-summary__item">
+              <view class="archive-summary__label">灵石</view>
+              <view class="archive-summary__value">{{memberStats.stoneBalance}}</view>
+            </view>
+          </view>
+        </view>
+
+        <view class="archive-section" wx:if="{{profileEditor.renameHistory.length}}">
+          <view class="archive-section__title">改名记录</view>
+          <view class="rename-history">
+            <view class="rename-history__item" wx:for="{{profileEditor.renameHistory}}" wx:key="id">
+              <view class="rename-history__names">{{item.previous || '—'}} → {{item.current || '—'}}</view>
+              <view class="rename-history__time">{{item.displayTime}}</view>
+            </view>
+          </view>
+        </view>
+      </scroll-view>
+      <view class="modal-footer">
+        <button class="modal-footer__btn modal-footer__btn--ghost" bindtap="handleCloseProfile" disabled="{{profileSaving}}">取消</button>
+        <button
+          class="modal-footer__btn"
+          type="primary"
+          loading="{{profileSaving}}"
+          disabled="{{profileSaving}}"
+          bindtap="handleArchiveSubmit"
+        >保存档案</button>
       </view>
     </view>
   </view>

--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -104,12 +104,18 @@
               class="gender-option {{profileEditor.gender === 'male' ? 'gender-option--active' : ''}}"
               data-value="male"
               bindtap="handleGenderSelect"
-            >道友</view>
+            >
+              <text class="gender-option__icon" aria-hidden="true">♂</text>
+              <text class="gender-option__label">道友</text>
+            </view>
             <view
               class="gender-option {{profileEditor.gender === 'female' ? 'gender-option--active' : ''}}"
               data-value="female"
               bindtap="handleGenderSelect"
-            >仙子</view>
+            >
+              <text class="gender-option__icon" aria-hidden="true">♀</text>
+              <text class="gender-option__label">仙子</text>
+            </view>
           </view>
         </view>
 

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -459,7 +459,10 @@ page {
 .gender-option {
   flex: 1;
   padding: 18rpx 0;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10rpx;
   border-radius: 20rpx;
   border: 1rpx solid rgba(137, 155, 255, 0.25);
   background: rgba(32, 44, 108, 0.55);
@@ -473,6 +476,15 @@ page {
   border-color: rgba(185, 199, 255, 0.9);
   color: #ffffff;
   box-shadow: 0 12rpx 24rpx rgba(73, 86, 198, 0.45);
+}
+
+.gender-option__icon {
+  font-size: 30rpx;
+  line-height: 1;
+}
+
+.gender-option__label {
+  font-size: 26rpx;
 }
 
 .avatar-grid {

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -329,8 +329,16 @@ page {
   border: 1rpx solid rgba(137, 155, 255, 0.45);
   box-shadow: 0 28rpx 48rpx rgba(9, 12, 40, 0.6);
   color: #f6f4ff;
-  padding: 36rpx;
+  padding: 32rpx 36rpx;
   box-sizing: border-box;
+}
+
+.modal-content--editor {
+  width: 620rpx;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  padding: 32rpx 36rpx 28rpx;
 }
 
 .modal-header {
@@ -360,60 +368,229 @@ page {
 .modal-body {
   display: flex;
   flex-direction: column;
-  gap: 18rpx;
 }
 
-.modal-row {
+.modal-body--scroll {
+  flex: 1;
+  min-height: 0;
+  max-height: 520rpx;
+  display: flex;
+  flex-direction: column;
+  gap: 24rpx;
+  padding-right: 12rpx;
+  box-sizing: border-box;
+}
+
+.archive-section {
+  padding: 20rpx 0;
+  border-bottom: 1rpx solid rgba(127, 147, 255, 0.18);
+}
+
+.archive-section:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.archive-section__header {
   display: flex;
   justify-content: space-between;
-  font-size: 26rpx;
-  color: rgba(232, 236, 255, 0.92);
+  align-items: center;
+  margin-bottom: 16rpx;
 }
 
-.modal-label {
-  color: rgba(200, 210, 255, 0.72);
-}
-
-.modal-divider {
-  height: 1rpx;
-  background: linear-gradient(90deg, rgba(143, 160, 255, 0), rgba(143, 160, 255, 0.6), rgba(143, 160, 255, 0));
-  margin: 12rpx 0 4rpx;
-}
-
-.modal-section-title {
-  font-size: 28rpx;
-  color: rgba(235, 240, 255, 0.9);
+.archive-section__title {
+  font-size: 30rpx;
+  font-weight: 600;
   letter-spacing: 3rpx;
 }
 
-.modal-task-list {
+.archive-section__meta {
+  font-size: 24rpx;
+  color: rgba(200, 210, 255, 0.7);
+}
+
+.archive-section__link {
+  font-size: 24rpx;
+  color: #9db6ff;
+  text-decoration: underline;
+}
+
+.archive-field {
+  padding: 12rpx 20rpx;
+  border-radius: 22rpx;
+  background: rgba(35, 48, 110, 0.5);
+  border: 1rpx solid rgba(137, 155, 255, 0.35);
+}
+
+.archive-input {
+  width: 100%;
+  font-size: 28rpx;
+  color: #f6f4ff;
+}
+
+.archive-helper {
+  margin-top: 12rpx;
+  font-size: 22rpx;
+  line-height: 34rpx;
+  color: rgba(204, 212, 255, 0.72);
+}
+
+.archive-action {
+  margin-top: 18rpx;
+  border-radius: 20rpx;
+  padding: 0 28rpx;
+  height: 64rpx;
+  line-height: 64rpx;
+  font-size: 24rpx;
+  color: #f4f6ff;
+  background: rgba(124, 146, 255, 0.2);
+  border: 1rpx solid rgba(143, 160, 255, 0.45);
+}
+
+.archive-action::after {
+  display: none;
+}
+
+.gender-options {
+  display: flex;
+  gap: 16rpx;
+}
+
+.gender-option {
+  flex: 1;
+  padding: 18rpx 0;
+  text-align: center;
+  border-radius: 20rpx;
+  border: 1rpx solid rgba(137, 155, 255, 0.25);
+  background: rgba(32, 44, 108, 0.55);
+  color: rgba(220, 228, 255, 0.82);
+  font-size: 26rpx;
+  transition: all 0.2s ease;
+}
+
+.gender-option--active {
+  background: linear-gradient(120deg, rgba(119, 154, 255, 0.85), rgba(185, 141, 255, 0.9));
+  border-color: rgba(185, 199, 255, 0.9);
+  color: #ffffff;
+  box-shadow: 0 12rpx 24rpx rgba(73, 86, 198, 0.45);
+}
+
+.avatar-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18rpx;
+  margin: 18rpx 0;
+}
+
+.avatar-option {
+  position: relative;
+  border-radius: 24rpx;
+  overflow: hidden;
+  border: 2rpx solid transparent;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.avatar-option--active {
+  border-color: rgba(156, 178, 255, 0.85);
+  transform: translateY(-4rpx);
+  box-shadow: 0 12rpx 28rpx rgba(46, 61, 160, 0.45);
+}
+
+.avatar-option__image {
+  width: 100%;
+  height: 160rpx;
+  border-radius: 24rpx;
+}
+
+.avatar-option__badge {
+  position: absolute;
+  right: 12rpx;
+  bottom: 12rpx;
+  padding: 6rpx 16rpx;
+  border-radius: 16rpx;
+  background: rgba(19, 30, 86, 0.78);
+  color: #f6f4ff;
+  font-size: 22rpx;
+}
+
+.archive-summary {
+  display: flex;
+  gap: 12rpx;
+  padding: 20rpx;
+  border-radius: 24rpx;
+  background: rgba(35, 48, 110, 0.55);
+  border: 1rpx solid rgba(143, 160, 255, 0.25);
+}
+
+.archive-summary__item {
+  flex: 1;
+  text-align: center;
+}
+
+.archive-summary__label {
+  font-size: 22rpx;
+  color: rgba(204, 212, 255, 0.72);
+}
+
+.archive-summary__value {
+  margin-top: 8rpx;
+  font-size: 30rpx;
+  color: #ffffff;
+  letter-spacing: 2rpx;
+}
+
+.rename-history {
   display: flex;
   flex-direction: column;
-  gap: 12rpx;
+  gap: 14rpx;
+  margin-top: 12rpx;
 }
 
-.modal-task {
+.rename-history__item {
   padding: 16rpx 20rpx;
-  border-radius: 24rpx;
-  background: rgba(35, 48, 110, 0.72);
-  border: 1rpx solid rgba(119, 138, 230, 0.28);
+  border-radius: 20rpx;
+  background: rgba(35, 48, 110, 0.5);
+  border: 1rpx solid rgba(137, 155, 255, 0.25);
 }
 
-.task-name {
+.rename-history__names {
   font-size: 26rpx;
-  margin-bottom: 6rpx;
+  color: #f6f4ff;
 }
 
-.task-reward {
+.rename-history__time {
+  margin-top: 6rpx;
   font-size: 22rpx;
-  color: rgba(210, 220, 255, 0.78);
+  color: rgba(204, 212, 255, 0.7);
 }
 
-.modal-empty {
-  font-size: 24rpx;
-  color: rgba(204, 212, 255, 0.7);
-  text-align: center;
-  padding: 24rpx 0;
+.modal-footer {
+  margin-top: 28rpx;
+  display: flex;
+  justify-content: flex-end;
+  gap: 18rpx;
+}
+
+.modal-footer__btn {
+  min-width: 160rpx;
+  height: 68rpx;
+  line-height: 68rpx;
+  border-radius: 26rpx;
+  font-size: 26rpx;
+  color: #ffffff;
+  background: linear-gradient(120deg, #6f88ff, #c18bff);
+  border: none;
+  padding: 0 32rpx;
+}
+
+.modal-footer__btn::after {
+  display: none;
+}
+
+.modal-footer__btn--ghost {
+  background: transparent;
+  border: 1rpx solid rgba(143, 160, 255, 0.45);
+  color: rgba(220, 228, 255, 0.85);
 }
 
 .onboarding-modal {

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -48,6 +48,18 @@ export const MemberService = {
       payload.phoneNumber = options.phoneNumber;
     }
     return callCloud(CLOUD_FUNCTIONS.MEMBER, payload);
+  },
+  async updateArchive(updates = {}) {
+    return callCloud(CLOUD_FUNCTIONS.MEMBER, {
+      action: 'updateArchive',
+      updates
+    });
+  },
+  async redeemRenameCard(count = 1) {
+    return callCloud(CLOUD_FUNCTIONS.MEMBER, {
+      action: 'redeemRenameCard',
+      count
+    });
   }
 };
 


### PR DESCRIPTION
## Summary
- add rename tracking, gender defaults, and archive update actions to the member cloud function
- expose archive update APIs to the mini program and redesign the profile modal with rename card support and avatar selection
- document the new archive editing flow, including deployment reminders and schema updates

## Testing
- not run (mini program environment)


------
https://chatgpt.com/codex/tasks/task_e_68d905014e58833084a1a0cf47ff77d9