### PR TITLE
feat: display experience requirements on level list

### DIFF
--- a/miniprogram/pages/membership/membership.js
+++ b/miniprogram/pages/membership/membership.js
@@ -174,17 +174,5 @@ Page({
   },
 
   formatCurrency,
-  formatExperience,
-
-  formatDiscount(value) {
-    const numeric = typeof value === 'number' ? value : 1;
-    const discount = numeric * 10;
-    if (Number.isNaN(discount)) {
-      return '10';
-    }
-    if (Math.abs(discount - Math.round(discount)) < 0.001) {
-      return `${Math.round(discount)}`;
-    }
-    return discount.toFixed(1);
-  }
+  formatExperience
 });

--- a/miniprogram/pages/membership/membership.wxml
+++ b/miniprogram/pages/membership/membership.wxml
@@ -52,8 +52,7 @@
         <view class="level-info">
           <view class="level-title">LV{{item.order}} · {{item.name}}</view>
           <view class="level-meta">
-            <text>累计充值 {{formatCurrency(item.threshold)}}</text>
-            <text class="level-discount">尊享 {{formatDiscount(item.discount)}} 折</text>
+            <text>修为达到 {{formatExperience(item.threshold)}} 点</text>
           </view>
           <view class="level-desc" wx:if="{{item.subLevel === 1 && item.realmDescription}}">{{item.realmDescription}}</view>
           <view class="level-virtual" wx:if="{{item.virtualRewards && item.virtualRewards.length}}">

--- a/miniprogram/pages/membership/membership.wxss
+++ b/miniprogram/pages/membership/membership.wxss
@@ -198,11 +198,6 @@
   margin-top: 12rpx;
 }
 
-.level-discount {
-  color: #ffd39c;
-  font-weight: 600;
-}
-
 .level-desc {
   font-size: 24rpx;
   color: rgba(207, 216, 255, 0.75);


### PR DESCRIPTION
## Summary
- show the required cultivation experience for each level in the membership list
- remove the cumulative recharge/discount display and related styling logic

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9de972a508330ad6fac6494a42a1f