### PR TITLE
feat: support direct WeChat scanning for admin charge orders

### DIFF
--- a/miniprogram/pages/admin/charge/index.wxml
+++ b/miniprogram/pages/admin/charge/index.wxml
@@ -67,12 +67,28 @@
       <view class="row"><text class="label">有效期至</text><text class="value">{{currentOrder.expireAtLabel}}</text></view>
     </view>
     <view class="qr-wrapper">
-      <canvas
-        type="2d"
-        id="charge-qr"
-        canvas-id="charge-qr"
-        style="width:240px;height:240px;"
-      ></canvas>
+      <view class="qr-block">
+        <view class="qr-title">微信扫一扫</view>
+        <view class="qr-image" wx:if="{{miniProgramQr}}">
+          <image mode="aspectFit" src="{{miniProgramQr}}"></image>
+        </view>
+        <view class="qr-placeholder" wx:elif="{{miniProgramQrLoading}}">小程序码生成中…</view>
+        <view class="qr-placeholder error" wx:elif="{{miniProgramQrError}}">
+          <text>{{miniProgramQrError}}</text>
+          <button class="retry" size="mini" bindtap="handleReloadMiniProgramQr">重新生成</button>
+        </view>
+        <view class="qr-tip">管理员可直接使用微信扫一扫完成扣费</view>
+      </view>
+      <view class="qr-block">
+        <view class="qr-title">会员钱包扫码</view>
+        <canvas
+          type="2d"
+          id="charge-qr"
+          canvas-id="charge-qr"
+          style="width:240px;height:240px;"
+        ></canvas>
+        <view class="qr-tip">会员也可在钱包页使用扫码功能识别</view>
+      </view>
     </view>
     <button class="outline" loading="{{loadingOrder}}" bindtap="handleRefresh">刷新状态</button>
   </view>

--- a/miniprogram/pages/admin/charge/index.wxss
+++ b/miniprogram/pages/admin/charge/index.wxss
@@ -141,8 +141,71 @@ page {
 
 .qr-wrapper {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 32rpx;
   padding: 24rpx 0;
+}
+
+.qr-block {
+  background: rgba(15, 24, 64, 0.6);
+  border-radius: 24rpx;
+  padding: 28rpx 32rpx 36rpx;
+  width: 100%;
+  max-width: 360rpx;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16rpx;
+}
+
+.qr-title {
+  font-size: 28rpx;
+  font-weight: 600;
+}
+
+.qr-image {
+  width: 240rpx;
+  height: 240rpx;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.qr-image image {
+  width: 100%;
+  height: 100%;
+}
+
+.qr-placeholder {
+  min-height: 240rpx;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16rpx;
+  font-size: 26rpx;
+  color: rgba(226, 232, 240, 0.8);
+  text-align: center;
+}
+
+.qr-placeholder.error {
+  color: #ff8a80;
+}
+
+.retry {
+  margin-top: 8rpx;
+  background: rgba(255, 255, 255, 0.1);
+  color: #e2e8f0;
+  border-radius: 999px;
+  padding: 8rpx 24rpx;
+  border: none;
+}
+
+.qr-tip {
+  font-size: 24rpx;
+  opacity: 0.7;
+  text-align: center;
 }
 
 .outline {

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -301,6 +301,12 @@ export const AdminService = {
       orderId
     });
   },
+  async getChargeOrderQrCode(orderId) {
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, {
+      action: 'getChargeOrderQrCode',
+      orderId
+    });
+  },
   async listChargeOrders({ page = 1, pageSize = 20, memberId = '', keyword = '' } = {}) {
     return callCloud(CLOUD_FUNCTIONS.ADMIN, {
       action: 'listChargeOrders',


### PR DESCRIPTION
## Summary
- generate mini program QR codes for charge orders so WeChat scan can open the confirmation page directly
- surface the WeChat mini program QR code alongside the existing wallet QR on the admin charge screen with updated UI and retry handling
- allow the wallet charge confirmation page to resolve order IDs from mini program scan scenes

## Testing
- not run (WeChat mini program runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9302c8d58833084393e7bcb20fa01