### PR TITLE
feat: switch asset urls to cloud storage

### DIFF
--- a/cloudfunctions/member/avatar-frames.local.js
+++ b/cloudfunctions/member/avatar-frames.local.js
@@ -1,7 +1,12 @@
-const AVATAR_FRAME_BASE_PATH = '/assets/border';
+const AVATAR_FRAME_BASE_PATH =
+  'cloud://cloud1-8gyoxq651fcc92c2.636c-cloud1-8gyoxq651fcc92c2-1380371219/assets/border';
+const LEGACY_AVATAR_FRAME_BASE_PATH = '/assets/border';
 const AVATAR_FRAME_IDS = ['1', '2', '3'];
 
 const AVATAR_FRAME_URLS = AVATAR_FRAME_IDS.map((id) => `${AVATAR_FRAME_BASE_PATH}/${id}.png`);
+const LEGACY_AVATAR_FRAME_URLS = AVATAR_FRAME_IDS.map((id) => `${LEGACY_AVATAR_FRAME_BASE_PATH}/${id}.png`);
+
+const LEGACY_AVATAR_FRAME_URL_PATTERN = /^\/?assets\/border\/([1-9]\d*)\.png$/i;
 
 function listAvatarFrameUrls() {
   return AVATAR_FRAME_URLS.slice();
@@ -29,7 +34,17 @@ function isValidAvatarFrameUrl(url) {
   if (!trimmed) {
     return false;
   }
-  return AVATAR_FRAME_URLS.includes(trimmed);
+  if (AVATAR_FRAME_URLS.includes(trimmed)) {
+    return true;
+  }
+  if (LEGACY_AVATAR_FRAME_URLS.includes(trimmed)) {
+    return true;
+  }
+  const match = trimmed.match(LEGACY_AVATAR_FRAME_URL_PATTERN);
+  if (!match) {
+    return false;
+  }
+  return AVATAR_FRAME_IDS.includes(match[1]);
 }
 
 function normalizeAvatarFrameValue(value) {
@@ -42,6 +57,10 @@ function normalizeAvatarFrameValue(value) {
   }
   if (AVATAR_FRAME_URLS.includes(trimmed)) {
     return trimmed;
+  }
+  const legacyMatch = trimmed.match(LEGACY_AVATAR_FRAME_URL_PATTERN);
+  if (legacyMatch && AVATAR_FRAME_IDS.includes(legacyMatch[1])) {
+    return buildAvatarFrameUrlById(legacyMatch[1]);
   }
   const byId = buildAvatarFrameUrlById(trimmed);
   if (byId) {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -79,7 +79,7 @@ Error: TencentCloud API error: {
 
 **解决方案**
 
-自 2024-05-10 起，首页会使用头像目录的统一清单（`shared/avatar-catalog.js`）动态生成角色图映射。只要为头像与角色图提供同名 PNG 资源（例如头像 `assets/avatar/male-b-1.png` 与角色图 `assets/character/male-b-1.png`），即可自动生效，无需再次修改前端页面代码。
+自 2024-05-10 起，首页会使用头像目录的统一清单（`shared/avatar-catalog.js`）动态生成角色图映射。只要为头像与角色图提供同名 PNG 资源（例如头像 `cloud://cloud1-8gyoxq651fcc92c2.636c-cloud1-8gyoxq651fcc92c2-1380371219/assets/avatar/male-b-1.png` 与角色图 `cloud://cloud1-8gyoxq651fcc92c2.636c-cloud1-8gyoxq651fcc92c2-1380371219/assets/character/male-b-1.png`），即可自动生效，无需再次修改前端页面代码。
 
 > 补充：新增头像时仍需按照既定流程更新头像清单（`shared/avatar-catalog.js`），以便头像选择器、解锁逻辑及角色图映射同时感知新资源。
 
@@ -95,10 +95,12 @@ Error: TencentCloud API error: {
 
 **解决方案**
 
-1. 将这两类静态资源上传到云开发的存储空间，保持目录结构不变，例如当前环境使用的：
+1. 将静态资源上传到云开发的存储空间，保持目录结构不变，例如当前环境使用的：
    - `cloud://cloud1-8gyoxq651fcc92c2.636c-cloud1-8gyoxq651fcc92c2-1380371219/assets/background/`
    - `cloud://cloud1-8gyoxq651fcc92c2.636c-cloud1-8gyoxq651fcc92c2-1380371219/assets/character/`
-2. 在前端代码中统一改为引用云存储路径。仓库已新增 `miniprogram/shared/asset-paths.js`，用于集中维护云端基础路径，并被首页背景与角色图逻辑复用。
+   - `cloud://cloud1-8gyoxq651fcc92c2.636c-cloud1-8gyoxq651fcc92c2-1380371219/assets/avatar/`
+   - `cloud://cloud1-8gyoxq651fcc92c2.636c-cloud1-8gyoxq651fcc92c2-1380371219/assets/border/`
+2. 在前端代码中统一改为引用云存储路径。仓库已新增 `miniprogram/shared/asset-paths.js`，用于集中维护云端基础路径，并被首页背景、角色图、头像与相框逻辑复用。
 3. 日后新增背景/角色素材时，只需：
    - 将文件上传至对应云端目录；
    - 确保文件名与本地约定一致（例如 `1.jpg`、`male-b-1.png`）；

--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -18,8 +18,13 @@ const {
   getDefaultBackgroundId,
   isBackgroundUnlocked
 } = require('../../shared/backgrounds.js');
-const { CHARACTER_IMAGE_BASE_PATH } = require('../../shared/asset-paths.js');
+const {
+  CHARACTER_IMAGE_BASE_PATH,
+  AVATAR_IMAGE_BASE_PATH
+} = require('../../shared/asset-paths.js');
 const { listAvatarIds: listAllAvatarIds } = require('../../shared/avatar-catalog.js');
+
+const LEGACY_AVATAR_URL_PATTERN = /^\/?assets\/avatar\/((male|female)-[a-z]+-\d+)\.png$/i;
 
 function buildCharacterImageMap() {
   const ids = listAllAvatarIds();
@@ -368,6 +373,10 @@ function sanitizeAvatarUrl(url) {
   let sanitized = url.trim();
   if (!sanitized) {
     return '';
+  }
+  const legacyMatch = sanitized.match(LEGACY_AVATAR_URL_PATTERN);
+  if (legacyMatch) {
+    return `${AVATAR_IMAGE_BASE_PATH}/${legacyMatch[1]}.png`;
   }
   if (!sanitized.startsWith('data:')) {
     sanitized = sanitized.replace(/^http:\/\//i, 'https://');

--- a/miniprogram/shared/asset-paths.js
+++ b/miniprogram/shared/asset-paths.js
@@ -1,6 +1,8 @@
 const CLOUD_ASSET_BASE_PATH =
   'cloud://cloud1-8gyoxq651fcc92c2.636c-cloud1-8gyoxq651fcc92c2-1380371219/assets';
 
+const LEGACY_ASSET_BASE_PATH = '/assets';
+
 function buildCloudAssetUrl(...segments) {
   return [CLOUD_ASSET_BASE_PATH, ...segments]
     .map((segment) => `${segment}`.replace(/(^\/+|\/+$)/g, ''))
@@ -10,10 +12,15 @@ function buildCloudAssetUrl(...segments) {
 
 const BACKGROUND_IMAGE_BASE_PATH = buildCloudAssetUrl('background');
 const CHARACTER_IMAGE_BASE_PATH = buildCloudAssetUrl('character');
+const AVATAR_IMAGE_BASE_PATH = buildCloudAssetUrl('avatar');
+const AVATAR_FRAME_BASE_PATH = buildCloudAssetUrl('border');
 
 module.exports = {
   CLOUD_ASSET_BASE_PATH,
+  LEGACY_ASSET_BASE_PATH,
   BACKGROUND_IMAGE_BASE_PATH,
   CHARACTER_IMAGE_BASE_PATH,
+  AVATAR_IMAGE_BASE_PATH,
+  AVATAR_FRAME_BASE_PATH,
   buildCloudAssetUrl
 };

--- a/miniprogram/shared/avatar-frames.js
+++ b/miniprogram/shared/avatar-frames.js
@@ -1,7 +1,15 @@
-const AVATAR_FRAME_BASE_PATH = '/assets/border';
+const {
+  AVATAR_FRAME_BASE_PATH,
+  LEGACY_ASSET_BASE_PATH
+} = require('./asset-paths.js');
+
+const LEGACY_AVATAR_FRAME_BASE_PATH = `${LEGACY_ASSET_BASE_PATH}/border`;
 const AVATAR_FRAME_IDS = ['1', '2', '3'];
 
 const AVATAR_FRAME_URLS = AVATAR_FRAME_IDS.map((id) => `${AVATAR_FRAME_BASE_PATH}/${id}.png`);
+const LEGACY_AVATAR_FRAME_URLS = AVATAR_FRAME_IDS.map((id) => `${LEGACY_AVATAR_FRAME_BASE_PATH}/${id}.png`);
+
+const LEGACY_AVATAR_FRAME_URL_PATTERN = /^\/?assets\/border\/([1-9]\d*)\.png$/i;
 
 function listAvatarFrameUrls() {
   return AVATAR_FRAME_URLS.slice();
@@ -29,7 +37,17 @@ function isValidAvatarFrameUrl(url) {
   if (!trimmed) {
     return false;
   }
-  return AVATAR_FRAME_URLS.includes(trimmed);
+  if (AVATAR_FRAME_URLS.includes(trimmed)) {
+    return true;
+  }
+  if (LEGACY_AVATAR_FRAME_URLS.includes(trimmed)) {
+    return true;
+  }
+  const match = trimmed.match(LEGACY_AVATAR_FRAME_URL_PATTERN);
+  if (!match) {
+    return false;
+  }
+  return AVATAR_FRAME_IDS.includes(match[1]);
 }
 
 function normalizeAvatarFrameValue(value) {
@@ -42,6 +60,10 @@ function normalizeAvatarFrameValue(value) {
   }
   if (AVATAR_FRAME_URLS.includes(trimmed)) {
     return trimmed;
+  }
+  const legacyMatch = trimmed.match(LEGACY_AVATAR_FRAME_URL_PATTERN);
+  if (legacyMatch && AVATAR_FRAME_IDS.includes(legacyMatch[1])) {
+    return buildAvatarFrameUrlById(legacyMatch[1]);
   }
   const byId = buildAvatarFrameUrlById(trimmed);
   if (byId) {

--- a/miniprogram/utils/avatar-catalog.js
+++ b/miniprogram/utils/avatar-catalog.js
@@ -1,4 +1,9 @@
-const { RAW_AVATARS, buildAvatarId, listAvatarIds } = require('../shared/avatar-catalog.js');
+const {
+  RAW_AVATARS,
+  buildAvatarId,
+  listAvatarIds
+} = require('../shared/avatar-catalog.js');
+const { AVATAR_IMAGE_BASE_PATH } = require('../shared/asset-paths.js');
 
 const AVATAR_GENDER_LABELS = {
   male: '男',
@@ -29,7 +34,7 @@ function buildAvatarName({ gender, rarity, index }) {
 }
 
 function buildAvatarUrl(id) {
-  return `/assets/avatar/${id}.png`;
+  return `${AVATAR_IMAGE_BASE_PATH}/${id}.png`;
 }
 
 export const AVATAR_CATALOG = RAW_AVATARS.map((item) => {


### PR DESCRIPTION
## Summary
- point avatar catalog, profile sanitizer, and frame utilities to the cloud asset base paths
- keep backward compatibility with legacy local asset URLs and document the cloud directories

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daf70b68f08330b2c6a421dea4d178