### PR TITLE
Smooth dynamic background transitions

### DIFF
--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -530,6 +530,7 @@ Page({
     backgroundImage: resolveBackgroundImage(null),
     backgroundVideo: resolveBackgroundVideo(null),
     showBackgroundVideo: false,
+    showBackgroundOverlay: true,
     backgroundVideoError: false,
     dynamicBackgroundEnabled: false,
     navHeight: 88,
@@ -622,11 +623,13 @@ Page({
     const { image, video, dynamicEnabled } = resolveBackgroundDisplay(member);
     const shouldShowVideo = dynamicEnabled && !!video;
     const hasError = shouldShowVideo ? (options.resetError ? false : !!this.data.backgroundVideoError) : false;
+    const showVideo = hasError ? false : shouldShowVideo;
     this.setData({
       backgroundImage: image,
       backgroundVideo: video,
       dynamicBackgroundEnabled: dynamicEnabled,
-      showBackgroundVideo: hasError ? false : shouldShowVideo,
+      showBackgroundVideo: showVideo,
+      showBackgroundOverlay: !showVideo,
       backgroundVideoError: hasError
     });
   },
@@ -637,7 +640,8 @@ Page({
     }
     this.setData({
       backgroundVideoError: true,
-      showBackgroundVideo: false
+      showBackgroundVideo: false,
+      showBackgroundOverlay: true
     });
   },
 

--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -11,9 +11,10 @@
     class="background background--video background-layer {{showBackgroundVideo ? 'background-layer--visible' : ''}}"
   >
     <video
+      id="backgroundVideo"
       class="background-video background-layer {{showBackgroundVideo ? 'background-layer--visible' : ''}}"
       src="{{backgroundVideo}}"
-      autoplay
+      autoplay="{{showBackgroundVideo}}"
       loop
       muted
       controls="{{false}}"

--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -6,9 +6,12 @@
       mode="aspectFill"
     ></image>
   </view>
-  <view wx:if="{{showBackgroundVideo}}" class="background background--video">
+  <view
+    wx:if="{{backgroundVideo}}"
+    class="background background--video background-layer {{showBackgroundVideo ? 'background-layer--visible' : ''}}"
+  >
     <video
-      class="background-video"
+      class="background-video background-layer {{showBackgroundVideo ? 'background-layer--visible' : ''}}"
       src="{{backgroundVideo}}"
       autoplay
       loop
@@ -24,9 +27,11 @@
       binderror="handleBackgroundVideoError"
     ></video>
   </view>
-  <view wx:if="{{!dynamicBackgroundEnabled}}" class="background background--overlay"></view>
-  <view wx:if="{{!dynamicBackgroundEnabled}}" class="mist-layer mist-layer--one"></view>
-  <view wx:if="{{!dynamicBackgroundEnabled}}" class="mist-layer mist-layer--two"></view>
+  <view
+    class="background background--overlay background-layer {{showBackgroundOverlay ? 'background-layer--visible' : ''}}"
+  ></view>
+  <view class="mist-layer mist-layer--one background-layer {{showBackgroundOverlay ? 'background-layer--visible' : ''}}"></view>
+  <view class="mist-layer mist-layer--two background-layer {{showBackgroundOverlay ? 'background-layer--visible' : ''}}"></view>
 
   <custom-nav title="会员中心" enable-back="{{false}}" theme="transparent"></custom-nav>
 

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -24,6 +24,15 @@ page {
   pointer-events: none;
 }
 
+.background-layer {
+  opacity: 0;
+  transition: opacity 360ms ease;
+}
+
+.background-layer--visible {
+  opacity: 1;
+}
+
 
 .background--fallback {
   overflow: hidden;
@@ -66,6 +75,7 @@ page {
   z-index: 1;
   animation: drift 18s linear infinite;
   opacity: 0.4;
+  pointer-events: none;
 }
 
 .mist-layer--one {

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -26,7 +26,7 @@ page {
 
 .background-layer {
   opacity: 0;
-  transition: opacity 360ms ease;
+  transition: opacity 3600ms ease;
 }
 
 .background-layer--visible {


### PR DESCRIPTION
## Summary
- track overlay visibility alongside the video so toggling dynamic backgrounds can fade layers smoothly
- add transition classes to the background video and mask layers to create a softer enable/disable animation
- keep mist overlays non-interactive while transitioning to avoid blocking foreground content

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68db638bdd948330813943a674c3d114