### PR TITLE
Refine dodge scaling and combat resolution

### DIFF
--- a/cloudfunctions/pve/index.js
+++ b/cloudfunctions/pve/index.js
@@ -15,27 +15,139 @@ const MAX_SKILL_SLOTS = 3;
 const MAX_BATTLE_HISTORY = 15;
 const MAX_SKILL_HISTORY = 30;
 
-const BASE_ATTRIBUTE_GROWTH = {
-  hp: { base: 1200, perLevel: 180 },
-  attack: { base: 120, perLevel: 12 },
-  defense: { base: 80, perLevel: 9 },
-  speed: { base: 60, perLevel: 3 },
-  luck: { base: 10, perLevel: 1 },
-  critRate: { base: 0.05, perLevel: 0.002 },
-  critDamage: { base: 1.5, perLevel: 0.015 }
+const BASE_ATTRIBUTE_KEYS = ['constitution', 'strength', 'spirit', 'root', 'agility', 'insight'];
+const COMBAT_STAT_KEYS = [
+  'maxHp',
+  'physicalAttack',
+  'magicAttack',
+  'physicalDefense',
+  'magicDefense',
+  'speed',
+  'accuracy',
+  'dodge',
+  'critRate',
+  'critDamage',
+  'finalDamageBonus',
+  'finalDamageReduction',
+  'lifeSteal',
+  'healingBonus',
+  'healingReduction',
+  'controlHit',
+  'controlResist',
+  'physicalPenetration',
+  'magicPenetration'
+];
+
+const COMBAT_STAT_LABELS = {
+  maxHp: '生命值',
+  physicalAttack: '物理攻击',
+  magicAttack: '法术攻击',
+  physicalDefense: '物理防御',
+  magicDefense: '法术防御',
+  speed: '速度',
+  accuracy: '命中',
+  dodge: '闪避值',
+  critRate: '暴击率',
+  critDamage: '暴击伤害',
+  finalDamageBonus: '最终增伤',
+  finalDamageReduction: '最终减伤',
+  lifeSteal: '吸血',
+  healingBonus: '治疗强化',
+  healingReduction: '治疗削弱',
+  controlHit: '控制命中',
+  controlResist: '控制抗性',
+  physicalPenetration: '破甲',
+  magicPenetration: '法穿'
 };
 
-let membershipLevelsCache = null;
-
 const ATTRIBUTE_CONFIG = [
-  { key: 'hp', label: '气血', type: 'number', step: 45 },
-  { key: 'attack', label: '攻击', type: 'number', step: 6 },
-  { key: 'defense', label: '防御', type: 'number', step: 6 },
-  { key: 'speed', label: '身法', type: 'number', step: 3 },
-  { key: 'luck', label: '灵运', type: 'number', step: 2 },
-  { key: 'critRate', label: '暴击率', type: 'percentage', step: 0.01 },
-  { key: 'critDamage', label: '暴击伤害', type: 'multiplier', step: 0.04 }
+  { key: 'constitution', label: '体质', type: 'number', step: 1 },
+  { key: 'strength', label: '力量', type: 'number', step: 1 },
+  { key: 'spirit', label: '灵力', type: 'number', step: 1 },
+  { key: 'root', label: '根骨', type: 'number', step: 1 },
+  { key: 'agility', label: '敏捷', type: 'number', step: 1 },
+  { key: 'insight', label: '悟性', type: 'number', step: 1 }
 ];
+
+const BASELINE_ATTRIBUTES = {
+  constitution: 20,
+  strength: 16,
+  spirit: 16,
+  root: 18,
+  agility: 12,
+  insight: 12
+};
+
+const REALM_PHASES = [
+  {
+    id: 'qi_refining',
+    name: '炼气期',
+    short: '炼气',
+    range: [1, 30],
+    perLevel: { constitution: 2, strength: 2, spirit: 2, root: 2, agility: 1, insight: 1 },
+    breakthroughBonus: {}
+  },
+  {
+    id: 'foundation',
+    name: '筑基期',
+    short: '筑基',
+    range: [31, 60],
+    perLevel: { constitution: 2.5, strength: 2.4, spirit: 2.5, root: 2.4, agility: 1.4, insight: 1.3 },
+    breakthroughBonus: {
+      maxHp: 0.05,
+      physicalAttack: 0.05,
+      magicAttack: 0.05,
+      physicalDefense: 0.05,
+      magicDefense: 0.05,
+      speed: 0.02,
+      accuracy: 0.02
+    }
+  },
+  {
+    id: 'golden_core',
+    name: '金丹期',
+    short: '金丹',
+    range: [61, 90],
+    perLevel: { constitution: 3, strength: 2.8, spirit: 3, root: 2.8, agility: 1.6, insight: 1.5 },
+    breakthroughBonus: {
+      maxHp: 0.08,
+      physicalAttack: 0.08,
+      magicAttack: 0.08,
+      physicalDefense: 0.08,
+      magicDefense: 0.08,
+      speed: 0.03,
+      accuracy: 0.03
+    }
+  },
+  {
+    id: 'nascent_soul',
+    name: '元婴期',
+    short: '元婴',
+    range: [91, 100],
+    perLevel: { constitution: 3.5, strength: 3.2, spirit: 3.4, root: 3.2, agility: 1.8, insight: 1.7 },
+    breakthroughBonus: {
+      maxHp: 0.12,
+      physicalAttack: 0.12,
+      magicAttack: 0.12,
+      physicalDefense: 0.12,
+      magicDefense: 0.12,
+      speed: 0.04,
+      accuracy: 0.04
+    }
+  }
+];
+
+const REALM_BONUS_TARGETS = [
+  'maxHp',
+  'physicalAttack',
+  'magicAttack',
+  'physicalDefense',
+  'magicDefense',
+  'speed',
+  'accuracy'
+];
+
+let membershipLevelsCache = null;
 
 const RARITY_CONFIG = {
   common: { key: 'common', label: '常见', color: '#9aa4b5', weight: 60 },
@@ -58,7 +170,7 @@ const EQUIPMENT_LIBRARY = [
     rarity: 'common',
     levelRequirement: 1,
     description: '以万年青竹制成的入门木剑，轻巧易上手。',
-    stats: { attack: 18, speed: 4 },
+    stats: { strength: 6, agility: 3, critRate: 0.015 },
     tags: ['入门', '轻灵'],
     refineScale: 0.08
   },
@@ -69,7 +181,7 @@ const EQUIPMENT_LIBRARY = [
     rarity: 'rare',
     levelRequirement: 6,
     description: '由灵矿铸造的利刃，剑身流转灵光，出手凌厉。',
-    stats: { attack: 42, critRate: 0.05, speed: 6 },
+    stats: { strength: 12, spirit: 6, agility: 4, critRate: 0.03 },
     tags: ['输出', '暴击'],
     refineScale: 0.09
   },
@@ -80,7 +192,7 @@ const EQUIPMENT_LIBRARY = [
     rarity: 'epic',
     levelRequirement: 12,
     description: '以远古蛟龙之骨打磨而成，刀啸之间风雷激荡。',
-    stats: { attack: 68, critRate: 0.08, critDamage: 0.25 },
+    stats: { strength: 18, critRate: 0.05, critDamage: 0.2 },
     tags: ['爆发', '传奇猎获'],
     refineScale: 0.1
   },
@@ -91,7 +203,7 @@ const EQUIPMENT_LIBRARY = [
     rarity: 'common',
     levelRequirement: 1,
     description: '绣有基础灵纹的道袍，可抵挡初阶灵力冲击。',
-    stats: { hp: 320, defense: 22 },
+    stats: { constitution: 10, root: 8, physicalDefense: 18 },
     tags: ['护体'],
     refineScale: 0.06
   },
@@ -102,7 +214,7 @@ const EQUIPMENT_LIBRARY = [
     rarity: 'rare',
     levelRequirement: 7,
     description: '凝聚星辰碎屑炼制而成，能在战斗中缓释星辉。',
-    stats: { hp: 520, defense: 40, critRate: 0.02 },
+    stats: { constitution: 14, root: 12, finalDamageReduction: 0.04 },
     tags: ['稳固', '星辉护佑'],
     refineScale: 0.07
   },
@@ -113,7 +225,7 @@ const EQUIPMENT_LIBRARY = [
     rarity: 'epic',
     levelRequirement: 14,
     description: '虚空灵蛛吐丝织就，既轻若鸿羽，又可化去钝击。',
-    stats: { hp: 720, defense: 55, speed: 8 },
+    stats: { agility: 12, root: 10, dodge: 18, dodgeChance: 0.05 },
     tags: ['闪避', '轻盈'],
     refineScale: 0.08
   },
@@ -124,7 +236,7 @@ const EQUIPMENT_LIBRARY = [
     rarity: 'common',
     levelRequirement: 1,
     description: '简易聚灵阵刻印于戒身，辅助修行者凝聚灵气。',
-    stats: { attack: 12, luck: 8, critRate: 0.02 },
+    stats: { spirit: 8, insight: 6, critRate: 0.02 },
     tags: ['入门'],
     refineScale: 0.07
   },
@@ -135,7 +247,7 @@ const EQUIPMENT_LIBRARY = [
     rarity: 'rare',
     levelRequirement: 8,
     description: '玉佩蕴含青霄雷意，为持有者带来敏锐感知。',
-    stats: { defense: 24, luck: 12, critDamage: 0.12 },
+    stats: { insight: 10, spirit: 6, critDamage: 0.15 },
     tags: ['暴击', '雷意'],
     refineScale: 0.08
   },
@@ -146,7 +258,7 @@ const EQUIPMENT_LIBRARY = [
     rarity: 'legendary',
     levelRequirement: 18,
     description: '传闻采自南明离火凤凰的一缕尾羽，可唤醒血脉之力。',
-    stats: { attack: 35, speed: 12, critRate: 0.08, critDamage: 0.25 },
+    stats: { strength: 12, agility: 10, insight: 8, critRate: 0.06, finalDamageBonus: 0.04 },
     tags: ['传说', '高爆发'],
     refineScale: 0.1
   }
@@ -158,8 +270,8 @@ const SKILL_LIBRARY = [
     name: '灵息引',
     rarity: 'common',
     description: '调动灵息贯通四肢，提升攻击与身法。',
-    effects: { attackMultiplier: 0.12, speed: 6 },
-    levelScaling: { attackMultiplier: 0.04, speed: 2 },
+    effects: { physicalAttackMultiplier: 0.12, speed: 8 },
+    levelScaling: { physicalAttackMultiplier: 0.04, speed: 2 },
     tags: ['输出', '常驻'],
     maxLevel: 5
   },
@@ -168,8 +280,8 @@ const SKILL_LIBRARY = [
     name: '磐石护体',
     rarity: 'common',
     description: '引山岳之力护体，提升防御并获得护盾。',
-    effects: { defenseMultiplier: 0.18, shield: 80 },
-    levelScaling: { defenseMultiplier: 0.06, shield: 35 },
+    effects: { physicalDefenseMultiplier: 0.2, shield: 120 },
+    levelScaling: { physicalDefenseMultiplier: 0.05, shield: 40 },
     tags: ['防御', '护盾'],
     maxLevel: 5
   },
@@ -178,8 +290,8 @@ const SKILL_LIBRARY = [
     name: '凌空步',
     rarity: 'rare',
     description: '掌握凌空而行的诀窍，大幅提升身法与气血。',
-    effects: { speed: 15, hpMultiplier: 0.08 },
-    levelScaling: { speed: 4, hpMultiplier: 0.03 },
+    effects: { agility: 8, maxHpMultiplier: 0.08 },
+    levelScaling: { agility: 3, maxHpMultiplier: 0.03 },
     tags: ['身法', '生存'],
     maxLevel: 5
   },
@@ -188,8 +300,8 @@ const SKILL_LIBRARY = [
     name: '霆鸣决',
     rarity: 'rare',
     description: '以雷霆之势击溃敌人，攻击提升并附带雷击。',
-    effects: { attackMultiplier: 0.18, bonusDamage: 50 },
-    levelScaling: { attackMultiplier: 0.05, bonusDamage: 22 },
+    effects: { physicalAttackMultiplier: 0.2, bonusDamage: 70, critRate: 0.04 },
+    levelScaling: { physicalAttackMultiplier: 0.05, bonusDamage: 25, critRate: 0.01 },
     tags: ['输出', '爆发'],
     maxLevel: 5
   },
@@ -198,8 +310,8 @@ const SKILL_LIBRARY = [
     name: '朱焰冲霄',
     rarity: 'epic',
     description: '化身朱焰，攻击与暴击伤害大幅提升。',
-    effects: { attackMultiplier: 0.28, critDamage: 0.45 },
-    levelScaling: { attackMultiplier: 0.07, critDamage: 0.15 },
+    effects: { critDamage: 0.3, finalDamageBonus: 0.06 },
+    levelScaling: { critDamage: 0.08, finalDamageBonus: 0.02 },
     tags: ['暴击', '高爆发'],
     maxLevel: 5
   },
@@ -208,8 +320,8 @@ const SKILL_LIBRARY = [
     name: '星幕结界',
     rarity: 'epic',
     description: '星光化为屏障，为自身提供护盾与暴击率。',
-    effects: { shield: 160, defenseMultiplier: 0.22, critRate: 0.05 },
-    levelScaling: { shield: 55, defenseMultiplier: 0.05, critRate: 0.02 },
+    effects: { shield: 180, maxHpMultiplier: 0.12, finalDamageReduction: 0.06 },
+    levelScaling: { shield: 45, maxHpMultiplier: 0.03, finalDamageReduction: 0.015 },
     tags: ['防御', '暴击'],
     maxLevel: 5
   },
@@ -218,8 +330,8 @@ const SKILL_LIBRARY = [
     name: '龙吟破军',
     rarity: 'legendary',
     description: '以龙吟震慑四方，攻击暴涨并附加剧烈震荡。',
-    effects: { attackMultiplier: 0.32, critRate: 0.08, bonusDamage: 100 },
-    levelScaling: { attackMultiplier: 0.08, critRate: 0.02, bonusDamage: 45 },
+    effects: { physicalAttackMultiplier: 0.25, critRate: 0.07, bonusDamage: 120 },
+    levelScaling: { physicalAttackMultiplier: 0.06, critRate: 0.015, bonusDamage: 45 },
     tags: ['传说', '暴击'],
     maxLevel: 5
   },
@@ -228,8 +340,8 @@ const SKILL_LIBRARY = [
     name: '御时术',
     rarity: 'legendary',
     description: '暂借时光伟力，提升身法并大幅提高闪避概率。',
-    effects: { speed: 20, speedMultiplier: 0.15, dodgeChance: 0.1 },
-    levelScaling: { speed: 6, speedMultiplier: 0.04, dodgeChance: 0.02 },
+    effects: { speedMultiplier: 0.15, dodge: 20, dodgeChance: 0.1 },
+    levelScaling: { speedMultiplier: 0.04, dodge: 6, dodgeChance: 0.025 },
     tags: ['身法', '闪避'],
     maxLevel: 5
   }
@@ -241,7 +353,26 @@ const ENEMY_LIBRARY = [
     name: '灵芽傀儡',
     level: 1,
     description: '由木灵催生的守园傀儡，行动迟缓但防御扎实。',
-    stats: { hp: 900, attack: 110, defense: 68, speed: 42, critRate: 0.04, critDamage: 1.5 },
+    stats: {
+      maxHp: 900,
+      physicalAttack: 110,
+      magicAttack: 60,
+      physicalDefense: 70,
+      magicDefense: 55,
+      speed: 45,
+      accuracy: 105,
+      dodge: 90,
+      critRate: 0.05,
+      critDamage: 1.4,
+      finalDamageBonus: 0,
+      finalDamageReduction: 0.05,
+      lifeSteal: 0,
+      controlHit: 20,
+      controlResist: 10,
+      physicalPenetration: 6,
+      magicPenetration: 0
+    },
+    special: { shield: 30, bonusDamage: 12, dodgeChance: 0.02 },
     rewards: { stones: 18, attributePoints: 0 },
     loot: [
       { type: 'equipment', itemId: 'starsea_mail', chance: 0.08 },
@@ -253,7 +384,26 @@ const ENEMY_LIBRARY = [
     name: '炽火幽灵',
     level: 7,
     description: '灵火凝聚的亡魂，速度极快且攻击灼热。',
-    stats: { hp: 1150, attack: 160, defense: 74, speed: 72, critRate: 0.08, critDamage: 1.6 },
+    stats: {
+      maxHp: 1150,
+      physicalAttack: 135,
+      magicAttack: 160,
+      physicalDefense: 82,
+      magicDefense: 70,
+      speed: 90,
+      accuracy: 120,
+      dodge: 120,
+      critRate: 0.08,
+      critDamage: 1.55,
+      finalDamageBonus: 0.08,
+      finalDamageReduction: 0.04,
+      lifeSteal: 0.05,
+      controlHit: 35,
+      controlResist: 20,
+      physicalPenetration: 12,
+      magicPenetration: 18
+    },
+    special: { shield: 20, bonusDamage: 40, dodgeChance: 0.04 },
     rewards: { stones: 32, attributePoints: 1 },
     loot: [
       { type: 'equipment', itemId: 'spirit_blade', chance: 0.12 },
@@ -265,7 +415,26 @@ const ENEMY_LIBRARY = [
     name: '渊狱巨灵',
     level: 15,
     description: '行走于渊狱的巨灵，攻击沉重无比，防御如壁。',
-    stats: { hp: 1800, attack: 210, defense: 110, speed: 58, critRate: 0.1, critDamage: 1.7 },
+    stats: {
+      maxHp: 1800,
+      physicalAttack: 220,
+      magicAttack: 110,
+      physicalDefense: 150,
+      magicDefense: 120,
+      speed: 65,
+      accuracy: 125,
+      dodge: 110,
+      critRate: 0.1,
+      critDamage: 1.6,
+      finalDamageBonus: 0.05,
+      finalDamageReduction: 0.12,
+      lifeSteal: 0.03,
+      controlHit: 40,
+      controlResist: 40,
+      physicalPenetration: 20,
+      magicPenetration: 8
+    },
+    special: { shield: 120, bonusDamage: 55, dodgeChance: 0.03 },
     rewards: { stones: 48, attributePoints: 2 },
     loot: [
       { type: 'equipment', itemId: 'dragonbone_sabre', chance: 0.08 },
@@ -278,7 +447,27 @@ const ENEMY_LIBRARY = [
     name: '缚时织者',
     level: 20,
     description: '掌控时间缝隙的神秘存在，拥有不可思议的闪避能力。',
-    stats: { hp: 2000, attack: 230, defense: 120, speed: 90, critRate: 0.12, critDamage: 1.75, dodgeChance: 0.08 },
+    stats: {
+      maxHp: 2000,
+      physicalAttack: 210,
+      magicAttack: 240,
+      physicalDefense: 120,
+      magicDefense: 150,
+      speed: 120,
+      accuracy: 135,
+      dodge: 150,
+      critRate: 0.12,
+      critDamage: 1.7,
+      finalDamageBonus: 0.12,
+      finalDamageReduction: 0.08,
+      lifeSteal: 0.07,
+      controlHit: 60,
+      controlResist: 50,
+      physicalPenetration: 18,
+      magicPenetration: 26,
+      critResist: 0.03
+    },
+    special: { shield: 80, bonusDamage: 80, dodgeChance: 0.08 },
     rewards: { stones: 66, attributePoints: 3 },
     loot: [
       { type: 'equipment', itemId: 'phoenix_plume', chance: 0.05 },
@@ -323,27 +512,49 @@ function resolveMemberLevelInfo(levels = [], member = {}) {
   return { sorted, current, next, index };
 }
 
+function findRealmPhaseForLevel(level) {
+  return (
+    REALM_PHASES.find((phase) => level >= phase.range[0] && level <= phase.range[1]) ||
+    REALM_PHASES[REALM_PHASES.length - 1]
+  );
+}
+
+function resolveRealmBonus(level) {
+  const target = Math.max(1, Math.min(MAX_LEVEL, Math.floor(level)));
+  const bonuses = {};
+  REALM_PHASES.forEach((phase) => {
+    if (target >= phase.range[0]) {
+      const values = phase.breakthroughBonus || {};
+      REALM_BONUS_TARGETS.forEach((key) => {
+        bonuses[key] = (bonuses[key] || 0) + (values[key] || 0);
+      });
+    }
+  });
+  return bonuses;
+}
+
 function calculateBaseAttributesForLevel(level = 1) {
   const value = Math.max(1, Math.min(MAX_LEVEL, Math.floor(level)));
-  return {
-    hp: Math.round(BASE_ATTRIBUTE_GROWTH.hp.base + (value - 1) * BASE_ATTRIBUTE_GROWTH.hp.perLevel),
-    attack: Math.round(BASE_ATTRIBUTE_GROWTH.attack.base + (value - 1) * BASE_ATTRIBUTE_GROWTH.attack.perLevel),
-    defense: Math.round(BASE_ATTRIBUTE_GROWTH.defense.base + (value - 1) * BASE_ATTRIBUTE_GROWTH.defense.perLevel),
-    speed: Math.round(BASE_ATTRIBUTE_GROWTH.speed.base + (value - 1) * BASE_ATTRIBUTE_GROWTH.speed.perLevel),
-    luck: Math.round(BASE_ATTRIBUTE_GROWTH.luck.base + (value - 1) * BASE_ATTRIBUTE_GROWTH.luck.perLevel),
-    critRate: Number(
-      (
-        BASE_ATTRIBUTE_GROWTH.critRate.base +
-        (value - 1) * BASE_ATTRIBUTE_GROWTH.critRate.perLevel
-      ).toFixed(4)
-    ),
-    critDamage: Number(
-      (
-        BASE_ATTRIBUTE_GROWTH.critDamage.base +
-        (value - 1) * BASE_ATTRIBUTE_GROWTH.critDamage.perLevel
-      ).toFixed(2)
-    )
-  };
+  const totals = { ...BASELINE_ATTRIBUTES };
+  if (value <= 1) {
+    return BASE_ATTRIBUTE_KEYS.reduce((acc, key) => {
+      acc[key] = Math.round(totals[key] || 0);
+      return acc;
+    }, {});
+  }
+
+  for (let lvl = 2; lvl <= value; lvl += 1) {
+    const phase = findRealmPhaseForLevel(lvl);
+    BASE_ATTRIBUTE_KEYS.forEach((key) => {
+      const growth = phase.perLevel && typeof phase.perLevel[key] === 'number' ? phase.perLevel[key] : 0;
+      totals[key] = (totals[key] || 0) + growth;
+    });
+  }
+
+  return BASE_ATTRIBUTE_KEYS.reduce((acc, key) => {
+    acc[key] = Math.round(totals[key] || 0);
+    return acc;
+  }, {});
 }
 
 function areStatsEqual(a = {}, b = {}) {
@@ -358,9 +569,8 @@ function areStatsEqual(a = {}, b = {}) {
   return true;
 }
 
-function getAttributePointRewardForLevel(level) {
-  const value = Math.max(1, Math.floor(level));
-  return 3 + Math.floor(value / 3);
+function getAttributePointRewardForLevel() {
+  return 5;
 }
 
 function syncAttributesWithMemberLevel(attributes, member, levels) {
@@ -371,6 +581,8 @@ function syncAttributesWithMemberLevel(attributes, member, levels) {
   const levelOrder = current ? current.order || sorted.indexOf(current) + 1 : 1;
   const experience = Math.max(0, Math.floor(Number(member.experience) || 0));
   const baseStats = calculateBaseAttributesForLevel(levelOrder);
+  const realmPhase = findRealmPhaseForLevel(levelOrder);
+  const realmBonus = resolveRealmBonus(levelOrder);
   let changed = false;
 
   const maxLevel = Math.min(MAX_LEVEL, sorted.length || MAX_LEVEL);
@@ -400,7 +612,7 @@ function syncAttributesWithMemberLevel(attributes, member, levels) {
   if (levelOrder > lastSyncedLevel) {
     let bonusPoints = 0;
     for (let lvl = lastSyncedLevel + 1; lvl <= levelOrder; lvl += 1) {
-      bonusPoints += getAttributePointRewardForLevel(lvl);
+      bonusPoints += getAttributePointRewardForLevel();
     }
     if (bonusPoints > 0) {
       attributes.attributePoints = (attributes.attributePoints || 0) + bonusPoints;
@@ -409,6 +621,23 @@ function syncAttributesWithMemberLevel(attributes, member, levels) {
   }
   if (attributes.lastSyncedLevel !== levelOrder) {
     attributes.lastSyncedLevel = levelOrder;
+    changed = true;
+  }
+
+  if (attributes.realmId !== realmPhase.id) {
+    attributes.realmId = realmPhase.id;
+    changed = true;
+  }
+  if (attributes.realmName !== realmPhase.name) {
+    attributes.realmName = realmPhase.name;
+    changed = true;
+  }
+  if (attributes.realmShort !== realmPhase.short) {
+    attributes.realmShort = realmPhase.short;
+    changed = true;
+  }
+  if (!attributes.realmBonus || !areStatsEqual(attributes.realmBonus, realmBonus)) {
+    attributes.realmBonus = realmBonus;
     changed = true;
   }
 
@@ -431,22 +660,6 @@ function syncAttributesWithMemberLevel(attributes, member, levels) {
     attributes.levelShort = levelShort;
     changed = true;
   }
-  const realmName = current ? current.realm || '' : '';
-  if (attributes.realmName !== realmName) {
-    attributes.realmName = realmName;
-    changed = true;
-  }
-  const realmShort = current ? current.realmShort || '' : '';
-  if (attributes.realmShort !== realmShort) {
-    attributes.realmShort = realmShort;
-    changed = true;
-  }
-  const realmId = current ? current.realmId || '' : '';
-  if (attributes.realmId !== realmId) {
-    attributes.realmId = realmId;
-    changed = true;
-  }
-
   const nextLevelId = next ? next._id || '' : '';
   if (attributes.nextLevelId !== nextLevelId) {
     attributes.nextLevelId = nextLevelId;
@@ -801,6 +1014,8 @@ function buildDefaultProfile(now = new Date()) {
 
 function buildDefaultAttributes() {
   const base = calculateBaseAttributesForLevel(1);
+  const realmBonus = resolveRealmBonus(1);
+  const realmPhase = findRealmPhaseForLevel(1);
   return {
     level: 1,
     experience: 0,
@@ -810,24 +1025,20 @@ function buildDefaultAttributes() {
     levelLabel: '',
     levelName: '',
     levelShort: '',
-    realmId: '',
-    realmName: '',
-    realmShort: '',
     nextLevelId: '',
     nextLevelLabel: '',
     experienceThreshold: 0,
     nextExperienceThreshold: null,
     maxLevel: MAX_LEVEL,
     base,
-    trained: {
-      hp: 0,
-      attack: 0,
-      defense: 0,
-      speed: 0,
-      luck: 0,
-      critRate: 0,
-      critDamage: 0
-    }
+    trained: BASE_ATTRIBUTE_KEYS.reduce((acc, key) => {
+      acc[key] = 0;
+      return acc;
+    }, {}),
+    realmId: realmPhase.id,
+    realmName: realmPhase.name,
+    realmShort: realmPhase.short,
+    realmBonus
   };
 }
 
@@ -897,7 +1108,8 @@ function normalizeAttributes(attributes) {
       Math.min(MAX_LEVEL, Math.floor(Number(payload.maxLevel || defaults.maxLevel || MAX_LEVEL)))
     ),
     base: mergeStats(payload.base, defaults.base),
-    trained: mergeStats(payload.trained, defaults.trained)
+    trained: mergeStats(payload.trained, defaults.trained),
+    realmBonus: mergeStats(payload.realmBonus, defaults.realmBonus)
   };
 }
 
@@ -1088,7 +1300,7 @@ function decorateProfile(member, profile) {
   const attributeSummary = calculateAttributes(attributes, equipment, skills);
   const equipmentSummary = decorateEquipment(profile);
   const skillsSummary = decorateSkills(profile);
-  const enemies = ENEMY_LIBRARY.map((enemy) => decorateEnemy(enemy, attributeSummary.finalStats));
+  const enemies = ENEMY_LIBRARY.map((enemy) => decorateEnemy(enemy, attributeSummary));
   const battleHistory = decorateBattleHistory(profile.battleHistory, profile);
   const skillHistory = decorateSkillHistory(profile.skillHistory);
 
@@ -1118,20 +1330,21 @@ function calculateAttributes(attributes, equipment, skills) {
     combinedBase[attr.key] = (Number(base[attr.key]) || 0) + (Number(trained[attr.key]) || 0);
   });
 
-  const equipmentBonus = sumEquipmentBonuses(equipment);
-  const skillEffects = aggregateSkillEffects(skills);
-  const finalStats = {};
+  const equipmentSummary = sumEquipmentBonuses(equipment);
+  const skillSummary = aggregateSkillEffects(skills);
 
+  const baseTotals = {};
   baseConfig.forEach((attr) => {
     const key = attr.key;
-    const baseValue = combinedBase[key] || 0;
-    const equipmentValue = equipmentBonus[key] || 0;
-    const skillAdditive = skillEffects.additive[key] || 0;
-    const multiplier = skillEffects.multipliers[key] || 1;
-    finalStats[key] = formatStatResult(key, (baseValue + equipmentValue + skillAdditive) * multiplier);
+    baseTotals[key] =
+      (combinedBase[key] || 0) + (equipmentSummary.base[key] || 0) + (skillSummary.base[key] || 0);
   });
 
-  const combatPower = calculateCombatPower(finalStats, skillEffects);
+  const realmBonus = attributes.realmBonus || {};
+  const derived = calculateDerivedStatBlock(baseTotals, realmBonus, equipmentSummary, skillSummary);
+  const finalStats = derived.finalStats;
+
+  const combatPower = calculateCombatPower(finalStats, derived.special);
 
   const experience = Math.max(0, Math.floor(Number(attributes.experience) || 0));
   const level = Math.max(1, Math.floor(Number(attributes.level) || 1));
@@ -1181,59 +1394,166 @@ function calculateAttributes(attributes, equipment, skills) {
     experienceProgress: Math.round(expProgress * 100),
     maxLevel,
     combatPower,
-    baseTotals: combinedBase,
-    equipmentBonus,
-    skillBonus: skillEffects.additive,
-    skillMultipliers: skillEffects.multipliers,
+    baseTotals,
+    equipmentBonus: equipmentSummary,
+    skillBonus: skillSummary,
+    derivedSummary: derived,
     skillSummary: {
-      shield: skillEffects.shield,
-      bonusDamage: skillEffects.bonusDamage,
-      dodgeChance: skillEffects.dodgeChance
+      shield: derived.special.shield,
+      bonusDamage: derived.special.bonusDamage,
+      dodgeChance: derived.special.dodgeChance
     },
     finalStats,
     attributeList: baseConfig.map((attr) => ({
       key: attr.key,
       label: attr.label,
       step: attr.step || 1,
-      value: finalStats[attr.key],
-      base: combinedBase[attr.key] || 0,
-      equipment: equipmentBonus[attr.key] || 0,
-      skill: skillEffects.additive[attr.key] || 0,
+      value: baseTotals[attr.key] || 0,
+      base: Number(base[attr.key]) || 0,
+      trained: Number(trained[attr.key]) || 0,
+      equipment: equipmentSummary.base[attr.key] || 0,
+      skill: skillSummary.base[attr.key] || 0,
       type: attr.type,
-      formattedValue: formatStatDisplay(attr.key, finalStats[attr.key]),
-      formattedBase: formatStatDisplay(attr.key, combinedBase[attr.key] || 0),
-      formattedEquipment: formatStatDisplay(attr.key, equipmentBonus[attr.key] || 0, true),
-      formattedSkill: formatSkillBonus(attr.key, skillEffects)
-    }))
+      formattedValue: formatStatDisplay(attr.key, baseTotals[attr.key] || 0),
+      formattedBase: formatStatDisplay(attr.key, Number(base[attr.key]) || 0),
+      formattedTrained: formatStatDisplay(attr.key, Number(trained[attr.key]) || 0, true),
+      formattedEquipment: formatStatDisplay(attr.key, equipmentSummary.base[attr.key] || 0, true),
+      formattedSkill: formatStatDisplay(attr.key, skillSummary.base[attr.key] || 0, true)
+    })),
+    combatStats: COMBAT_STAT_KEYS.map((key) => {
+      const multiplier = derived.combinedMultipliers[key] || 1;
+      return {
+        key,
+        label: resolveCombatStatLabel(key),
+        value: finalStats[key],
+        base: derived.baseStats[key] || 0,
+        equipment: derived.equipmentAdditive[key] || 0,
+        skill: derived.skillAdditive[key] || 0,
+        multiplier,
+        formattedValue: formatStatDisplay(key, finalStats[key]),
+        formattedBase: formatStatDisplay(key, derived.baseStats[key] || 0),
+        formattedEquipment: formatStatDisplay(key, derived.equipmentAdditive[key] || 0, true),
+        formattedSkill: formatStatDisplay(key, derived.skillAdditive[key] || 0, true),
+        formattedMultiplier: multiplier && multiplier !== 1 ? `${Math.round((multiplier - 1) * 10000) / 100}%` : ''
+      };
+    })
   };
 }
 
-function formatSkillBonus(key, skillEffects) {
-  const additive = skillEffects.additive[key] || 0;
-  const multiplier = skillEffects.multipliers[key] || 1;
-  const parts = [];
-  if (additive) {
-    parts.push(formatStatDisplay(key, additive, true));
+function createBonusSummary() {
+  const base = {};
+  BASE_ATTRIBUTE_KEYS.forEach((key) => {
+    base[key] = 0;
+  });
+  const combatAdditive = {};
+  const combatMultipliers = {};
+  COMBAT_STAT_KEYS.forEach((key) => {
+    combatAdditive[key] = 0;
+    combatMultipliers[key] = 1;
+  });
+  return {
+    base,
+    combatAdditive,
+    combatMultipliers,
+    special: { shield: 0, bonusDamage: 0, dodgeChance: 0 }
+  };
+}
+
+function cloneBonusSummary(summary = createBonusSummary()) {
+  const cloned = createBonusSummary();
+  BASE_ATTRIBUTE_KEYS.forEach((key) => {
+    cloned.base[key] = summary.base && typeof summary.base[key] === 'number' ? summary.base[key] : 0;
+  });
+  COMBAT_STAT_KEYS.forEach((key) => {
+    cloned.combatAdditive[key] =
+      summary.combatAdditive && typeof summary.combatAdditive[key] === 'number'
+        ? summary.combatAdditive[key]
+        : 0;
+    cloned.combatMultipliers[key] =
+      summary.combatMultipliers && typeof summary.combatMultipliers[key] === 'number'
+        ? summary.combatMultipliers[key]
+        : 1;
+  });
+  cloned.special.shield = summary.special && typeof summary.special.shield === 'number' ? summary.special.shield : 0;
+  cloned.special.bonusDamage =
+    summary.special && typeof summary.special.bonusDamage === 'number' ? summary.special.bonusDamage : 0;
+  cloned.special.dodgeChance =
+    summary.special && typeof summary.special.dodgeChance === 'number' ? summary.special.dodgeChance : 0;
+  return cloned;
+}
+
+function applyBonus(summary, key, value) {
+  if (!summary || value == null || value === 0) {
+    return;
   }
-  if (multiplier && multiplier !== 1) {
-    const delta = multiplier - 1;
-    parts.push(`${Math.round(delta * 10000) / 100}%`);
+  if (BASE_ATTRIBUTE_KEYS.includes(key)) {
+    summary.base[key] = (summary.base[key] || 0) + value;
+    return;
   }
-  return parts.join(' / ');
+  if (key.endsWith('Multiplier')) {
+    const target = key.replace('Multiplier', '');
+    if (COMBAT_STAT_KEYS.includes(target)) {
+      summary.combatMultipliers[target] = (summary.combatMultipliers[target] || 1) * (1 + value);
+    }
+    return;
+  }
+  if (COMBAT_STAT_KEYS.includes(key)) {
+    summary.combatAdditive[key] = (summary.combatAdditive[key] || 0) + value;
+    return;
+  }
+  if (key === 'shield' || key === 'bonusDamage' || key === 'dodgeChance') {
+    summary.special[key] = (summary.special[key] || 0) + value;
+  }
+}
+
+function mergeBonusSummary(target, source) {
+  if (!source) {
+    return target;
+  }
+  BASE_ATTRIBUTE_KEYS.forEach((key) => {
+    target.base[key] = (target.base[key] || 0) + (source.base[key] || 0);
+  });
+  COMBAT_STAT_KEYS.forEach((key) => {
+    target.combatAdditive[key] = (target.combatAdditive[key] || 0) + (source.combatAdditive[key] || 0);
+    target.combatMultipliers[key] = (target.combatMultipliers[key] || 1) * (source.combatMultipliers[key] || 1);
+  });
+  target.special.shield = (target.special.shield || 0) + (source.special.shield || 0);
+  target.special.bonusDamage = (target.special.bonusDamage || 0) + (source.special.bonusDamage || 0);
+  target.special.dodgeChance = (target.special.dodgeChance || 0) + (source.special.dodgeChance || 0);
+  return target;
+}
+
+function flattenBonusSummary(summary) {
+  const result = {};
+  BASE_ATTRIBUTE_KEYS.forEach((key) => {
+    if (summary.base[key]) {
+      result[key] = summary.base[key];
+    }
+  });
+  COMBAT_STAT_KEYS.forEach((key) => {
+    if (summary.combatAdditive[key]) {
+      result[key] = (result[key] || 0) + summary.combatAdditive[key];
+    }
+    if (summary.combatMultipliers[key] && summary.combatMultipliers[key] !== 1) {
+      result[`${key}Multiplier`] = (summary.combatMultipliers[key] || 1) - 1;
+    }
+  });
+  if (summary.special.shield) {
+    result.shield = (result.shield || 0) + summary.special.shield;
+  }
+  if (summary.special.bonusDamage) {
+    result.bonusDamage = (result.bonusDamage || 0) + summary.special.bonusDamage;
+  }
+  if (summary.special.dodgeChance) {
+    result.dodgeChance = (result.dodgeChance || 0) + summary.special.dodgeChance;
+  }
+  return result;
 }
 
 function sumEquipmentBonuses(equipment) {
-  const result = {
-    hp: 0,
-    attack: 0,
-    defense: 0,
-    speed: 0,
-    luck: 0,
-    critRate: 0,
-    critDamage: 0
-  };
+  const summary = createBonusSummary();
   if (!equipment || typeof equipment !== 'object') {
-    return result;
+    return summary;
   }
   const slots = equipment.slots || {};
   const inventory = Array.isArray(equipment.inventory) ? equipment.inventory : [];
@@ -1250,21 +1570,17 @@ function sumEquipmentBonuses(equipment) {
     const owned = inventoryMap[itemId] || { itemId, refine: 0 };
     const bonus = calculateEquipmentStats(definition, owned.refine || 0);
     Object.keys(bonus).forEach((key) => {
-      result[key] = (result[key] || 0) + (bonus[key] || 0);
+      applyBonus(summary, key, bonus[key]);
     });
   });
-  return result;
+
+  return summary;
 }
 
 function aggregateSkillEffects(skills) {
-  const additive = { hp: 0, attack: 0, defense: 0, speed: 0, luck: 0, critRate: 0, critDamage: 0 };
-  const multipliers = { hp: 1, attack: 1, defense: 1, speed: 1, luck: 1, critRate: 1, critDamage: 1 };
-  let bonusDamage = 0;
-  let shield = 0;
-  let dodgeChance = 0;
-
+  const summary = createBonusSummary();
   if (!skills || typeof skills !== 'object') {
-    return { additive, multipliers, bonusDamage, shield, dodgeChance };
+    return summary;
   }
 
   const inventory = Array.isArray(skills.inventory) ? skills.inventory : [];
@@ -1280,18 +1596,112 @@ function aggregateSkillEffects(skills) {
     const definition = SKILL_MAP[skillId];
     if (!definition) return;
     const effects = resolveSkillEffects(definition, entry.level || 1);
-    Object.keys(effects.additive).forEach((key) => {
-      additive[key] = (additive[key] || 0) + (effects.additive[key] || 0);
-    });
-    Object.keys(effects.multipliers).forEach((key) => {
-      multipliers[key] = (multipliers[key] || 1) * (effects.multipliers[key] || 1);
-    });
-    bonusDamage += effects.bonusDamage || 0;
-    shield += effects.shield || 0;
-    dodgeChance += effects.dodgeChance || 0;
+    mergeBonusSummary(summary, effects);
   });
 
-  return { additive, multipliers, bonusDamage, shield, dodgeChance };
+  return summary;
+}
+
+function resolveCombatStatLabel(key) {
+  return COMBAT_STAT_LABELS[key] || key;
+}
+
+function resolveAttributeLabel(key) {
+  const attr = ATTRIBUTE_CONFIG.find((item) => item.key === key);
+  if (attr) {
+    return attr.label;
+  }
+  return resolveCombatStatLabel(key);
+}
+
+function deriveBaseCombatStats(baseAttributes, realmBonus = {}) {
+  const attributes = baseAttributes || {};
+  const constitution = Number(attributes.constitution) || 0;
+  const strength = Number(attributes.strength) || 0;
+  const spirit = Number(attributes.spirit) || 0;
+  const root = Number(attributes.root) || 0;
+  const agility = Number(attributes.agility) || 0;
+  const insight = Number(attributes.insight) || 0;
+  const stats = {};
+  COMBAT_STAT_KEYS.forEach((key) => {
+    stats[key] = 0;
+  });
+
+  stats.maxHp = 500 + constitution * 100 + root * 20;
+  stats.physicalAttack = 50 + strength * 2;
+  stats.magicAttack = 50 + spirit * 2;
+  stats.physicalDefense = 40 + root * 1 + strength * 0.2;
+  stats.magicDefense = 40 + root * 1 + spirit * 0.2;
+  stats.speed = 80 + agility * 1;
+  stats.accuracy = 100 + insight * 1;
+  stats.dodge = 80 + agility * 0.9 + insight * 0.4;
+  stats.critRate = 0.05 + insight * 0.001;
+  stats.critDamage = 1.5 + insight * 0.0015;
+  stats.finalDamageBonus = 0;
+  stats.finalDamageReduction = Math.min(0.4, root * 0.001 + constitution * 0.0003);
+  stats.lifeSteal = 0;
+  stats.healingBonus = spirit * 0.005;
+  stats.healingReduction = 0;
+  stats.controlHit = insight * 0.5 + spirit * 0.3;
+  stats.controlResist = root * 0.6;
+  stats.physicalPenetration = strength * 0.05;
+  stats.magicPenetration = spirit * 0.05;
+
+  REALM_BONUS_TARGETS.forEach((key) => {
+    if (typeof stats[key] === 'number') {
+      const bonus = realmBonus && typeof realmBonus[key] === 'number' ? realmBonus[key] : 0;
+      if (bonus) {
+        stats[key] = stats[key] * (1 + bonus);
+      }
+    }
+  });
+
+  return stats;
+}
+
+function calculateDerivedStatBlock(baseAttributes, realmBonus, equipmentSummary, skillSummary) {
+  const baseStats = deriveBaseCombatStats(baseAttributes, realmBonus);
+  const finalStats = {};
+  const equipmentAdditive = {};
+  const skillAdditive = {};
+  const equipmentMultipliers = {};
+  const skillMultipliers = {};
+  const combinedAdditive = {};
+  const combinedMultipliers = {};
+
+  COMBAT_STAT_KEYS.forEach((key) => {
+    const eqAdd = equipmentSummary.combatAdditive[key] || 0;
+    const skAdd = skillSummary.combatAdditive[key] || 0;
+    const eqMul = equipmentSummary.combatMultipliers[key] || 1;
+    const skMul = skillSummary.combatMultipliers[key] || 1;
+    equipmentAdditive[key] = eqAdd;
+    skillAdditive[key] = skAdd;
+    equipmentMultipliers[key] = eqMul;
+    skillMultipliers[key] = skMul;
+    combinedAdditive[key] = eqAdd + skAdd;
+    combinedMultipliers[key] = eqMul * skMul;
+    let value = (baseStats[key] || 0) + combinedAdditive[key];
+    value *= combinedMultipliers[key];
+    finalStats[key] = formatStatResult(key, value);
+  });
+
+  const special = {
+    shield: (equipmentSummary.special.shield || 0) + (skillSummary.special.shield || 0),
+    bonusDamage: (equipmentSummary.special.bonusDamage || 0) + (skillSummary.special.bonusDamage || 0),
+    dodgeChance: (equipmentSummary.special.dodgeChance || 0) + (skillSummary.special.dodgeChance || 0)
+  };
+
+  return {
+    finalStats,
+    baseStats,
+    equipmentAdditive,
+    skillAdditive,
+    equipmentMultipliers,
+    skillMultipliers,
+    combinedAdditive,
+    combinedMultipliers,
+    special
+  };
 }
 
 function calculateEquipmentStats(definition, refine = 0) {
@@ -1303,13 +1713,42 @@ function calculateEquipmentStats(definition, refine = 0) {
   Object.keys(definition.stats).forEach((key) => {
     const baseValue = definition.stats[key];
     if (typeof baseValue !== 'number') return;
-    if (key === 'critRate' || key === 'critDamage') {
-      result[key] = Number((baseValue * multiplier).toFixed(4));
-    } else if (key === 'luck') {
-      result[key] = Math.round(baseValue * multiplier);
-    } else {
-      result[key] = Math.round(baseValue * multiplier);
+    const value = baseValue * multiplier;
+    if (
+      BASE_ATTRIBUTE_KEYS.includes(key) ||
+      ['speed', 'accuracy', 'dodge', 'physicalDefense', 'magicDefense', 'physicalAttack', 'magicAttack'].includes(key)
+    ) {
+      result[key] = Math.round(value);
+      return;
     }
+    if (key.endsWith('Multiplier')) {
+      result[key] = Number(value.toFixed(4));
+      return;
+    }
+    if (
+      key === 'critRate' ||
+      key === 'finalDamageBonus' ||
+      key === 'finalDamageReduction' ||
+      key === 'lifeSteal' ||
+      key === 'healingBonus' ||
+      key === 'healingReduction'
+    ) {
+      result[key] = Number(value.toFixed(4));
+      return;
+    }
+    if (key === 'critDamage') {
+      result[key] = Number(value.toFixed(2));
+      return;
+    }
+    if (key === 'bonusDamage' || key === 'shield') {
+      result[key] = Math.round(value);
+      return;
+    }
+    if (key === 'dodgeChance') {
+      result[key] = Number(value.toFixed(4));
+      return;
+    }
+    result[key] = Math.round(value);
   });
   return result;
 }
@@ -1320,84 +1759,70 @@ function resolveSkillEffects(definition, level = 1) {
   const maxLevel = definition.maxLevel || 5;
   const clampedLevel = Math.min(maxLevel, Math.max(1, level));
   const extraLevel = clampedLevel - 1;
-
-  const additive = { hp: 0, attack: 0, defense: 0, speed: 0, luck: 0, critRate: 0, critDamage: 0 };
-  const multipliers = { hp: 1, attack: 1, defense: 1, speed: 1, luck: 1, critRate: 1, critDamage: 1 };
-  let bonusDamage = 0;
-  let shield = 0;
-  let dodgeChance = 0;
+  const summary = createBonusSummary();
 
   Object.keys(effects).forEach((key) => {
-    const baseValue = effects[key];
-    const scalingValue = scaling[key] || 0;
-    const total = baseValue + scalingValue * extraLevel;
-    applySkillEffect(additive, multipliers, key, total);
-    if (key === 'bonusDamage') {
-      bonusDamage += total;
-    } else if (key === 'shield') {
-      shield += total;
-    } else if (key === 'dodgeChance') {
-      dodgeChance += total;
-    }
+    const baseValue = effects[key] || 0;
+    const scaleValue = scaling[key] || 0;
+    const total = baseValue + scaleValue * extraLevel;
+    applyBonus(summary, key, total);
   });
 
   Object.keys(scaling).forEach((key) => {
     if (effects[key]) {
       return;
     }
-    const total = (scaling[key] || 0) * extraLevel;
-    applySkillEffect(additive, multipliers, key, total);
-    if (key === 'bonusDamage') {
-      bonusDamage += total;
-    } else if (key === 'shield') {
-      shield += total;
-    } else if (key === 'dodgeChance') {
-      dodgeChance += total;
-    }
+    const extra = (scaling[key] || 0) * extraLevel;
+    applyBonus(summary, key, extra);
   });
 
-  return { additive, multipliers, bonusDamage, shield, dodgeChance };
+  return summary;
 }
 
-function applySkillEffect(additive, multipliers, key, value) {
-  if (!value) return;
-  if (key.endsWith('Multiplier')) {
-    const target = key.replace('Multiplier', '');
-    multipliers[target] = (multipliers[target] || 1) * (1 + value);
-    return;
-  }
-  if (key === 'critRate' || key === 'critDamage' || key === 'luck') {
-    additive[key] = (additive[key] || 0) + value;
-    return;
-  }
-  if (key === 'hp' || key === 'attack' || key === 'defense' || key === 'speed') {
-    additive[key] = (additive[key] || 0) + value;
-  }
-}
-
-function calculateCombatPower(stats, skillEffects) {
+function calculateCombatPower(stats, special = {}) {
   if (!stats) return 0;
-  const hp = Number(stats.hp) || 0;
-  const attack = Number(stats.attack) || 0;
-  const defense = Number(stats.defense) || 0;
+  const maxHp = Number(stats.maxHp) || 0;
+  const physicalAttack = Number(stats.physicalAttack) || 0;
+  const magicAttack = Number(stats.magicAttack) || 0;
+  const physicalDefense = Number(stats.physicalDefense) || 0;
+  const magicDefense = Number(stats.magicDefense) || 0;
   const speed = Number(stats.speed) || 0;
-  const luck = Number(stats.luck) || 0;
-  const critRate = clamp(Number(stats.critRate) || 0, 0, 1);
-  const critDamage = Math.max(1, Number(stats.critDamage) || 1.5);
-  const shield = skillEffects.shield || 0;
-  const bonusDamage = skillEffects.bonusDamage || 0;
-  const dodgeChance = skillEffects.dodgeChance || 0;
+  const accuracy = Number(stats.accuracy) || 0;
+  const dodge = Number(stats.dodge) || 0;
+  const critRate = clamp(Number(stats.critRate) || 0, 0, 0.95);
+  const critDamage = Math.max(1.2, Number(stats.critDamage) || 1.5);
+  const finalDamageBonus = Number(stats.finalDamageBonus) || 0;
+  const finalDamageReduction = Number(stats.finalDamageReduction) || 0;
+  const lifeSteal = Number(stats.lifeSteal) || 0;
+  const healingBonus = Number(stats.healingBonus) || 0;
+  const controlHit = Number(stats.controlHit) || 0;
+  const controlResist = Number(stats.controlResist) || 0;
+  const physicalPenetration = Number(stats.physicalPenetration) || 0;
+  const magicPenetration = Number(stats.magicPenetration) || 0;
+  const shield = special.shield || 0;
+  const bonusDamage = special.bonusDamage || 0;
+  const dodgeChance = special.dodgeChance || 0;
+
   const power =
-    hp * 0.4 +
-    attack * 2.2 +
-    defense * 1.8 +
-    speed * 1.5 +
-    luck * 1.3 +
-    critRate * 400 +
-    critDamage * 120 +
-    shield * 0.3 +
-    bonusDamage * 1.5 +
-    dodgeChance * 600;
+    maxHp * 0.35 +
+    (physicalAttack + magicAttack) * 1.8 +
+    (physicalDefense + magicDefense) * 1.45 +
+    speed * 1.2 +
+    accuracy * 0.9 +
+    dodge * 2.5 +
+    critRate * 520 +
+    (critDamage - 1) * 180 +
+    finalDamageBonus * 650 -
+    finalDamageReduction * 480 +
+    lifeSteal * 420 +
+    healingBonus * 380 +
+    controlHit * 1.1 +
+    controlResist * 1.1 +
+    physicalPenetration * 2.2 +
+    magicPenetration * 2.2 +
+    shield * 0.25 +
+    bonusDamage * 1.4 +
+    dodgeChance * 620;
   return Math.round(power);
 }
 
@@ -1486,6 +1911,7 @@ function decorateSkillInventoryEntry(entry, profile) {
     return null;
   }
   const effects = resolveSkillEffects(definition, entry.level || 1);
+  const flattened = flattenBonusSummary(effects);
   return {
     skillId: entry.skillId,
     name: definition.name,
@@ -1495,12 +1921,7 @@ function decorateSkillInventoryEntry(entry, profile) {
     description: definition.description,
     level: entry.level || 1,
     maxLevel: resolveSkillMaxLevel(entry.skillId),
-    effectsSummary: formatStatsText({
-      ...effects.additive,
-      bonusDamage: effects.bonusDamage,
-      shield: effects.shield,
-      dodgeChance: effects.dodgeChance
-    }),
+    effectsSummary: formatStatsText(flattened),
     tags: definition.tags || [],
     obtainedAt: entry.obtainedAt,
     obtainedAtText: formatDateTime(entry.obtainedAt),
@@ -1509,13 +1930,9 @@ function decorateSkillInventoryEntry(entry, profile) {
       : false
   };
 }
-function decorateEnemy(enemy, playerStats) {
-  const combatPower = calculateCombatPower(enemy.stats, {
-    shield: 0,
-    bonusDamage: 0,
-    dodgeChance: enemy.stats.dodgeChance || 0
-  });
-  const playerPower = calculateCombatPower(playerStats, { shield: 0, bonusDamage: 0, dodgeChance: 0 });
+function decorateEnemy(enemy, attributeSummary) {
+  const combatPower = calculateCombatPower(enemy.stats, enemy.special || {});
+  const playerPower = calculateCombatPower(attributeSummary.finalStats || {}, attributeSummary.skillSummary || {});
   const difficulty = resolveDifficultyLabel(playerPower, combatPower);
   const rewards = normalizeDungeonRewards(enemy.rewards);
   return {
@@ -1524,6 +1941,7 @@ function decorateEnemy(enemy, playerStats) {
     description: enemy.description,
     level: enemy.level,
     stats: enemy.stats,
+    special: enemy.special || {},
     rewards,
     rewardsText: formatRewardText(rewards),
     loot: decorateEnemyLoot(enemy.loot || []),
@@ -1678,79 +2096,79 @@ function formatStatsText(stats) {
       texts.push(`护盾 +${Math.round(value)}`);
     } else if (key === 'dodgeChance') {
       texts.push(`闪避率 +${Math.round(value * 100)}%`);
+    } else if (key.endsWith('Multiplier')) {
+      const target = key.replace('Multiplier', '');
+      const label = resolveAttributeLabel(target);
+      texts.push(`${label} +${Math.round(value * 10000) / 100}%`);
     } else {
-      texts.push(formatStatDisplay(key, value, true));
+      const label = resolveAttributeLabel(key);
+      texts.push(`${label} ${formatStatDisplay(key, value, true)}`);
     }
   });
   return texts;
 }
 function buildBattleSetup(profile, enemy) {
   const attributes = calculateAttributes(profile.attributes, profile.equipment, profile.skills);
-  const playerStats = {
-    hp: Number(attributes.finalStats.hp) || 0,
-    attack: Number(attributes.finalStats.attack) || 0,
-    defense: Number(attributes.finalStats.defense) || 0,
-    speed: Number(attributes.finalStats.speed) || 0,
-    luck: Number(attributes.finalStats.luck) || 0,
-    critRate: clamp(Number(attributes.finalStats.critRate) || 0, 0, 1),
-    critDamage: Math.max(1.2, Number(attributes.finalStats.critDamage) || 1.5),
-    shield: attributes.skillSummary.shield || 0,
-    bonusDamage: attributes.skillSummary.bonusDamage || 0,
-    dodgeChance: clamp((attributes.skillSummary.dodgeChance || 0) + Math.min(0.15, attributes.finalStats.luck * 0.001), 0, 0.5)
-  };
-
-  const enemyStats = {
-    hp: enemy.stats.hp,
-    attack: enemy.stats.attack,
-    defense: enemy.stats.defense,
-    speed: enemy.stats.speed,
-    critRate: enemy.stats.critRate || 0.08,
-    critDamage: enemy.stats.critDamage || 1.5,
-    dodgeChance: clamp(enemy.stats.dodgeChance || 0, 0, 0.4)
-  };
-
-  return { player: playerStats, enemy: enemyStats, attributes };
+  const player = createPlayerCombatant(attributes);
+  const enemyCombatant = createEnemyCombatant(enemy);
+  return { player, enemy: enemyCombatant, attributes };
 }
 
 function runBattleSimulation({ player, enemy, attributes }) {
   const log = [];
-  let playerHp = player.hp + player.shield;
-  let enemyHp = enemy.hp;
+  const playerStats = player.stats;
+  const enemyStats = enemy.stats;
+  const playerSpecial = player.special || {};
+  const enemySpecial = enemy.special || {};
+  let playerHp = playerStats.maxHp + (playerSpecial.shield || 0);
+  let enemyHp = enemyStats.maxHp + (enemySpecial.shield || 0);
   let round = 1;
   const maxRounds = 30;
-  const playerFirst = player.speed >= enemy.speed;
+  const playerFirst = playerStats.speed >= enemyStats.speed;
   let attacker = playerFirst ? 'player' : 'enemy';
-  const basePlayerDamage = Math.max(5, player.attack - enemy.defense * 0.35);
-  const baseEnemyDamage = Math.max(5, enemy.attack - player.defense * 0.35);
 
   while (playerHp > 0 && enemyHp > 0 && round <= maxRounds) {
     if (attacker === 'player') {
-      const { damage, crit, extra } = calculatePlayerDamage({ player, enemy, basePlayerDamage });
-      enemyHp -= damage;
-      log.push(
-        `第${round}回合：你造成 ${Math.max(0, Math.round(damage))} 点伤害${
-          crit ? '（暴击）' : ''
-        }，敌方剩余 ${Math.max(0, Math.round(enemyHp))}`
-      );
-      if (extra) {
-        log.push(`灵息共鸣触发，额外震荡伤害 ${Math.round(extra)} 点`);
+      const result = executeAttack(playerStats, playerSpecial, enemyStats, enemySpecial);
+      if (result.dodged) {
+        log.push(`第${round}回合：敌方闪避了你的攻势`);
+      } else {
+        enemyHp -= result.damage;
+        log.push(
+          `第${round}回合：你造成 ${Math.max(0, Math.round(result.damage))} 点伤害${
+            result.crit ? '（暴击）' : ''
+          }，敌方剩余 ${Math.max(0, Math.round(enemyHp))}`
+        );
+        if (result.heal > 0) {
+          const healed = Math.min(result.heal, Math.max(0, playerStats.maxHp - playerHp));
+          playerHp = Math.min(playerStats.maxHp, playerHp + result.heal);
+          if (healed > 0) {
+            log.push(`灵血回流，你回复了 ${Math.round(healed)} 点生命`);
+          }
+        }
       }
       attacker = 'enemy';
       if (enemyHp <= 0) {
         break;
       }
     } else {
-      const dodged = Math.random() < player.dodgeChance;
-      if (dodged) {
+      const result = executeAttack(enemyStats, enemySpecial, playerStats, playerSpecial);
+      if (result.dodged) {
         log.push(`第${round}回合：你闪避了敌方的攻势`);
       } else {
-        const { damage, crit } = calculateEnemyDamage({ player, enemy, baseEnemyDamage });
-        playerHp -= damage;
+        playerHp -= result.damage;
         log.push(
-          `第${round}回合：敌方造成 ${Math.max(0, Math.round(damage))} 点伤害${
-            crit ? '（暴击）' : ''
+          `第${round}回合：敌方造成 ${Math.max(0, Math.round(result.damage))} 点伤害${
+            result.crit ? '（暴击）' : ''
           }，你剩余 ${Math.max(0, Math.round(playerHp))}`
         );
+        if (result.heal > 0) {
+          const healed = Math.min(result.heal, Math.max(0, enemyStats.maxHp - enemyHp));
+          enemyHp = Math.min(enemyStats.maxHp, enemyHp + result.heal);
+          if (healed > 0) {
+            log.push(`敌方吸取灵力，回复了 ${Math.round(healed)} 点生命`);
+          }
+        }
       }
       attacker = 'player';
       round += 1;
@@ -1760,7 +2178,7 @@ function runBattleSimulation({ player, enemy, attributes }) {
   const victory = enemyHp <= 0 && playerHp > 0;
   const draw = !victory && playerHp > 0 && enemyHp > 0;
 
-  const rewards = calculateBattleRewards(attributes, enemy, { victory, draw });
+  const rewards = calculateBattleRewards(attributes, enemy.meta || enemy, { victory, draw });
 
   return {
     victory,
@@ -1774,40 +2192,143 @@ function runBattleSimulation({ player, enemy, attributes }) {
     },
     combatPower: {
       player: attributes.combatPower,
-      enemy: calculateCombatPower(enemy, { shield: 0, bonusDamage: 0, dodgeChance: enemy.dodgeChance })
+      enemy: calculateCombatPower(enemyStats, enemySpecial)
     }
   };
 }
 
-function calculatePlayerDamage({ player, enemy, basePlayerDamage }) {
-  const variance = 0.85 + Math.random() * 0.3;
-  const critChance = clamp(player.critRate + Math.min(0.25, player.luck * 0.0025), 0, 0.85);
+function createPlayerCombatant(attributes) {
+  const final = attributes.finalStats || {};
+  const special = attributes.skillSummary || {};
+  return {
+    stats: {
+      maxHp: Number(final.maxHp) || 0,
+      physicalAttack: Number(final.physicalAttack) || 0,
+      magicAttack: Number(final.magicAttack) || 0,
+      physicalDefense: Number(final.physicalDefense) || 0,
+      magicDefense: Number(final.magicDefense) || 0,
+      speed: Number(final.speed) || 0,
+      accuracy: Number(final.accuracy) || 0,
+      dodge: Number(final.dodge) || 0,
+      critRate: clamp(Number(final.critRate) || 0, 0, 0.95),
+      critDamage: Math.max(1.2, Number(final.critDamage) || 1.5),
+      finalDamageBonus: Number(final.finalDamageBonus) || 0,
+      finalDamageReduction: Number(final.finalDamageReduction) || 0,
+      lifeSteal: Number(final.lifeSteal) || 0,
+      healingBonus: Number(final.healingBonus) || 0,
+      healingReduction: Number(final.healingReduction) || 0,
+      controlHit: Number(final.controlHit) || 0,
+      controlResist: Number(final.controlResist) || 0,
+      physicalPenetration: Number(final.physicalPenetration) || 0,
+      magicPenetration: Number(final.magicPenetration) || 0,
+      critResist: Number(final.critResist) || 0
+    },
+    special: {
+      shield: special.shield || 0,
+      bonusDamage: special.bonusDamage || 0,
+      dodgeChance: clamp(special.dodgeChance || 0, 0, 0.5)
+    }
+  };
+}
+
+function createEnemyCombatant(enemy) {
+  const stats = normalizeEnemyStats(enemy.stats || {});
+  const special = enemy.special || {};
+  return {
+    stats,
+    special: {
+      shield: special.shield || 0,
+      bonusDamage: special.bonusDamage || 0,
+      dodgeChance: clamp(special.dodgeChance || 0, 0, 0.6)
+    },
+    meta: enemy
+  };
+}
+
+function normalizeEnemyStats(stats = {}) {
+  return {
+    maxHp: Number(stats.maxHp || stats.hp || 0),
+    physicalAttack: Number(stats.physicalAttack || stats.attack || 0),
+    magicAttack: Number(stats.magicAttack || 0),
+    physicalDefense: Number(stats.physicalDefense || stats.defense || 0),
+    magicDefense: Number(stats.magicDefense || 0),
+    speed: Number(stats.speed || 0),
+    accuracy: Number(stats.accuracy || 110),
+    dodge: Number(stats.dodge || 0),
+    critRate: clamp(Number(stats.critRate || 0.05), 0, 0.95),
+    critDamage: Math.max(1.2, Number(stats.critDamage || 1.5)),
+    finalDamageBonus: Number(stats.finalDamageBonus || 0),
+    finalDamageReduction: Number(stats.finalDamageReduction || 0),
+    lifeSteal: Number(stats.lifeSteal || 0),
+    healingBonus: Number(stats.healingBonus || 0),
+    healingReduction: Number(stats.healingReduction || 0),
+    controlHit: Number(stats.controlHit || 0),
+    controlResist: Number(stats.controlResist || 0),
+    physicalPenetration: Number(stats.physicalPenetration || 0),
+    magicPenetration: Number(stats.magicPenetration || 0),
+    critResist: Number(stats.critResist || 0)
+  };
+}
+
+function executeAttack(attacker, attackerSpecial, defender, defenderSpecial) {
+  const offensiveSpecial = attackerSpecial || {};
+  const defensiveSpecial = defenderSpecial || {};
+  const accuracy = Number(attacker.accuracy || 100);
+  const dodge = Number(defender.dodge || 0);
+  const baseHitChance = clamp(0.85 + (accuracy - dodge) * 0.005, 0.2, 0.99);
+  if (Math.random() > baseHitChance) {
+    return { dodged: true, damage: 0, crit: false, heal: 0 };
+  }
+  if (Math.random() < clamp(defensiveSpecial.dodgeChance || 0, 0, 0.8)) {
+    return { dodged: true, damage: 0, crit: false, heal: 0 };
+  }
+
+  const physicalAttack = Math.max(0, Number(attacker.physicalAttack) || 0);
+  const magicAttack = Math.max(0, Number(attacker.magicAttack) || 0);
+  const physicalPenetrationRating = Math.max(0, Number(attacker.physicalPenetration) || 0);
+  const magicPenetrationRating = Math.max(0, Number(attacker.magicPenetration) || 0);
+  const physicalPenetration = clamp(physicalPenetrationRating * 0.005, 0, 0.6);
+  const magicPenetration = clamp(magicPenetrationRating * 0.005, 0, 0.6);
+
+  const physicalDefense = Math.max(0, Number(defender.physicalDefense) || 0);
+  const magicDefense = Math.max(0, Number(defender.magicDefense) || 0);
+  const effectivePhysicalDefense = physicalDefense * (1 - physicalPenetration);
+  const effectiveMagicDefense = magicDefense * (1 - magicPenetration);
+
+  const basePhysical = physicalAttack > 0 ? Math.max(physicalAttack * 0.25, physicalAttack - effectivePhysicalDefense) : 0;
+  const baseMagic = magicAttack > 0 ? Math.max(magicAttack * 0.25, magicAttack - effectiveMagicDefense) : 0;
+  const usingMagic = baseMagic > basePhysical;
+  let damage = usingMagic ? baseMagic : basePhysical;
+  damage *= 0.9 + Math.random() * 0.2;
+
+  const bonusDamage = Number(offensiveSpecial.bonusDamage) || 0;
+  if (bonusDamage) {
+    damage += bonusDamage;
+  }
+
+  const critChance = clamp((Number(attacker.critRate) || 0) - (Number(defender.critResist) || 0), 0.05, 0.95);
   const crit = Math.random() < critChance;
-  let damage = basePlayerDamage * variance + player.bonusDamage;
   if (crit) {
-    damage *= player.critDamage;
+    damage *= Math.max(1.2, Number(attacker.critDamage) || 1.5);
   }
-  let extra = 0;
-  if (Math.random() < Math.min(0.2, player.luck * 0.002)) {
-    extra = Math.max(10, player.attack * 0.2);
-    damage += extra;
-  }
-  damage = Math.max(8, damage);
-  return { damage, crit, extra };
+
+  const finalDamageBonus = Number(attacker.finalDamageBonus) || 0;
+  const finalDamageReduction = clamp(Number(defender.finalDamageReduction) || 0, 0, 0.9);
+  const finalMultiplier = Math.max(0.1, 1 + finalDamageBonus - finalDamageReduction);
+  damage *= finalMultiplier;
+
+  damage = Math.max(1, damage);
+
+  const lifeSteal = clamp(Number(attacker.lifeSteal) || 0, 0, 0.6);
+  const healingBonus = Number(attacker.healingBonus) || 0;
+  const healingReduction = Number(defender.healingReduction) || 0;
+  const healingMultiplier = clamp(1 + healingBonus - healingReduction, 0, 2);
+  const heal = Math.max(0, damage * lifeSteal * healingMultiplier);
+
+  return { damage, crit, dodged: false, heal };
 }
 
-function calculateEnemyDamage({ player, enemy, baseEnemyDamage }) {
-  const variance = 0.9 + Math.random() * 0.25;
-  const crit = Math.random() < enemy.critRate;
-  let damage = baseEnemyDamage * variance;
-  if (crit) {
-    damage *= enemy.critDamage;
-  }
-  damage = Math.max(6, damage);
-  return { damage, crit };
-}
-
-function calculateBattleRewards(attributes, enemy, { victory, draw }) {
+function calculateBattleRewards(attributes, enemy, { victory, draw, enemyStats }) {
   const rewardConfig = (enemy && enemy.rewards) || {};
   const baseStones = Math.max(0, Math.floor(Number(rewardConfig.stones) || 0));
 
@@ -1820,23 +2341,24 @@ function calculateBattleRewards(attributes, enemy, { victory, draw }) {
     };
   }
 
-  const luckBonus = Math.min(0.3, (attributes.finalStats.luck || 0) * 0.003);
-  const stones = Math.round(baseStones * (1 + luckBonus / 2));
+  const insight = (attributes.baseTotals && attributes.baseTotals.insight) || 0;
+  const insightBonus = Math.min(0.25, insight * 0.002);
+  const stones = Math.round(baseStones * (1 + insightBonus / 2));
   const attributePoints = rewardConfig.attributePoints || 0;
-  const loot = resolveBattleLoot(enemy.loot || [], attributes.finalStats.luck || 0);
+  const loot = resolveBattleLoot(enemy.loot || [], insight);
   return { exp: 0, stones, attributePoints, loot };
 }
 
-function resolveBattleLoot(loot, luck) {
+function resolveBattleLoot(loot, insight) {
   if (!Array.isArray(loot) || !loot.length) {
     return [];
   }
   const results = [];
   loot.forEach((item) => {
     const chance = item.chance || 0;
-    const luckBonus = Math.min(0.2, luck * 0.0015);
+    const insightBonus = Math.min(0.2, insight * 0.0015);
     const roll = Math.random();
-    if (roll < chance + luckBonus) {
+    if (roll < chance + insightBonus) {
       if (item.type === 'equipment' && EQUIPMENT_MAP[item.itemId]) {
         results.push({ type: 'equipment', itemId: item.itemId });
       } else if (item.type === 'skill' && SKILL_MAP[item.skillId]) {
@@ -2040,10 +2562,22 @@ function findAttributeStep(key) {
 
 function formatStatResult(key, value) {
   if (key === 'critRate') {
-    return Number(value.toFixed(4));
+    return Number(Math.max(0, Math.min(0.95, value)).toFixed(4));
   }
   if (key === 'critDamage') {
-    return Number(value.toFixed(2));
+    return Number(Math.max(1.2, value).toFixed(2));
+  }
+  if (key === 'finalDamageBonus') {
+    return Number(Math.max(-0.5, Math.min(1.5, value)).toFixed(4));
+  }
+  if (key === 'finalDamageReduction') {
+    return Number(Math.max(0, Math.min(0.9, value)).toFixed(4));
+  }
+  if (key === 'lifeSteal') {
+    return Number(Math.max(0, Math.min(0.6, value)).toFixed(4));
+  }
+  if (key === 'healingBonus' || key === 'healingReduction') {
+    return Number(value.toFixed(4));
   }
   return Math.round(value);
 }
@@ -2056,6 +2590,15 @@ function formatStatDisplay(key, value, signed = false) {
   }
   if (key === 'critDamage') {
     return `${prefix}${Math.round(abs * 100)}%`;
+  }
+  if (
+    key === 'finalDamageBonus' ||
+    key === 'finalDamageReduction' ||
+    key === 'lifeSteal' ||
+    key === 'healingBonus' ||
+    key === 'healingReduction'
+  ) {
+    return `${prefix}${Math.round(abs * 10000) / 100}%`;
   }
   return `${prefix}${Math.round(abs)}`;
 }


### PR DESCRIPTION
## Summary
- rebalance base dodge rating growth to follow agility and insight contributions from the six-stat model
- enhance attack execution to choose between physical and magical routes, apply penetration as percentage ignores, and pipe life steal through healing modifiers
- tune enemy dodge ratings to the new scale so hit chances remain meaningful

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da5e720d9483309d85a84aef88550c