### PR TITLE
style: adjust appearance tabs layout

### DIFF
--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -187,7 +187,10 @@
     <view class="modal-mask" bindtap="handleCloseAvatarPicker"></view>
     <view class="modal-content modal-content--avatar">
       <view class="modal-header modal-header--appearance">
-        <view class="modal-title">外观设置</view>
+        <view class="modal-header__row">
+          <view class="modal-title">外观设置</view>
+          <view class="modal-close" bindtap="handleCloseAvatarPicker">×</view>
+        </view>
         <view class="appearance-tabs">
           <view
             class="appearance-tab {{avatarPicker.activeTab === 'avatar' ? 'appearance-tab--active' : ''}}"
@@ -205,13 +208,9 @@
             bindtap="handleAppearanceTabChange"
           >背景</view>
         </view>
-        <view class="modal-close" bindtap="handleCloseAvatarPicker">×</view>
       </view>
       <scroll-view scroll-y="true" class="modal-body modal-body--scroll">
         <view wx:if="{{avatarPicker.activeTab === 'avatar'}}" class="archive-section appearance-section">
-          <view class="archive-section__header">
-            <view class="archive-section__title">可选头像</view>
-          </view>
           <view class="avatar-grid">
             <view
               class="avatar-option {{avatarPicker.avatarUrl === item.url ? 'avatar-option--active' : ''}}"
@@ -226,9 +225,6 @@
           <button class="archive-action" size="mini" bindtap="handleAvatarPickerSyncWechat">同步微信头像</button>
         </view>
         <view wx:elif="{{avatarPicker.activeTab === 'frame'}}" class="archive-section appearance-section">
-          <view class="archive-section__header">
-            <view class="archive-section__title">可选相框</view>
-          </view>
           <view class="avatar-frame-grid">
             <view
               class="avatar-frame-option {{avatarPicker.avatarFrame === item.url ? 'avatar-frame-option--active' : ''}}"
@@ -255,9 +251,6 @@
           </view>
         </view>
         <view wx:else class="archive-section appearance-section appearance-section--background">
-          <view class="archive-section__header">
-            <view class="archive-section__title">可选背景</view>
-          </view>
           <view class="appearance-background-grid">
             <view
               class="appearance-background-option {{avatarPicker.backgroundId === item.id ? 'appearance-background-option--active' : ''}} {{!item.unlocked ? 'appearance-background-option--locked' : ''}}"

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -411,6 +411,7 @@ page {
   padding: 32rpx 36rpx 28rpx;
 }
 
+
 .modal-header {
   display: flex;
   justify-content: space-between;
@@ -419,35 +420,37 @@ page {
 }
 
 .modal-header--appearance {
-  align-items: flex-end;
+  flex-direction: column;
+  align-items: stretch;
   gap: 16rpx;
 }
 
-.modal-header--appearance .modal-title {
-  flex-shrink: 0;
+.modal-header__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .appearance-tabs {
   display: flex;
   flex: 1;
-  justify-content: center;
-  gap: 16rpx;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 40rpx;
+  height: 64rpx;
 }
 
 .appearance-tab {
-  padding: 8rpx 28rpx;
-  border-radius: 26rpx;
-  background: rgba(239, 242, 255, 0.12);
-  color: rgba(255, 255, 255, 0.6);
-  font-size: 26rpx;
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 28rpx;
   letter-spacing: 2rpx;
-  transition: all 0.2s ease;
+  transition: color 0.2s ease, font-size 0.2s ease;
 }
 
 .appearance-tab--active {
-  background: linear-gradient(120deg, #7b5bff, #b07bff);
+  font-size: 34rpx;
+  font-weight: 700;
   color: #ffffff;
-  box-shadow: 0 8rpx 16rpx rgba(123, 91, 255, 0.35);
 }
 
 .modal-title {


### PR DESCRIPTION
## Summary
- move the appearance tabs onto their own row beneath the header title for better alignment
- dim inactive appearance tab labels while keeping the active tab bold and prominent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dad663528483308dcecdff1580a181