### PR TITLE
fix: ensure cloud assets load via cdn urls

### DIFF
--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -18,8 +18,7 @@ const {
   getDefaultBackgroundId,
   isBackgroundUnlocked
 } = require('../../shared/backgrounds.js');
-
-const CHARACTER_IMAGE_BASE_PATH = '../../assets/character';
+const { CHARACTER_IMAGE_BASE_PATH } = require('../../shared/asset-paths.js');
 const { listAvatarIds: listAllAvatarIds } = require('../../shared/avatar-catalog.js');
 
 function buildCharacterImageMap() {

--- a/miniprogram/shared/asset-paths.js
+++ b/miniprogram/shared/asset-paths.js
@@ -1,0 +1,73 @@
+const CLOUD_ASSET_FILE_ID_BASE_PATH =
+  'cloud://cloud1-8gyoxq651fcc92c2.636c-cloud1-8gyoxq651fcc92c2-1380371219/assets';
+
+function trimSlashes(value) {
+  return `${value}`.replace(/(^\/+|\/+$)/g, '');
+}
+
+function joinPath(base, ...segments) {
+  const safeBase = `${base}`.replace(/\/+$/g, '');
+  const rest = segments
+    .map((segment) => trimSlashes(segment))
+    .filter(Boolean)
+    .join('/');
+  return rest ? `${safeBase}/${rest}` : safeBase;
+}
+
+function parseFileIdBase(base) {
+  const normalized = `${base}`.trim();
+  if (!normalized.startsWith('cloud://')) {
+    return { envId: '', bucket: '', rootPath: trimSlashes(normalized) };
+  }
+  const withoutScheme = normalized.replace(/^cloud:\/\//, '');
+  const dotIndex = withoutScheme.indexOf('.');
+  if (dotIndex === -1) {
+    return { envId: '', bucket: '', rootPath: '' };
+  }
+  const envId = withoutScheme.slice(0, dotIndex);
+  const remainder = withoutScheme.slice(dotIndex + 1);
+  const slashIndex = remainder.indexOf('/');
+  if (slashIndex === -1) {
+    return { envId, bucket: trimSlashes(remainder), rootPath: '' };
+  }
+  const bucket = trimSlashes(remainder.slice(0, slashIndex));
+  const rootPath = trimSlashes(remainder.slice(slashIndex + 1));
+  return { envId, bucket, rootPath };
+}
+
+const { bucket: CLOUD_ASSET_BUCKET, rootPath: CLOUD_ASSET_ROOT_PATH } =
+  parseFileIdBase(CLOUD_ASSET_FILE_ID_BASE_PATH);
+
+const CLOUD_ASSET_CDN_BASE_PATH = CLOUD_ASSET_BUCKET
+  ? joinPath(`https://${CLOUD_ASSET_BUCKET}.tcb.qcloud.la`, CLOUD_ASSET_ROOT_PATH)
+  : '';
+
+function buildCloudAssetFileId(...segments) {
+  return joinPath(CLOUD_ASSET_FILE_ID_BASE_PATH, ...segments);
+}
+
+function buildCloudAssetCdnUrl(...segments) {
+  if (!CLOUD_ASSET_CDN_BASE_PATH) {
+    return buildCloudAssetFileId(...segments);
+  }
+  return joinPath(CLOUD_ASSET_CDN_BASE_PATH, ...segments);
+}
+
+const BACKGROUND_IMAGE_FILE_ID_BASE_PATH = buildCloudAssetFileId('background');
+const CHARACTER_IMAGE_FILE_ID_BASE_PATH = buildCloudAssetFileId('character');
+
+const BACKGROUND_IMAGE_BASE_PATH = buildCloudAssetCdnUrl('background');
+const CHARACTER_IMAGE_BASE_PATH = buildCloudAssetCdnUrl('character');
+
+module.exports = {
+  CLOUD_ASSET_FILE_ID_BASE_PATH,
+  CLOUD_ASSET_CDN_BASE_PATH,
+  CLOUD_ASSET_BUCKET,
+  CLOUD_ASSET_ROOT_PATH,
+  BACKGROUND_IMAGE_FILE_ID_BASE_PATH,
+  CHARACTER_IMAGE_FILE_ID_BASE_PATH,
+  BACKGROUND_IMAGE_BASE_PATH,
+  CHARACTER_IMAGE_BASE_PATH,
+  buildCloudAssetFileId,
+  buildCloudAssetCdnUrl
+};

--- a/miniprogram/shared/backgrounds.js
+++ b/miniprogram/shared/backgrounds.js
@@ -1,4 +1,7 @@
-const BACKGROUND_IMAGE_BASE_PATH = '/assets/background';
+const {
+  BACKGROUND_IMAGE_BASE_PATH,
+  buildCloudAssetFileId
+} = require('./asset-paths.js');
 
 const RAW_BACKGROUNDS = [
   { id: 'realm_refining', realmOrder: 1, realmName: '炼气期', name: '炼气之地' },
@@ -24,10 +27,14 @@ function resolveImageIndex(realmOrder) {
   return ((normalizedOrder - 1) % availableCount) + 1;
 }
 
-const BACKGROUNDS = RAW_BACKGROUNDS.map((item) => ({
-  ...item,
-  image: `${BACKGROUND_IMAGE_BASE_PATH}/${resolveImageIndex(item.realmOrder)}.jpg`
-}));
+const BACKGROUNDS = RAW_BACKGROUNDS.map((item) => {
+  const fileName = `${resolveImageIndex(item.realmOrder)}.jpg`;
+  return {
+    ...item,
+    image: `${BACKGROUND_IMAGE_BASE_PATH}/${fileName}`,
+    imageFileId: buildCloudAssetFileId('background', fileName)
+  };
+});
 
 function cloneBackground(background) {
   return background ? { ...background } : null;


### PR DESCRIPTION
## Summary
- derive the CDN domain from the cloud file ID base so background and character images use HTTPS URLs
- keep background metadata while pointing image fields at the CDN resources to ensure the avatar picker renders correctly
- document that the runtime now converts `cloud://` file IDs to CDN URLs for reliable loading in experience and release builds

## Testing
- not run (mini program project)

------
https://chatgpt.com/codex/tasks/task_e_68dae3a259d0833093bfef017e084856