### PR TITLE
Update home navigation for skill tab

### DIFF
--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -14,7 +14,7 @@ const app = getApp();
 const BASE_NAV_ITEMS = [
   { icon: '🧝', label: '角色', url: '/pages/role/index?tab=character' },
   { icon: '🛡️', label: '装备', url: '/pages/role/index?tab=equipment' },
-  { icon: '💳', label: '等级', url: '/pages/membership/membership' },
+  { icon: '📜', label: '技能', url: '/pages/role/index?tab=skill' },
   { icon: '🎁', label: '权益', url: '/pages/rights/rights' },
   { icon: '📅', label: '预订', url: '/pages/reservation/reservation' },
   { icon: '💰', label: '钱包', url: '/pages/wallet/wallet' },
@@ -575,6 +575,10 @@ Page({
 
   handleStoneTap() {
     wx.navigateTo({ url: '/pages/stones/stones' });
+  },
+
+  handleLevelTap() {
+    wx.navigateTo({ url: '/pages/membership/membership' });
   },
 
   handleExperienceTap() {

--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -16,8 +16,8 @@
         ></image>
         <view class="profile-info">
           <view class="profile-name" bindtap="handleProfileTap">{{member ? (member.nickName || '无名仙友') : '无名仙友'}}</view>
-          <view class="profile-level">境界：{{member ? (member.level ? member.level.name : '练气初期') : '练气初期'}}</view>
           <view class="profile-meta">
+            <text class="profile-meta__text" bindtap="handleLevelTap">境界 {{member ? (member.level ? member.level.name : '练气初期') : '练气初期'}}</text>
             <text class="profile-meta__text" bindtap="handleStoneTap">灵石 {{memberStats.stoneBalance}}</text>
             <text class="profile-meta__text" bindtap="handleExperienceTap">修为 {{memberStats.experience}}</text>
           </view>

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -102,15 +102,6 @@ page {
   text-overflow: ellipsis;
 }
 
-.profile-level {
-  margin-top: 8rpx;
-  font-size: 26rpx;
-  color: rgba(217, 225, 255, 0.9);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .profile-meta {
   margin-top: 12rpx;
   display: flex;

--- a/miniprogram/pages/role/index.js
+++ b/miniprogram/pages/role/index.js
@@ -62,6 +62,9 @@ Page({
     if (value === 'equipment' || value === 'equip' || value === 'bag') {
       return 'equipment';
     }
+    if (value === 'skill' || value === 'skills') {
+      return 'skill';
+    }
     return '';
   },
 

--- a/miniprogram/pages/role/index.wxml
+++ b/miniprogram/pages/role/index.wxml
@@ -1,4 +1,4 @@
-<custom-nav title="角色与装备" theme="dark"></custom-nav>
+<custom-nav title="角色养成" theme="dark"></custom-nav>
 <view class="page">
   <view class="tab-bar">
     <view
@@ -13,6 +13,12 @@
       hover-class="tab-item--hover"
       bindtap="handleTabChange"
     >装备</view>
+    <view
+      class="tab-item {{activeTab === 'skill' ? 'tab-item--active' : ''}}"
+      data-tab="skill"
+      hover-class="tab-item--hover"
+      bindtap="handleTabChange"
+    >技能</view>
   </view>
 
   <view wx:if="{{loading}}" class="loading">灵气汇聚中...</view>
@@ -94,7 +100,7 @@
       </view>
     </block>
 
-    <block wx:else>
+    <block wx:elif="{{activeTab === 'equipment'}}">
       <view class="section-card">
         <view class="section-header">
           <view class="section-title">装备总览</view>
@@ -152,7 +158,9 @@
           <view class="inventory-footer__label">灵石仓库</view>
         </view>
       </view>
+    </block>
 
+    <block wx:elif="{{activeTab === 'skill'}}">
       <view class="section-card">
         <view class="section-header">
           <view class="section-title">技能与抽卡</view>
@@ -226,6 +234,12 @@
       </view>
       <view class="empty-card" wx:if="{{!(profile.skillHistory && profile.skillHistory.length)}}">
         <text class="empty-tip">暂无技能动态</text>
+      </view>
+    </block>
+
+    <block wx:else>
+      <view class="empty-card">
+        <text class="empty-tip">请选择上方分类</text>
       </view>
     </block>
   </scroll-view>


### PR DESCRIPTION
## Summary
- make the realm display clickable and redirect to the level page while replacing the home bottom navigation level entry with a skill entry
- split the role screen into character, equipment, and skill tabs, moving the skill-related sections into the dedicated tab

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9beaae0008330a11c3ba2372b54ac