### PR TITLE
Ensure avatar displays use circular styling

### DIFF
--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -85,7 +85,8 @@ page {
 .profile-avatar {
   width: 120rpx;
   height: 120rpx;
-  border-radius: 32rpx;
+  border-radius: 50%;
+  overflow: hidden;
 }
 
 .profile-info {
@@ -502,29 +503,32 @@ page {
 
 .avatar-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 18rpx;
   margin: 18rpx 0;
+  justify-items: center;
 }
 
 .avatar-option {
   position: relative;
-  border-radius: 24rpx;
+  width: 160rpx;
+  height: 160rpx;
+  border-radius: 50%;
   overflow: hidden;
-  border: 2rpx solid transparent;
-  transition: transform 0.2s ease, border-color 0.2s ease;
+  border: 4rpx solid transparent;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .avatar-option--active {
   border-color: rgba(156, 178, 255, 0.85);
   transform: translateY(-4rpx);
-  box-shadow: 0 12rpx 28rpx rgba(46, 61, 160, 0.45), 0 0 0 4rpx rgba(156, 178, 255, 0.2);
+  box-shadow: 0 0 0 8rpx rgba(156, 178, 255, 0.2);
 }
 
 .avatar-option__image {
   width: 100%;
-  height: 160rpx;
-  border-radius: 24rpx;
+  height: 100%;
+  border-radius: 50%;
 }
 
 .archive-summary {
@@ -719,8 +723,9 @@ page {
 .authorization-avatar {
   width: 96rpx;
   height: 96rpx;
-  border-radius: 24rpx;
+  border-radius: 50%;
   border: 1rpx solid rgba(147, 168, 255, 0.55);
+  overflow: hidden;
 }
 
 .authorization-input {


### PR DESCRIPTION
## Summary
- update profile avatar styling so all profile images render within circular frames
- adjust avatar picker layout and active highlight to maintain circular selection visuals
- ensure authorization preview avatar uses the same rounded presentation

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9c1ff0c4483308cc36648eb52aa8b