### PR TITLE
Implement level visibility controls and reward claiming

### DIFF
--- a/miniprogram/pages/membership/membership.wxml
+++ b/miniprogram/pages/membership/membership.wxml
@@ -44,7 +44,12 @@
 
     <view class="card">
       <view class="section-title">等级列表</view>
-      <view wx:for="{{levels}}" wx:key="_id" class="level-item {{item.milestoneReward ? 'level-item--milestone' : ''}}">
+      <view class="level-toolbar" wx:if="{{!isAdmin}}">
+        <view class="toggle-past" bindtap="onTogglePastLevels">
+          {{showPastLevels ? '隐藏过往等级' : '查看过往等级'}}
+        </view>
+      </view>
+      <view wx:for="{{visibleLevels}}" wx:key="_id" class="level-item {{item.milestoneReward ? 'level-item--milestone' : ''}}">
         <view class="level-rank" style="{{item.badgeStyle}}">
           <text class="rank-realm">{{item.realmShort}}</text>
           <text class="rank-stage">{{item.subLevelLabel}}</text>
@@ -69,6 +74,23 @@
           <view class="level-bonus" wx:if="{{item.rewards && item.rewards.length}}">
             <text class="reward-label">实体权益：</text>
             <text class="reward-text" wx:for="{{item.rewards}}" wx:key="{{index}}">{{item}}</text>
+          </view>
+          <view class="level-actions-row" wx:if="{{item.hasRewards}}">
+            <button
+              wx:if="{{item.claimable}}"
+              class="claim-button"
+              type="default"
+              size="mini"
+              data-level-id="{{item._id}}"
+              bindtap="onClaimReward"
+            >领取奖励</button>
+            <button
+              wx:elif="{{!item.claimed}}"
+              class="claim-button claim-button--disabled"
+              type="default"
+              size="mini"
+              disabled
+            >未达成</button>
           </view>
         </view>
       </view>

--- a/miniprogram/pages/membership/membership.wxml
+++ b/miniprogram/pages/membership/membership.wxml
@@ -24,10 +24,10 @@
       </view>
     </view>
 
-    <view class="card realm-card" wx:if="{{realms.length}}">
+    <view class="card realm-card" wx:if="{{visibleRealms.length}}">
       <view class="section-title">主境界进阶</view>
       <view class="realm-grid">
-        <view class="realm-item" wx:for="{{realms}}" wx:key="{{item.realm}}">
+        <view class="realm-item" wx:for="{{visibleRealms}}" wx:key="{{item.realmKey || item.realm}}">
           <view class="realm-header">
             <text class="realm-name">{{item.realm}}</text>
             <text class="realm-range">{{formatCurrency(item.start)}} ~ {{formatCurrency(item.end)}}</text>
@@ -78,7 +78,7 @@
           <view class="level-actions-row" wx:if="{{item.hasRewards}}">
             <button
               wx:if="{{item.claimable}}"
-              class="claim-button"
+              class="claim-button claim-button--active"
               type="default"
               size="mini"
               data-level-id="{{item._id}}"

--- a/miniprogram/pages/membership/membership.wxss
+++ b/miniprogram/pages/membership/membership.wxss
@@ -219,10 +219,7 @@
 
 .level-actions-row {
   margin-top: 16rpx;
-  display: flex;
-  gap: 12rpx;
-  flex-wrap: wrap;
-  justify-content: flex-start;
+  display: block;
 }
 
 .claim-button {
@@ -242,12 +239,28 @@
   border: none;
 }
 
-.claim-button--active {
-  background: linear-gradient(90deg, #ff5a5a, #ff3030);
-  color: #ffffff;
+.claim-button.claim-button--active {
+    min-height: 48rpx;
+    line-height: 48rpx;
+    padding: 0 24rpx;
+    font-size: 22rpx;
+    min-width: 0;
+    width: auto;
+    border-radius: 999rpx;
+    border: none;
+    background: linear-gradient(90deg, #ff5a5a, #ff3030);
+    color: #ffffff;
 }
 
 .claim-button.claim-button--disabled {
+    min-height: 48rpx;
+    line-height: 48rpx;
+    padding: 0 24rpx;
+    font-size: 22rpx;
+    min-width: 0;
+    width: auto;
+    border-radius: 999rpx;
+    border: none;
   background: rgba(110, 122, 180, 0.4);
   color: rgba(230, 236, 255, 0.6);
 }

--- a/miniprogram/pages/membership/membership.wxss
+++ b/miniprogram/pages/membership/membership.wxss
@@ -198,6 +198,49 @@
   margin-top: 12rpx;
 }
 
+.level-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 16rpx;
+}
+
+.toggle-past {
+  font-size: 24rpx;
+  color: #8ea0ff;
+  padding: 8rpx 16rpx;
+  border-radius: 999rpx;
+  border: 1rpx solid rgba(142, 160, 255, 0.6);
+  background: rgba(14, 22, 58, 0.6);
+}
+
+.toggle-past:active {
+  opacity: 0.7;
+}
+
+.level-actions-row {
+  margin-top: 20rpx;
+  display: flex;
+  gap: 16rpx;
+  flex-wrap: wrap;
+}
+
+.claim-button {
+  background: linear-gradient(90deg, #6f7bff, #9b6fff);
+  color: #ffffff;
+  border: none;
+  border-radius: 999rpx;
+  padding: 0 32rpx;
+}
+
+.claim-button::after {
+  border: none;
+}
+
+.claim-button.claim-button--disabled {
+  background: rgba(110, 122, 180, 0.4);
+  color: rgba(230, 236, 255, 0.6);
+}
+
 .level-desc {
   font-size: 24rpx;
   color: rgba(207, 216, 255, 0.75);

--- a/miniprogram/pages/membership/membership.wxss
+++ b/miniprogram/pages/membership/membership.wxss
@@ -218,22 +218,33 @@
 }
 
 .level-actions-row {
-  margin-top: 20rpx;
+  margin-top: 16rpx;
   display: flex;
-  gap: 16rpx;
+  gap: 12rpx;
   flex-wrap: wrap;
+  justify-content: flex-start;
 }
 
 .claim-button {
-  background: linear-gradient(90deg, #6f7bff, #9b6fff);
-  color: #ffffff;
-  border: none;
+  min-height: 48rpx;
+  line-height: 48rpx;
+  padding: 0 24rpx;
+  font-size: 22rpx;
+  min-width: 0;
+  width: auto;
   border-radius: 999rpx;
-  padding: 0 32rpx;
+  border: none;
+  background: rgba(110, 122, 180, 0.4);
+  color: rgba(230, 236, 255, 0.8);
 }
 
 .claim-button::after {
   border: none;
+}
+
+.claim-button--active {
+  background: linear-gradient(90deg, #ff5a5a, #ff3030);
+  color: #ffffff;
 }
 
 .claim-button.claim-button--disabled {

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -145,6 +145,12 @@ export const MemberService = {
   async getLevelProgress() {
     return callCloud(CLOUD_FUNCTIONS.MEMBER, { action: 'progress' });
   },
+  async claimLevelReward(levelId) {
+    return callCloud(CLOUD_FUNCTIONS.MEMBER, {
+      action: 'claimLevelReward',
+      levelId
+    });
+  },
   async getRights() {
     return callCloud(CLOUD_FUNCTIONS.MEMBER, { action: 'rights' });
   },


### PR DESCRIPTION
## Summary
- restrict the membership page to the current and next levels for regular members while allowing admins or a toggle to view the full list
- add backend support and a client API for tracking claimed level rewards and validating eligibility before claims
- surface claim buttons per level that become available at the appropriate threshold and disappear once claimed

## Testing
- not run (mini program tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9e91f973c8330808ee70064610bd3