### PR TITLE
fix: display fallback background image when video fails

### DIFF
--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -25,8 +25,10 @@ page {
 }
 
 .background--fallback {
-  background: linear-gradient(180deg, #050921 0%, #1b3c68 45%, #3d0c3d 100%);
+  background: linear-gradient(180deg, rgba(5, 9, 33, 0.85) 0%, rgba(27, 60, 104, 0.75) 45%, rgba(61, 12, 61, 0.85) 100%),
+    url('../../assets/background/1.jpg');
   background-repeat: no-repeat;
+  background-position: center;
   background-size: cover;
   filter: saturate(110%);
 }


### PR DESCRIPTION
## Summary
- layer a gradient over the static background image so the fallback view uses 1.jpg when the video fails to load

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da097375dc8330a48c1826646bf681