### PR TITLE
Add avatar frame selection and overlay

### DIFF
--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -8,12 +8,19 @@
   <view class="content" wx:if="{{!loading}}" style="min-height: calc(100vh - {{navHeight}}px);">
     <view class="top-bar">
       <view class="profile-card">
-        <image
-          class="profile-avatar"
-          src="{{(member && member.avatarUrl) ? member.avatarUrl : defaultAvatar}}"
-          mode="cover"
-          bindtap="handleAvatarTap"
-        ></image>
+        <view class="profile-avatar-wrapper" bindtap="handleAvatarTap">
+          <image
+            class="profile-avatar"
+            src="{{(member && member.avatarUrl) ? member.avatarUrl : defaultAvatar}}"
+            mode="cover"
+          ></image>
+          <image
+            wx:if="{{member && member.avatarFrame}}"
+            class="profile-avatar-frame"
+            src="{{member.avatarFrame}}"
+            mode="scaleToFill"
+          ></image>
+        </view>
         <view class="profile-info">
           <view class="profile-name" bindtap="handleProfileTap">{{member ? (member.nickName || '无名仙友') : '无名仙友'}}</view>
           <view class="profile-meta">
@@ -188,6 +195,36 @@
               bindtap="handleAvatarPickerSelect"
             >
               <image class="avatar-option__image" src="{{item.url}}" mode="aspectFill"></image>
+            </view>
+          </view>
+          <view class="avatar-frame-section">
+            <view class="archive-section__header">
+              <view class="archive-section__title">可选相框</view>
+            </view>
+            <view class="avatar-frame-grid">
+              <view
+                class="avatar-frame-option {{avatarPicker.avatarFrame === item.url ? 'avatar-frame-option--active' : ''}}"
+                wx:for="{{avatarPicker.frameOptions}}"
+                wx:key="id"
+                data-url="{{item.url}}"
+                bindtap="handleAvatarFrameSelect"
+              >
+                <view class="avatar-frame-option__preview">
+                  <image
+                    class="avatar-frame-option__avatar"
+                    src="{{avatarPicker.avatarUrl || defaultAvatar}}"
+                    mode="cover"
+                  ></image>
+                  <image
+                    wx:if="{{item.url}}"
+                    class="avatar-frame-option__frame"
+                    src="{{item.url}}"
+                    mode="scaleToFill"
+                  ></image>
+                  <view wx:if="{{!item.url}}" class="avatar-frame-option__placeholder">无相框</view>
+                </view>
+                <view class="avatar-frame-option__label">{{item.name}}</view>
+              </view>
             </view>
           </view>
           <button class="archive-action" size="mini" bindtap="handleAvatarPickerSyncWechat">同步微信头像</button>

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -82,11 +82,27 @@ page {
   border-radius: 32rpx;
 }
 
-.profile-avatar {
+.profile-avatar-wrapper {
+  position: relative;
   width: 120rpx;
   height: 120rpx;
+}
+
+.profile-avatar {
+  width: 100%;
+  height: 100%;
   border-radius: 50%;
   overflow: hidden;
+  display: block;
+}
+
+.profile-avatar-frame {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
 }
 
 .profile-info {
@@ -529,6 +545,75 @@ page {
   width: 100%;
   height: 100%;
   border-radius: 50%;
+}
+
+.avatar-frame-section {
+  margin-top: 24rpx;
+}
+
+.avatar-frame-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18rpx;
+  margin: 18rpx 0;
+  justify-items: center;
+}
+
+.avatar-frame-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12rpx;
+}
+
+.avatar-frame-option__preview {
+  position: relative;
+  width: 160rpx;
+  height: 160rpx;
+  border-radius: 50%;
+  background: rgba(30, 42, 102, 0.6);
+  border: 4rpx solid transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.avatar-frame-option--active .avatar-frame-option__preview {
+  border-color: rgba(156, 178, 255, 0.85);
+  transform: translateY(-4rpx);
+  box-shadow: 0 0 0 8rpx rgba(156, 178, 255, 0.2);
+}
+
+.avatar-frame-option__avatar {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+}
+
+.avatar-frame-option__frame {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.avatar-frame-option__placeholder {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: rgba(220, 228, 255, 0.82);
+  font-size: 24rpx;
+  letter-spacing: 2rpx;
+  pointer-events: none;
+}
+
+.avatar-frame-option__label {
+  font-size: 24rpx;
+  color: rgba(214, 224, 255, 0.82);
 }
 
 .archive-summary {

--- a/miniprogram/shared/avatar-frames.js
+++ b/miniprogram/shared/avatar-frames.js
@@ -1,0 +1,61 @@
+const AVATAR_FRAME_BASE_PATH = '/assets/border';
+const AVATAR_FRAME_IDS = ['1', '2', '3'];
+
+const AVATAR_FRAME_URLS = AVATAR_FRAME_IDS.map((id) => `${AVATAR_FRAME_BASE_PATH}/${id}.png`);
+
+function listAvatarFrameUrls() {
+  return AVATAR_FRAME_URLS.slice();
+}
+
+function buildAvatarFrameUrlById(id) {
+  if (typeof id !== 'string') {
+    return '';
+  }
+  const trimmed = id.trim();
+  if (!trimmed) {
+    return '';
+  }
+  if (!AVATAR_FRAME_IDS.includes(trimmed)) {
+    return '';
+  }
+  return `${AVATAR_FRAME_BASE_PATH}/${trimmed}.png`;
+}
+
+function isValidAvatarFrameUrl(url) {
+  if (typeof url !== 'string') {
+    return false;
+  }
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return false;
+  }
+  return AVATAR_FRAME_URLS.includes(trimmed);
+}
+
+function normalizeAvatarFrameValue(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+  if (AVATAR_FRAME_URLS.includes(trimmed)) {
+    return trimmed;
+  }
+  const byId = buildAvatarFrameUrlById(trimmed);
+  if (byId) {
+    return byId;
+  }
+  return '';
+}
+
+module.exports = {
+  AVATAR_FRAME_BASE_PATH,
+  AVATAR_FRAME_IDS,
+  AVATAR_FRAME_URLS,
+  listAvatarFrameUrls,
+  buildAvatarFrameUrlById,
+  isValidAvatarFrameUrl,
+  normalizeAvatarFrameValue
+};


### PR DESCRIPTION
## Summary
- add a shared avatar frame catalog that is reused in both the client and member cloud function
- allow members to pick an avatar frame in the avatar picker and render it over avatars in the UI
- persist the selected frame alongside avatar updates when saving profile changes

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9c4ddd50083308c5d4d5e4291c7f0