### PR TITLE
feat: add role respec functionality

### DIFF
--- a/miniprogram/pages/role/index.wxml
+++ b/miniprogram/pages/role/index.wxml
@@ -80,6 +80,23 @@
           <text>战力 {{profile.attributes ? profile.attributes.combatPower : '--'}}</text>
           <text>剩余属性点 {{profile.attributes ? profile.attributes.attributePoints : 0}}</text>
         </view>
+        <view class="attr-respec">
+          <view class="attr-respec__info">
+            <text>
+              洗点次数 {{profile.attributes ? profile.attributes.respecAvailable : 0}} / {{
+                profile.attributes ? profile.attributes.respecLimit : 0
+              }}
+            </text>
+          </view>
+          <button
+            class="pill-btn pill-btn--ghost attr-respec__button"
+            hover-class="pill-btn--hover"
+            size="mini"
+            loading="{{resetting}}"
+            disabled="{{resetting || !(profile.attributes && profile.attributes.respecAvailable > 0)}}"
+            bindtap="handleResetAttributes"
+          >洗点</button>
+        </view>
         <block
           wx:if="{{profile.attributes && profile.attributes.combatStats && profile.attributes.combatStats.length}}"
         >

--- a/miniprogram/pages/role/index.wxss
+++ b/miniprogram/pages/role/index.wxss
@@ -241,6 +241,25 @@ button.pill-btn[disabled] {
   font-size: 24rpx;
 }
 
+.attr-respec {
+  margin-top: 20rpx;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 20rpx;
+  flex-wrap: wrap;
+}
+
+.attr-respec__info {
+  font-size: 24rpx;
+  color: rgba(189, 203, 255, 0.82);
+  flex: 1;
+}
+
+.attr-respec__button {
+  min-width: 150rpx;
+}
+
 .subsection-title {
   margin-top: 32rpx;
   font-size: 26rpx;

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -284,6 +284,9 @@ export const PveService = {
   },
   async allocatePoints(allocations = {}) {
     return callCloud(CLOUD_FUNCTIONS.PVE, { action: 'allocatePoints', allocations });
+  },
+  async resetAttributes() {
+    return callCloud(CLOUD_FUNCTIONS.PVE, { action: 'resetAttributes' });
   }
 };
 


### PR DESCRIPTION
## Summary
- add a consumable-driven wash-point allowance and server-side reset action to PvE profiles
- expose the reset API while including remaining respec metadata in decorated profile responses
- surface wash-point UI controls on the role page so users can spend available respec attempts

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da7633994083309afa86c30f515d4e