### PR TITLE
Remove redundant level and experience ratios

### DIFF
--- a/miniprogram/pages/role/index.wxml
+++ b/miniprogram/pages/role/index.wxml
@@ -51,10 +51,6 @@
           <view class="level-stack">
             <view class="level-name">
               {{profile.attributes ? profile.attributes.levelLabel : '--'}}
-              <text
-                class="level-count"
-                wx:if="{{profile.attributes && profile.metadata}}"
-              >（{{profile.attributes.level}} / {{profile.metadata.maxLevel}}）</text>
             </view>
             <view
               class="level-realm"
@@ -71,10 +67,9 @@
           </view>
           <view class="progress-text">
             修为 {{profile.attributes ? profile.attributes.experience : '--'}}
-            <text wx:if="{{profile.attributes && profile.attributes.nextLevelExp != null}}">
-              / {{profile.attributes.nextLevelExp}}
+            <text wx:if="{{profile.attributes && profile.attributes.nextLevelExp == null}}">
+              · 已满阶
             </text>
-            <text wx:else> · 已满阶</text>
           </view>
         </view>
         <view class="progress-bar">

--- a/miniprogram/pages/role/index.wxss
+++ b/miniprogram/pages/role/index.wxss
@@ -191,11 +191,6 @@ button.pill-btn[disabled] {
   gap: 6rpx;
 }
 
-.level-count {
-  font-size: 22rpx;
-  color: rgba(174, 190, 255, 0.72);
-}
-
 .level-realm {
   font-size: 24rpx;
   color: rgba(196, 206, 255, 0.8);


### PR DESCRIPTION
## Summary
- remove the level to max-level ratio from the role attributes header
- simplify the experience display so it no longer shows the current/next threshold pair

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68da2383287483309b75fbe271676514