### PR TITLE
Fix avatar frame persistence and realtime propagation

### DIFF
--- a/cloudfunctions/member/index.js
+++ b/cloudfunctions/member/index.js
@@ -195,7 +195,8 @@ async function completeProfile(openid, payload = {}) {
 
   const nickName = typeof profile.nickName === 'string' ? profile.nickName.trim() : '';
   const avatarUrl = typeof profile.avatarUrl === 'string' ? profile.avatarUrl : '';
-  const avatarFrame = normalizeAvatarFrameValue(profile.avatarFrame || '');
+  const hasAvatarFrame = Object.prototype.hasOwnProperty.call(profile, 'avatarFrame');
+  const avatarFrame = hasAvatarFrame ? normalizeAvatarFrameValue(profile.avatarFrame || '') : '';
   const genderValue = normalizeGender(profile.gender);
   const mobile = await resolveMobile(payload);
 
@@ -212,7 +213,7 @@ async function completeProfile(openid, payload = {}) {
   if (typeof profile.gender !== 'undefined' && profile.gender !== null) {
     updates.gender = genderValue;
   }
-  if (avatarFrame) {
+  if (hasAvatarFrame) {
     updates.avatarFrame = avatarFrame;
   }
 


### PR DESCRIPTION
## Summary
- persist avatar frame updates in the completeProfile flow when provided by the client
- sanitize avatar frame data in the realtime member service so snapshots retain the selected frame

## Testing
- not run (mini program)


------
https://chatgpt.com/codex/tasks/task_e_68d9d8a73bc88330bb98c5339d861eba