### PR TITLE
refactor: localize member avatar catalog helper

### DIFF
--- a/cloudfunctions/member/index.js
+++ b/cloudfunctions/member/index.js
@@ -2,7 +2,7 @@ const cloud = require('wx-server-sdk');
 
 cloud.init({ env: cloud.DYNAMIC_CURRENT_ENV });
 
-const { listAvatarIds } = require('../../miniprogram/shared/avatar-catalog.js');
+const { listAvatarIds } = require('./shared/avatar-catalog.js');
 
 const db = cloud.database();
 const _ = db.command;

--- a/cloudfunctions/member/shared/avatar-catalog.js
+++ b/cloudfunctions/member/shared/avatar-catalog.js
@@ -1,0 +1,40 @@
+const RAW_AVATARS = [
+  { gender: 'male', rarity: 'c', index: 1 },
+  { gender: 'male', rarity: 'c', index: 2 },
+  { gender: 'male', rarity: 'c', index: 3 },
+  { gender: 'male', rarity: 'b', index: 1 },
+  { gender: 'male', rarity: 'b', index: 2 },
+  { gender: 'male', rarity: 'b', index: 3 },
+  { gender: 'male', rarity: 'b', index: 4 },
+  { gender: 'male', rarity: 'b', index: 5 },
+  { gender: 'male', rarity: 'b', index: 6 },
+  { gender: 'male', rarity: 'a', index: 1 },
+  { gender: 'male', rarity: 'a', index: 2 },
+  { gender: 'female', rarity: 'c', index: 1 },
+  { gender: 'female', rarity: 'c', index: 2 },
+  { gender: 'female', rarity: 'c', index: 3 },
+  { gender: 'female', rarity: 'b', index: 1 },
+  { gender: 'female', rarity: 'b', index: 2 },
+  { gender: 'female', rarity: 'b', index: 3 },
+  { gender: 'female', rarity: 'b', index: 4 },
+  { gender: 'female', rarity: 'b', index: 5 },
+  { gender: 'female', rarity: 'b', index: 6 },
+  { gender: 'female', rarity: 'a', index: 1 },
+  { gender: 'female', rarity: 'a', index: 2 }
+];
+
+function buildAvatarId({ gender, rarity, index }) {
+  return `${gender}-${rarity}-${index}`;
+}
+
+const AVATAR_IDS = RAW_AVATARS.map((item) => buildAvatarId(item));
+
+function listAvatarIds() {
+  return AVATAR_IDS.slice();
+}
+
+module.exports = {
+  RAW_AVATARS,
+  buildAvatarId,
+  listAvatarIds
+};

--- a/cloudfunctions/member/shared/avatar-frames.js
+++ b/cloudfunctions/member/shared/avatar-frames.js
@@ -1,0 +1,8 @@
+// Placeholder avatar frames helper for cloud function runtime.
+// The original miniprogram/shared/avatar-frames.js module is not present
+// in this repository snapshot, but the cloud function expects a local
+// helper to avoid cross-package require paths.
+//
+// Update this file with the real frame catalog when it becomes available.
+
+module.exports = {};


### PR DESCRIPTION
## Summary
- add local shared copies of the avatar catalog (and placeholder frame module) for the member cloud function
- update the member cloud function to require the local helper instead of reaching into the mini program directory

## Testing
- not run (cloud function deployment not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9cbf7763c833084856e8ba25bedd5