### PR TITLE
Remove cultivation progress display from role attributes

### DIFF
--- a/miniprogram/pages/role/index.wxml
+++ b/miniprogram/pages/role/index.wxml
@@ -65,18 +65,6 @@
               下一阶段：{{profile.attributes.nextLevelLabel}}
             </view>
           </view>
-          <view class="progress-text">
-            修为 {{profile.attributes ? profile.attributes.experience : '--'}}
-            <text wx:if="{{profile.attributes && profile.attributes.nextLevelExp == null}}">
-              · 已满阶
-            </text>
-          </view>
-        </view>
-        <view class="progress-bar">
-          <view
-            class="progress-fill"
-            style="width: {{profile.attributes ? profile.attributes.experienceProgress : 0}}%;"
-          ></view>
         </view>
         <view class="attr-grid">
           <view class="attr-item" wx:for="{{(profile.attributes && profile.attributes.attributeList) || []}}" wx:key="key">

--- a/miniprogram/pages/role/index.wxss
+++ b/miniprogram/pages/role/index.wxss
@@ -170,7 +170,7 @@ button.pill-btn[disabled] {
   justify-content: space-between;
   color: rgba(194, 206, 255, 0.75);
   font-size: 24rpx;
-  margin-bottom: 12rpx;
+  margin-bottom: 0;
   align-items: flex-start;
   gap: 24rpx;
 }
@@ -201,39 +201,11 @@ button.pill-btn[disabled] {
   color: rgba(207, 218, 255, 0.78);
 }
 
-.progress-text {
-  font-size: 24rpx;
-  color: rgba(200, 210, 255, 0.78);
-  text-align: right;
-  line-height: 1.6;
-}
-
-.progress-text text {
-  display: inline;
-}
-
-.progress-bar {
-  position: relative;
-  background: rgba(40, 56, 118, 0.75);
-  border-radius: 999rpx;
-  height: 16rpx;
-  overflow: hidden;
-  margin-bottom: 24rpx;
-}
-
-.progress-fill {
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  background: linear-gradient(90deg, #4f78ff, #8a6cff);
-  border-radius: 999rpx;
-}
-
 .attr-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 24rpx;
+  margin-top: 0;
 }
 
 .attr-item {


### PR DESCRIPTION
## Summary
- remove the cultivation experience text and progress bar from the role attribute section
- tighten the spacing so the attribute grid sits flush beneath the level information

## Testing
- not run (WeChat mini program environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68da481ff8988330899745bf01c256e5