### PR TITLE
Remove overlay mask from home background

### DIFF
--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -5,7 +5,6 @@
       src="../../assets/background/1.jpg"
       mode="aspectFill"
     ></image>
-    <view class="background-fallback__overlay"></view>
   </view>
   <view class="mist-layer mist-layer--one"></view>
   <view class="mist-layer mist-layer--two"></view>

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -39,16 +39,6 @@ page {
   filter: saturate(110%);
 }
 
-.background-fallback__overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(180deg, rgba(5, 9, 33, 0.65) 0%, rgba(27, 60, 104, 0.45) 45%, rgba(61, 12, 61, 0.6) 100%);
-  pointer-events: none;
-}
-
 .mist-layer {
   position: absolute;
   left: -20%;


### PR DESCRIPTION
## Summary
- remove the extra overlay layer from the home page background so the source image colors show through
- delete the unused overlay styling from the index page stylesheet

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da197088b48330a5f9edd28a060ac9