### PR TITLE
Fix homepage background fallback image

### DIFF
--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -1,5 +1,10 @@
 <view class="home-page">
   <view wx:if="{{backgroundVideoError}}" class="background background--fallback">
+    <image
+      class="background-fallback__image"
+      src="../../assets/background/1.jpg"
+      mode="aspectFill"
+    ></image>
     <view class="background-fallback__overlay"></view>
   </view>
   <video

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -24,13 +24,19 @@ page {
   pointer-events: none;
 }
 
+
 .background--fallback {
-  background-image: url('../../assets/background/1.jpg');
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: cover;
-  filter: saturate(110%);
   overflow: hidden;
+}
+
+.background-fallback__image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  filter: saturate(110%);
 }
 
 .background-fallback__overlay {


### PR DESCRIPTION
## Summary
- render the homepage fallback background as an image element so the asset loads correctly
- update styles to position the fallback image and retain the saturation effect

## Testing
- not run (mini program)


------
https://chatgpt.com/codex/tasks/task_e_68da138e81b883309bb849cc76720789