### PR TITLE
feat: allow custom reservation time range

### DIFF
--- a/cloudfunctions/bootstrap/index.js
+++ b/cloudfunctions/bootstrap/index.js
@@ -383,7 +383,8 @@ const membershipRights = [
       { start: '12:00', end: '24:00' },
       { start: '00:00', end: '06:00' }
     ],
-    validDays: 120
+    validDays: 120,
+    meta: { roomUsageCount: 1 }
   },
   {
     _id: 'right_realm_core_gift',
@@ -444,7 +445,8 @@ const membershipRights = [
     description: '免费预订一次日间非高峰包房',
     applyReservation: true,
     applyTimeRanges: [{ start: '12:00', end: '18:00' }],
-    validDays: 90
+    validDays: 90,
+    meta: { roomUsageCount: 1 }
   },
   {
     _id: 'right_full_day_room',
@@ -452,7 +454,8 @@ const membershipRights = [
     description: '免费预订一次全天任意时段包房',
     applyReservation: true,
     applyTimeRanges: [{ start: '00:00', end: '24:00' }],
-    validDays: 120
+    validDays: 120,
+    meta: { roomUsageCount: 1 }
   },
   {
     _id: 'right_full_house',

--- a/cloudfunctions/bootstrap/index.js
+++ b/cloudfunctions/bootstrap/index.js
@@ -379,7 +379,10 @@ const membershipRights = [
     name: '筑基专属包房券',
     description: '非高峰时段私人包房 1 小时，需提前预约',
     applyReservation: true,
-    applySlots: ['day', 'night', 'late'],
+    applyTimeRanges: [
+      { start: '12:00', end: '24:00' },
+      { start: '00:00', end: '06:00' }
+    ],
     validDays: 120
   },
   {
@@ -440,7 +443,7 @@ const membershipRights = [
     name: '日间包房体验券',
     description: '免费预订一次日间非高峰包房',
     applyReservation: true,
-    applySlots: ['day'],
+    applyTimeRanges: [{ start: '12:00', end: '18:00' }],
     validDays: 90
   },
   {
@@ -448,7 +451,7 @@ const membershipRights = [
     name: '全天包房体验券',
     description: '免费预订一次全天任意时段包房',
     applyReservation: true,
-    applySlots: ['day', 'night', 'late'],
+    applyTimeRanges: [{ start: '00:00', end: '24:00' }],
     validDays: 120
   },
   {
@@ -535,42 +538,14 @@ function buildMembershipLevels() {
 
 const rooms = [
   {
-    _id: 'room_a',
-    name: '玉竹雅间',
-    capacity: 6,
-    facilities: ['环绕音响', '智能灯光', '小食吧'],
+    _id: 'room_jyzq10',
+    name: '酒隐之茄10人包',
+    capacity: 10,
+    facilities: ['顶级音响', 'LED大屏', '净烟卫士', '豪华沙发'],
     pricing: {
-      day: 68000,
-      night: 98000,
-      late: 78000
+      fixed: 0
     },
     priority: 1,
-    status: 'online'
-  },
-  {
-    _id: 'room_b',
-    name: '紫霄天境',
-    capacity: 10,
-    facilities: ['豪华沙发', '私人调酒', '舞台灯光'],
-    pricing: {
-      day: 98000,
-      night: 158000,
-      late: 118000
-    },
-    priority: 2,
-    status: 'online'
-  },
-  {
-    _id: 'room_c',
-    name: '云梦仙台',
-    capacity: 20,
-    facilities: ['LED 大屏', '舞台', '专业调音台'],
-    pricing: {
-      day: 158000,
-      night: 238000,
-      late: 188000
-    },
-    priority: 3,
     status: 'online'
   }
 ];

--- a/cloudfunctions/reservation/index.js
+++ b/cloudfunctions/reservation/index.js
@@ -18,7 +18,7 @@ exports.main = async (event, context) => {
 
   switch (action) {
     case 'availableRooms':
-      return listAvailableRooms(OPENID, event.date, event.slot);
+      return listAvailableRooms(OPENID, event.date, event.startTime, event.endTime);
     case 'create':
       return createReservation(OPENID, event.order || {});
     case 'cancel':
@@ -28,10 +28,15 @@ exports.main = async (event, context) => {
   }
 };
 
-async function listAvailableRooms(openid, date, slot) {
-  if (!date || !slot) {
-    throw new Error('请提供预约日期与时段');
+async function listAvailableRooms(openid, date, startTime, endTime) {
+  if (!date || !startTime || !endTime) {
+    throw new Error('请提供预约日期与时间');
   }
+  const requestRange = normalizeTimeRange(startTime, endTime);
+  if (!requestRange) {
+    throw new Error('预约时间不正确');
+  }
+
   const [roomsSnapshot, reservationsSnapshot, rightsSnapshot, rightsMaster] = await Promise.all([
     db.collection(COLLECTIONS.ROOMS)
       .where({ status: 'online' })
@@ -40,7 +45,6 @@ async function listAvailableRooms(openid, date, slot) {
     db.collection(COLLECTIONS.RESERVATIONS)
       .where({
         date,
-        slot,
         status: _.in(['pendingPayment', 'reserved', 'confirmed'])
       })
       .get(),
@@ -50,7 +54,12 @@ async function listAvailableRooms(openid, date, slot) {
     db.collection(COLLECTIONS.MEMBERSHIP_RIGHTS).get()
   ]);
 
-  const reservedRoomIds = new Set(reservationsSnapshot.data.map((item) => item.roomId));
+  const reservedRoomIds = new Set(
+    reservationsSnapshot.data
+      .map((reservation) => ({ reservation, range: normalizeReservationRange(reservation) }))
+      .filter(({ range }) => range && isTimeRangeOverlap(range, requestRange))
+      .map(({ reservation }) => reservation.roomId)
+  );
   const now = Date.now();
   const masterMap = {};
   rightsMaster.data.forEach((item) => {
@@ -63,13 +72,13 @@ async function listAvailableRooms(openid, date, slot) {
 
   return {
     rooms: roomsSnapshot.data.map((room) => {
-      const right = validRights.find((r) => canRightApply(masterMap[r.rightId], slot));
+      const right = validRights.find((r) => canRightApply(masterMap[r.rightId], requestRange));
       return {
         _id: room._id,
         name: room.name,
         capacity: room.capacity,
         facilities: (room.facilities || []).join('、'),
-        price: resolvePrice(room, slot),
+        price: resolvePrice(room, requestRange),
         isFree: Boolean(right),
         images: room.images || []
       };
@@ -78,9 +87,13 @@ async function listAvailableRooms(openid, date, slot) {
 }
 
 async function createReservation(openid, order) {
-  const { roomId, date, slot, rightId } = order;
-  if (!roomId || !date || !slot) {
+  const { roomId, date, startTime, endTime, rightId } = order;
+  if (!roomId || !date || !startTime || !endTime) {
     throw new Error('预约信息不完整');
+  }
+  const requestRange = normalizeTimeRange(startTime, endTime);
+  if (!requestRange) {
+    throw new Error('预约时间不正确');
   }
   const roomDoc = await db.collection(COLLECTIONS.ROOMS).doc(roomId).get().catch(() => null);
   if (!roomDoc || !roomDoc.data) {
@@ -88,21 +101,26 @@ async function createReservation(openid, order) {
   }
 
   const reservationResult = await db.runTransaction(async (transaction) => {
-    const existing = await transaction
+    const existingReservations = await transaction
       .collection(COLLECTIONS.RESERVATIONS)
       .where({
         roomId,
         date,
-        slot,
         status: _.in(['pendingPayment', 'reserved', 'confirmed'])
       })
-      .count();
-    if (existing.total > 0) {
+      .get();
+
+    const hasConflict = existingReservations.data.some((reservation) => {
+      const range = normalizeReservationRange(reservation);
+      if (!range) return false;
+      return isTimeRangeOverlap(range, requestRange);
+    });
+    if (hasConflict) {
       throw new Error('当前时段已被预约');
     }
 
     let appliedRight = null;
-    let price = resolvePrice(roomDoc.data, slot);
+    let price = resolvePrice(roomDoc.data, requestRange);
     if (rightId) {
       const rightDoc = await transaction
         .collection(COLLECTIONS.MEMBER_RIGHTS)
@@ -121,7 +139,7 @@ async function createReservation(openid, order) {
         .doc(right.rightId)
         .get()
         .catch(() => null);
-      if (!masterDoc || !masterDoc.data || !canRightApply(masterDoc.data, slot)) {
+      if (!masterDoc || !masterDoc.data || !canRightApply(masterDoc.data, requestRange)) {
         throw new Error('权益不适用于当前时段');
       }
       appliedRight = rightDoc;
@@ -132,7 +150,8 @@ async function createReservation(openid, order) {
       memberId: openid,
       roomId,
       date,
-      slot,
+      startTime: requestRange.startLabel,
+      endTime: requestRange.endLabel,
       price,
       rightId: appliedRight ? appliedRight.data._id : null,
       status: price === 0 ? 'reserved' : 'pendingPayment',
@@ -196,16 +215,112 @@ async function cancelReservation(openid, reservationId) {
   return { success: true, message: '预约已取消' };
 }
 
-function resolvePrice(room, slot) {
+function resolvePrice(room, range) {
   if (!room || !room.pricing) return 0;
-  const price = room.pricing[slot];
-  return typeof price === 'number' ? price : 0;
+  const pricing = room.pricing;
+  if (typeof pricing.fixed === 'number') {
+    return pricing.fixed;
+  }
+  if (typeof pricing.hourly === 'number') {
+    const hours = Math.max(1, Math.ceil((range.end - range.start) / 60));
+    return pricing.hourly * hours;
+  }
+  return 0;
 }
 
-function canRightApply(right, slot) {
+function canRightApply(right, range) {
   if (!right) return false;
   if (!right.applyReservation) return false;
-  const slots = right.applySlots || [];
-  if (!slots.length) return true;
-  return slots.includes(slot);
+  const ranges = normalizeRightTimeRanges(right);
+  if (!ranges.length) return true;
+  return ranges.some((candidate) => candidate.start <= range.start && candidate.end >= range.end);
+}
+
+function normalizeTimeRange(startTime, endTime) {
+  const start = timeToMinutes(startTime);
+  const end = timeToMinutes(endTime);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) {
+    return null;
+  }
+  if (start >= end) {
+    return null;
+  }
+  return {
+    start,
+    end,
+    startLabel: formatTimeLabel(start),
+    endLabel: formatTimeLabel(end)
+  };
+}
+
+function normalizeRightTimeRanges(right) {
+  if (!right) return [];
+  if (Array.isArray(right.applyTimeRanges) && right.applyTimeRanges.length) {
+    return right.applyTimeRanges
+      .map((item) => normalizeTimeRange(item.startTime || item.start || '', item.endTime || item.end || ''))
+      .filter(Boolean);
+  }
+  if (Array.isArray(right.applySlots) && right.applySlots.length) {
+    const slotRanges = {
+      day: normalizeTimeRange('12:00', '18:00'),
+      night: normalizeTimeRange('18:00', '24:00'),
+      late: normalizeTimeRange('00:00', '06:00')
+    };
+    return right.applySlots
+      .map((slot) => slotRanges[slot])
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function normalizeReservationRange(reservation) {
+  if (!reservation) return null;
+  const range = normalizeTimeRange(reservation.startTime, reservation.endTime);
+  if (range) {
+    return range;
+  }
+  if (reservation.slot) {
+    const slotRanges = {
+      day: normalizeTimeRange('12:00', '18:00'),
+      night: normalizeTimeRange('18:00', '24:00'),
+      late: normalizeTimeRange('00:00', '06:00')
+    };
+    return slotRanges[reservation.slot] || null;
+  }
+  return null;
+}
+
+function isTimeRangeOverlap(a, b) {
+  if (!a || !b) return false;
+  return a.start < b.end && b.start < a.end;
+}
+
+function timeToMinutes(value) {
+  if (typeof value !== 'string') return NaN;
+  const [hourStr, minuteStr] = value.split(':');
+  if (typeof hourStr === 'undefined' || typeof minuteStr === 'undefined') {
+    return NaN;
+  }
+  const hours = Number(hourStr);
+  const minutes = Number(minuteStr);
+  if (!Number.isInteger(hours) || !Number.isInteger(minutes)) {
+    return NaN;
+  }
+  if (hours < 0 || hours > 24) {
+    return NaN;
+  }
+  if (minutes < 0 || minutes > 59) {
+    return NaN;
+  }
+  if (hours === 24 && minutes !== 0) {
+    return NaN;
+  }
+  return hours * 60 + minutes;
+}
+
+function formatTimeLabel(totalMinutes) {
+  const minutes = Math.max(0, Math.min(24 * 60, totalMinutes));
+  const hoursPart = Math.floor(minutes / 60);
+  const minutesPart = minutes % 60;
+  return `${String(hoursPart).padStart(2, '0')}:${String(minutesPart).padStart(2, '0')}`;
 }

--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -11,6 +11,7 @@
     "pages/wallet/wallet",
     "pages/avatar/avatar",
     "pages/admin/index",
+    "pages/admin/reservations/index",
     "pages/admin/members/index",
     "pages/admin/member-detail/index",
     "pages/admin/charge/index",

--- a/miniprogram/pages/admin/index.js
+++ b/miniprogram/pages/admin/index.js
@@ -18,6 +18,12 @@ Page({
         label: '订单查询',
         description: '按会员查看扣费订单记录',
         url: '/pages/admin/orders/index'
+      },
+      {
+        icon: '🏠',
+        label: '预约审核',
+        description: '查看并审核包房预约申请',
+        url: '/pages/admin/reservations/index'
       }
     ]
   },

--- a/miniprogram/pages/admin/member-detail/index.js
+++ b/miniprogram/pages/admin/member-detail/index.js
@@ -80,7 +80,8 @@ Page({
       stoneBalance: '',
       levelId: '',
       roles: [],
-      renameCredits: ''
+      renameCredits: '',
+      roomUsageCount: ''
     },
     rechargeVisible: false,
     rechargeAmount: '',
@@ -135,22 +136,23 @@ Page({
       ...option,
       checked: roles.includes(option.value)
     }));
-    this.setData({
-      member,
-      levels,
-      levelIndex,
-      currentLevelName: currentLevel.name || '',
-      loading: false,
-      form: {
-        nickName: member.nickName || '',
-        mobile: member.mobile || '',
-        experience: String(member.experience ?? 0),
-        cashBalance: this.formatYuan(member.cashBalance ?? member.balance ?? 0),
-        stoneBalance: String(member.stoneBalance ?? 0),
-        levelId: member.levelId || currentLevel._id || '',
-        roles,
-        renameCredits: String(member.renameCredits ?? 0)
-      },
+      this.setData({
+        member,
+        levels,
+        levelIndex,
+        currentLevelName: currentLevel.name || '',
+        loading: false,
+        form: {
+          nickName: member.nickName || '',
+          mobile: member.mobile || '',
+          experience: String(member.experience ?? 0),
+          cashBalance: this.formatYuan(member.cashBalance ?? member.balance ?? 0),
+          stoneBalance: String(member.stoneBalance ?? 0),
+          levelId: member.levelId || currentLevel._id || '',
+          roles,
+          renameCredits: String(member.renameCredits ?? 0),
+          roomUsageCount: String(member.roomUsageCount ?? 0)
+        },
       roleOptions,
       renameHistory: formatRenameHistory(member.renameHistory)
     });
@@ -197,7 +199,8 @@ Page({
         stoneBalance: Number(this.data.form.stoneBalance || 0),
         levelId: this.data.form.levelId,
         roles: ensureMemberRole(this.data.form.roles),
-        renameCredits: this.parseRenameCredits(this.data.form.renameCredits)
+        renameCredits: this.parseRenameCredits(this.data.form.renameCredits),
+        roomUsageCount: Number(this.data.form.roomUsageCount || 0)
       };
       const detail = await AdminService.updateMember(this.data.memberId, payload);
       this.applyDetail(detail);

--- a/miniprogram/pages/admin/member-detail/index.wxml
+++ b/miniprogram/pages/admin/member-detail/index.wxml
@@ -45,6 +45,17 @@
     <view class="rename-meta">
       <text>已使用改名次数：{{member.renameUsed || 0}}</text>
     </view>
+    <view class="form-item">
+      <view class="form-label">包房使用次数</view>
+      <input
+        class="form-input"
+        type="number"
+        value="{{form.roomUsageCount}}"
+        placeholder="请输入剩余包房使用次数"
+        data-field="roomUsageCount"
+        bindinput="handleInputChange"
+      />
+    </view>
     <view wx:if="{{renameHistory.length}}" class="rename-history">
       <view class="rename-history__title">改名记录</view>
       <view class="rename-history__item" wx:for="{{renameHistory}}" wx:key="id">

--- a/miniprogram/pages/admin/reservations/index.js
+++ b/miniprogram/pages/admin/reservations/index.js
@@ -1,0 +1,141 @@
+import { AdminService } from '../../../services/api';
+
+const STATUS_OPTIONS = [
+  { value: 'pendingApproval', label: '待审核' },
+  { value: 'approved', label: '已通过' },
+  { value: 'rejected', label: '已拒绝' },
+  { value: 'cancelled', label: '已取消' },
+  { value: 'all', label: '全部' }
+];
+
+Page({
+  data: {
+    loading: true,
+    reservations: [],
+    statusOptions: STATUS_OPTIONS,
+    statusIndex: 0,
+    page: 1,
+    pageSize: 20,
+    total: 0,
+    finished: false,
+    error: '',
+    processingId: '',
+    processingType: '',
+    currentStatusLabel: STATUS_OPTIONS[0].label
+  },
+
+  onShow() {
+    this.fetchReservations(true);
+  },
+
+  onPullDownRefresh() {
+    this.fetchReservations(true)
+      .catch(() => {})
+      .finally(() => {
+        wx.stopPullDownRefresh();
+      });
+  },
+
+  onReachBottom() {
+    if (this.data.loading || this.data.finished) {
+      return;
+    }
+    this.fetchReservations();
+  },
+
+  handleStatusChange(event) {
+    const index = Number(event.detail.value);
+    if (Number.isNaN(index)) {
+      return;
+    }
+    this.setData({ statusIndex: index }, () => {
+      this.fetchReservations(true);
+    });
+  },
+
+  async fetchReservations(reset = false) {
+    const nextPage = reset ? 1 : this.data.page;
+    const statusOption = this.data.statusOptions[this.data.statusIndex] || STATUS_OPTIONS[0];
+    this.setData({
+      loading: true,
+      error: '',
+      currentStatusLabel: statusOption ? statusOption.label : STATUS_OPTIONS[0].label
+    });
+    try {
+      const response = await AdminService.listReservations({
+        status: statusOption ? statusOption.value : 'pendingApproval',
+        page: nextPage,
+        pageSize: this.data.pageSize
+      });
+      const items = response.reservations || [];
+      const merged = reset ? items : [...this.data.reservations, ...items];
+      const total = response.total || merged.length;
+      const finished = merged.length >= total || items.length < this.data.pageSize;
+      this.setData({
+        reservations: merged,
+        total,
+        page: nextPage + 1,
+        finished,
+        loading: false
+      });
+    } catch (error) {
+      console.error('[admin:reservations] fetch failed', error);
+      this.setData({
+        loading: false,
+        error: error.errMsg || error.message || '加载失败'
+      });
+      wx.showToast({ title: '加载失败，请稍后重试', icon: 'none' });
+    }
+  },
+
+  async handleApprove(event) {
+    const { id } = event.currentTarget.dataset;
+    if (!id || this.data.processingId) {
+      return;
+    }
+    this.setData({ processingId: id, processingType: 'approve' });
+    try {
+      await AdminService.approveReservation(id);
+      wx.showToast({ title: '已通过', icon: 'success' });
+      this.fetchReservations(true);
+    } catch (error) {
+      console.error('[admin:reservations] approve failed', error);
+      wx.showToast({ title: error.errMsg || error.message || '操作失败', icon: 'none' });
+    } finally {
+      this.setData({ processingId: '', processingType: '' });
+    }
+  },
+
+  handleReject(event) {
+    const { id } = event.currentTarget.dataset;
+    if (!id || this.data.processingId) {
+      return;
+    }
+    wx.showModal({
+      title: '拒绝预约',
+      content: '确认拒绝该预约申请？',
+      confirmText: '拒绝',
+      cancelText: '取消',
+      success: (res) => {
+        if (!res.confirm) {
+          return;
+        }
+        this.submitRejection(id);
+      }
+    });
+  },
+
+  async submitRejection(reservationId) {
+    this.setData({ processingId: reservationId, processingType: 'reject' });
+    try {
+      await AdminService.rejectReservation(reservationId, '房间已被其他会员锁定');
+      wx.showToast({ title: '已拒绝', icon: 'success' });
+      this.fetchReservations(true);
+    } catch (error) {
+      console.error('[admin:reservations] reject failed', error);
+      wx.showToast({ title: error.errMsg || error.message || '操作失败', icon: 'none' });
+    } finally {
+      this.setData({ processingId: '', processingType: '' });
+    }
+  }
+});

--- a/miniprogram/pages/admin/reservations/index.json
+++ b/miniprogram/pages/admin/reservations/index.json
@@ -1,0 +1,6 @@
+{
+  "navigationBarTitleText": "包房预约审核",
+  "usingComponents": {
+    "custom-nav": "/components/custom-nav/custom-nav"
+  }
+}

--- a/miniprogram/pages/admin/reservations/index.wxml
+++ b/miniprogram/pages/admin/reservations/index.wxml
@@ -1,0 +1,53 @@
+<custom-nav title="包房预约审核" theme="dark"></custom-nav>
+<view class="container">
+  <view class="card filter-card">
+    <view class="filter-label">筛选状态</view>
+    <picker
+      mode="selector"
+      range="{{statusOptions}}"
+      range-key="label"
+      value="{{statusIndex}}"
+      bindchange="handleStatusChange"
+    >
+      <view class="picker">当前：{{currentStatusLabel}}</view>
+    </picker>
+  </view>
+
+  <view wx:if="{{loading && !reservations.length}}" class="card">正在加载预约...</view>
+  <view wx:if="{{!loading && !reservations.length}}" class="card empty">暂无预约申请</view>
+
+  <view class="card" wx:for="{{reservations}}" wx:key="_id">
+    <view class="item-header">
+      <view class="room">{{item.roomName || '包房'}}</view>
+      <view class="status {{item.status}}">{{item.statusLabel}}</view>
+    </view>
+    <view class="item-time">{{item.date}} {{item.startTime}} - {{item.endTime}}</view>
+    <view class="item-member">
+      申请人：{{item.memberName || item.memberId}}
+      <text wx:if="{{item.memberMobile}}"> · {{item.memberMobile}}</text>
+    </view>
+    <view class="item-meta" wx:if="{{item.usageCredits}}">占用使用次数：{{item.usageCredits}}</view>
+    <view class="item-meta" wx:if="{{item.approval && item.approval.reason}}">审核备注：{{item.approval.reason}}</view>
+    <view class="item-actions" wx:if="{{item.status === 'pendingApproval'}}">
+      <button
+        size="mini"
+        type="warn"
+        loading="{{processingId === item._id && processingType === 'reject'}}"
+        disabled="{{!!processingId && processingId !== item._id}}"
+        data-id="{{item._id}}"
+        bindtap="handleReject"
+      >拒绝</button>
+      <button
+        size="mini"
+        type="primary"
+        loading="{{processingId === item._id && processingType === 'approve'}}"
+        disabled="{{!!processingId && processingId !== item._id}}"
+        data-id="{{item._id}}"
+        bindtap="handleApprove"
+      >通过</button>
+    </view>
+  </view>
+
+  <view wx:if="{{loading && reservations.length}}" class="loading">加载中...</view>
+  <view wx:if="{{finished && reservations.length}}" class="finished">没有更多记录了</view>
+</view>

--- a/miniprogram/pages/admin/reservations/index.wxss
+++ b/miniprogram/pages/admin/reservations/index.wxss
@@ -1,0 +1,86 @@
+.filter-card {
+  margin-bottom: 20rpx;
+}
+
+.filter-label {
+  font-size: 26rpx;
+  color: rgba(211, 220, 255, 0.8);
+  margin-bottom: 12rpx;
+}
+
+.picker {
+  background: rgba(14, 24, 60, 0.88);
+  padding: 16rpx 24rpx;
+  border-radius: 12rpx;
+  border: 1rpx solid rgba(122, 142, 232, 0.32);
+  color: #e6ecff;
+}
+
+.card.empty {
+  text-align: center;
+  color: rgba(198, 206, 255, 0.6);
+}
+
+.item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.room {
+  font-size: 30rpx;
+  font-weight: 600;
+  color: #f5f8ff;
+}
+
+.status {
+  font-size: 24rpx;
+  padding: 6rpx 16rpx;
+  border-radius: 16rpx;
+  background: rgba(40, 58, 120, 0.6);
+  color: #d6deff;
+  border: 1rpx solid rgba(116, 136, 226, 0.4);
+}
+
+.status.pendingApproval {
+  background: rgba(128, 146, 255, 0.24);
+  color: #dfe4ff;
+}
+
+.status.approved {
+  background: rgba(96, 196, 150, 0.24);
+  color: #c7f3df;
+}
+
+.status.rejected {
+  background: rgba(216, 116, 116, 0.24);
+  color: #ffd2d2;
+}
+
+.status.cancelled {
+  background: rgba(140, 140, 140, 0.24);
+  color: #cccccc;
+}
+
+.item-time,
+.item-member,
+.item-meta {
+  margin-top: 12rpx;
+  font-size: 24rpx;
+  color: rgba(204, 214, 255, 0.75);
+}
+
+.item-actions {
+  margin-top: 20rpx;
+  display: flex;
+  justify-content: flex-end;
+  gap: 16rpx;
+}
+
+.loading,
+.finished {
+  text-align: center;
+  color: rgba(198, 206, 255, 0.6);
+  margin-top: 24rpx;
+  font-size: 24rpx;
+}

--- a/miniprogram/pages/reservation/reservation.js
+++ b/miniprogram/pages/reservation/reservation.js
@@ -26,7 +26,10 @@ Page({
     endTime: DEFAULT_END_TIME,
     rooms: [],
     rightId: null,
-    timeError: ''
+    timeError: '',
+    notice: null,
+    noticeDismissed: false,
+    memberUsageCount: 0
   },
 
   onLoad(options) {
@@ -48,7 +51,13 @@ Page({
     this.setData({ loading: true, timeError: '' });
     try {
       const result = await ReservationService.listRooms(date, startTime, endTime);
-      this.setData({ rooms: result.rooms || [], loading: false });
+      this.setData({
+        rooms: result.rooms || [],
+        loading: false,
+        notice: result.notice || null,
+        noticeDismissed: false,
+        memberUsageCount: Math.max(0, Number(result.memberUsageCount || 0))
+      });
     } catch (error) {
       this.setData({ loading: false });
     }
@@ -94,6 +103,10 @@ Page({
       wx.showToast({ title: this.data.timeError || '预约时间不正确', icon: 'none' });
       return;
     }
+    if (this.data.memberUsageCount <= 0) {
+      wx.showToast({ title: '包房使用次数不足', icon: 'none' });
+      return;
+    }
     this.setData({ submitting: true });
     try {
       const payload = {
@@ -113,6 +126,10 @@ Page({
     } finally {
       this.setData({ submitting: false });
     }
+  },
+
+  dismissNotice() {
+    this.setData({ noticeDismissed: true });
   },
 
   formatCurrency

--- a/miniprogram/pages/reservation/reservation.js
+++ b/miniprogram/pages/reservation/reservation.js
@@ -1,21 +1,32 @@
 import { ReservationService } from '../../services/api';
 import { formatDate, formatCurrency } from '../../utils/format';
 
-const slots = [
-  { label: '日间（12:00-18:00）', value: 'day' },
-  { label: '夜间（18:00-24:00）', value: 'night' },
-  { label: '通宵（24:00-06:00）', value: 'late' }
-];
+const DEFAULT_START_TIME = '12:00';
+const DEFAULT_END_TIME = '14:00';
+
+function timeToMinutes(time) {
+  if (!time || typeof time !== 'string') return NaN;
+  const [hourStr = '', minuteStr = ''] = time.split(':');
+  const hours = Number(hourStr);
+  const minutes = Number(minuteStr);
+  if (!Number.isInteger(hours) || !Number.isInteger(minutes)) return NaN;
+  if (hours < 0 || hours > 24) return NaN;
+  if (minutes < 0 || minutes > 59) return NaN;
+  const total = hours * 60 + minutes;
+  if (hours === 24 && minutes !== 0) return NaN;
+  return total;
+}
 
 Page({
   data: {
     loading: true,
     submitting: false,
     date: formatDate(new Date()),
-    slotIndex: 0,
-    slots,
+    startTime: DEFAULT_START_TIME,
+    endTime: DEFAULT_END_TIME,
     rooms: [],
-    rightId: null
+    rightId: null,
+    timeError: ''
   },
 
   onLoad(options) {
@@ -29,10 +40,14 @@ Page({
   },
 
   async fetchRooms() {
-    const { date, slotIndex } = this.data;
-    this.setData({ loading: true });
+    const { date, startTime, endTime } = this.data;
+    if (!this.ensureValidTimeRange(startTime, endTime)) {
+      this.setData({ rooms: [], loading: false });
+      return;
+    }
+    this.setData({ loading: true, timeError: '' });
     try {
-      const result = await ReservationService.listRooms(date, slots[slotIndex].value);
+      const result = await ReservationService.listRooms(date, startTime, endTime);
       this.setData({ rooms: result.rooms || [], loading: false });
     } catch (error) {
       this.setData({ loading: false });
@@ -45,21 +60,47 @@ Page({
     });
   },
 
-  handleSlotChange(event) {
-    this.setData({ slotIndex: Number(event.detail.value) }, () => {
+  handleStartTimeChange(event) {
+    this.setData({ startTime: event.detail.value }, () => {
       this.fetchRooms();
     });
+  },
+
+  handleEndTimeChange(event) {
+    this.setData({ endTime: event.detail.value }, () => {
+      this.fetchRooms();
+    });
+  },
+
+  ensureValidTimeRange(start, end) {
+    const startMinutes = timeToMinutes(start);
+    const endMinutes = timeToMinutes(end);
+    if (!Number.isFinite(startMinutes) || !Number.isFinite(endMinutes)) {
+      this.setData({ timeError: '请选择有效的预约时间' });
+      return false;
+    }
+    if (startMinutes >= endMinutes) {
+      this.setData({ timeError: '结束时间需晚于开始时间' });
+      return false;
+    }
+    this.setData({ timeError: '' });
+    return true;
   },
 
   async handleReserve(event) {
     const room = event.currentTarget.dataset.room;
     if (!room) return;
+    if (!this.ensureValidTimeRange(this.data.startTime, this.data.endTime)) {
+      wx.showToast({ title: this.data.timeError || '预约时间不正确', icon: 'none' });
+      return;
+    }
     this.setData({ submitting: true });
     try {
       const payload = {
         roomId: room._id,
         date: this.data.date,
-        slot: slots[this.data.slotIndex].value,
+        startTime: this.data.startTime,
+        endTime: this.data.endTime,
         rightId: this.data.rightId
       };
       const res = await ReservationService.create(payload);

--- a/miniprogram/pages/reservation/reservation.wxml
+++ b/miniprogram/pages/reservation/reservation.wxml
@@ -1,7 +1,20 @@
 <custom-nav title="预约包房" theme="dark"></custom-nav>
 <view class="container">
+  <view
+    wx:if="{{notice && (!notice.closable || !noticeDismissed)}}"
+    class="notice {{notice.type || 'info'}}"
+  >
+    <text class="notice-text">{{notice.message}}</text>
+    <button
+      wx:if="{{notice.closable}}"
+      size="mini"
+      class="notice-close"
+      bindtap="dismissNotice"
+    >知道了</button>
+  </view>
   <view class="card filter-card">
     <view class="section-title">选择日期与时间</view>
+    <view class="usage">剩余包房使用次数：{{memberUsageCount}}</view>
     <picker mode="date" value="{{date}}" bindchange="handleDateChange">
       <view class="picker">预约日期：{{date}}</view>
     </picker>

--- a/miniprogram/pages/reservation/reservation.wxml
+++ b/miniprogram/pages/reservation/reservation.wxml
@@ -1,13 +1,17 @@
 <custom-nav title="预约包房" theme="dark"></custom-nav>
 <view class="container">
   <view class="card filter-card">
-    <view class="section-title">选择日期与时段</view>
+    <view class="section-title">选择日期与时间</view>
     <picker mode="date" value="{{date}}" bindchange="handleDateChange">
       <view class="picker">预约日期：{{date}}</view>
     </picker>
-    <picker mode="selector" range="{{slots}}" range-key="label" value="{{slotIndex}}" bindchange="handleSlotChange">
-      <view class="picker">预约时段：{{slots[slotIndex].label}}</view>
+    <picker mode="time" value="{{startTime}}" start="00:00" end="23:59" bindchange="handleStartTimeChange">
+      <view class="picker">开始时间：{{startTime}}</view>
     </picker>
+    <picker mode="time" value="{{endTime}}" start="00:00" end="23:59" bindchange="handleEndTimeChange">
+      <view class="picker">结束时间：{{endTime}}</view>
+    </picker>
+    <view wx:if="{{timeError}}" class="time-error">{{timeError}}</view>
   </view>
 
   <view class="card">

--- a/miniprogram/pages/reservation/reservation.wxss
+++ b/miniprogram/pages/reservation/reservation.wxss
@@ -7,6 +7,12 @@
   color: #e7edff;
 }
 
+.time-error {
+  margin-top: 8rpx;
+  color: #ff9d8e;
+  font-size: 24rpx;
+}
+
 .room {
   display: flex;
   justify-content: space-between;

--- a/miniprogram/pages/reservation/reservation.wxss
+++ b/miniprogram/pages/reservation/reservation.wxss
@@ -1,3 +1,52 @@
+.notice {
+  margin-bottom: 20rpx;
+  padding: 20rpx 24rpx;
+  border-radius: 16rpx;
+  border: 1rpx solid rgba(114, 136, 220, 0.4);
+  background: rgba(14, 24, 60, 0.9);
+  color: #dce4ff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.notice.success {
+  border-color: rgba(102, 214, 158, 0.45);
+  background: rgba(20, 64, 54, 0.8);
+  color: #b5f7d3;
+}
+
+.notice.warning {
+  border-color: rgba(255, 196, 122, 0.45);
+  background: rgba(70, 50, 12, 0.8);
+  color: #ffe0b2;
+}
+
+.notice.info {
+  border-color: rgba(138, 160, 255, 0.45);
+  background: rgba(28, 38, 82, 0.85);
+  color: #dfe6ff;
+}
+
+.notice-text {
+  flex: 1;
+  font-size: 24rpx;
+  line-height: 1.5;
+  padding-right: 16rpx;
+}
+
+.notice-close {
+  background: rgba(118, 142, 255, 0.15);
+  color: #cfd8ff;
+  border: 1rpx solid rgba(138, 160, 255, 0.5);
+}
+
+.usage {
+  margin-bottom: 12rpx;
+  font-size: 24rpx;
+  color: rgba(198, 208, 255, 0.85);
+}
+
 .filter-card .picker {
   background: rgba(14, 24, 60, 0.88);
   padding: 20rpx 24rpx;

--- a/miniprogram/pages/rights/rights.js
+++ b/miniprogram/pages/rights/rights.js
@@ -1,11 +1,12 @@
-import { MemberService } from '../../services/api';
+import { MemberService, ReservationService } from '../../services/api';
 import { formatDate } from '../../utils/format';
 
 Page({
   data: {
     loading: true,
     rights: [],
-    member: null
+    member: null,
+    redeemingRightId: ''
   },
 
   onShow() {
@@ -22,10 +23,11 @@ Page({
       this.setData({
         loading: false,
         member,
-        rights: rights || []
+        rights: rights || [],
+        redeemingRightId: ''
       });
     } catch (error) {
-      this.setData({ loading: false });
+      this.setData({ loading: false, redeemingRightId: '' });
     }
   },
 
@@ -36,5 +38,23 @@ Page({
     wx.navigateTo({
       url: `/pages/reservation/reservation?rightId=${rightId}`
     });
+  },
+
+  async handleRedeemUsage(event) {
+    const { rightId } = event.currentTarget.dataset;
+    if (!rightId) return;
+    if (this.data.redeemingRightId) {
+      return;
+    }
+    this.setData({ redeemingRightId: rightId });
+    try {
+      await ReservationService.redeemUsageCoupon(rightId);
+      wx.showToast({ title: '已增加使用次数', icon: 'success' });
+      await this.fetchRights();
+    } catch (error) {
+      const message = (error && (error.errMsg || error.message)) || '兑换失败';
+      wx.showToast({ title: message, icon: 'none' });
+      this.setData({ redeemingRightId: '' });
+    }
   }
 });

--- a/miniprogram/pages/rights/rights.wxml
+++ b/miniprogram/pages/rights/rights.wxml
@@ -14,9 +14,29 @@
             <view class="status {{item.status}}">{{item.statusLabel}}</view>
           </view>
           <view class="right-desc">{{item.description}}</view>
+          <view wx:if="{{item.canRedeemRoomUsage}}" class="right-meta">
+            兑换后可增加 {{item.roomUsageCredits}} 次使用次数
+          </view>
           <view class="right-footer">
             <text>有效期：{{formatDate(item.validUntil) || '长期有效'}}</text>
-            <button wx:if="{{item.canReserve}}" size="mini" type="primary" data-right-id="{{item._id}}" bindtap="handleReserve">预约</button>
+            <view class="right-actions">
+              <button
+                wx:if="{{item.canRedeemRoomUsage}}"
+                size="mini"
+                class="secondary"
+                loading="{{redeemingRightId === item._id}}"
+                disabled="{{redeemingRightId && redeemingRightId !== item._id}}"
+                data-right-id="{{item._id}}"
+                bindtap="handleRedeemUsage"
+              >兑换次数</button>
+              <button
+                wx:if="{{item.canReserve}}"
+                size="mini"
+                type="primary"
+                data-right-id="{{item._id}}"
+                bindtap="handleReserve"
+              >预约</button>
+            </view>
           </view>
         </view>
       </view>

--- a/miniprogram/pages/rights/rights.wxss
+++ b/miniprogram/pages/rights/rights.wxss
@@ -53,6 +53,12 @@
   line-height: 1.6;
 }
 
+.right-meta {
+  margin-top: 8rpx;
+  font-size: 22rpx;
+  color: rgba(189, 207, 255, 0.6);
+}
+
 .right-footer {
   margin-top: 16rpx;
   display: flex;
@@ -60,4 +66,15 @@
   align-items: center;
   font-size: 24rpx;
   color: rgba(191, 203, 255, 0.7);
+}
+
+.right-actions {
+  display: flex;
+  gap: 16rpx;
+}
+
+.right-actions .secondary {
+  background: rgba(123, 145, 250, 0.18);
+  border: 1rpx solid rgba(138, 158, 255, 0.4);
+  color: #d5ddff;
 }

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -191,11 +191,12 @@ export const TaskService = {
 };
 
 export const ReservationService = {
-  async listRooms(date, slot) {
+  async listRooms(date, startTime, endTime) {
     return callCloud(CLOUD_FUNCTIONS.RESERVATION, {
       action: 'availableRooms',
       date,
-      slot
+      startTime,
+      endTime
     });
   },
   async create(order) {

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -210,6 +210,12 @@ export const ReservationService = {
       action: 'cancel',
       reservationId
     });
+  },
+  async redeemUsageCoupon(memberRightId) {
+    return callCloud(CLOUD_FUNCTIONS.RESERVATION, {
+      action: 'redeemUsageCoupon',
+      memberRightId
+    });
   }
 };
 
@@ -347,6 +353,27 @@ export const AdminService = {
       action: 'rechargeMember',
       memberId,
       amount
+    });
+  },
+  async listReservations({ status = 'pendingApproval', page = 1, pageSize = 20 } = {}) {
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, {
+      action: 'listReservations',
+      status,
+      page,
+      pageSize
+    });
+  },
+  async approveReservation(reservationId) {
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, {
+      action: 'approveReservation',
+      reservationId
+    });
+  },
+  async rejectReservation(reservationId, reason = '') {
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, {
+      action: 'rejectReservation',
+      reservationId,
+      reason
     });
   }
 };


### PR DESCRIPTION
## Summary
- allow members to choose explicit start/end times when reserving a room in the mini program, including validation feedback
- update reservation APIs and cloud function logic to work with time ranges and respect existing records/rights
- refresh bootstrap data with the single “酒隐之茄10人包” room and updated reservation right windows

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d999a3665c833090185ad5b81cf49f