### PR TITLE
feat: update home background by realm

### DIFF
--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -2,7 +2,7 @@
   <view class="background background--fallback">
     <image
       class="background-fallback__image"
-      src="../../assets/background/1.jpg"
+      src="{{backgroundImage}}"
       mode="aspectFill"
     ></image>
     <view class="background-fallback__overlay"></view>


### PR DESCRIPTION
## Summary
- resolve a dynamic background image for the home page based on the member's realm level
- bind the resolved background to the home screen template and refresh it when member data updates

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da1f0a9e3c83309ff9636c3f098c4d