### PR TITLE
feat: open role equipment tooltip on tap

### DIFF
--- a/miniprogram/pages/role/index.js
+++ b/miniprogram/pages/role/index.js
@@ -215,16 +215,31 @@ Page({
     }
   },
 
-  handleEquipmentLongPress(event) {
+  handleEquipmentTap(event) {
     const dataset = (event && event.currentTarget && event.currentTarget.dataset) || {};
     const rawItem = dataset.item;
     if (!rawItem) {
+      this.closeEquipmentTooltip();
+      return;
+    }
+    const slot = (typeof dataset.slot === 'string' && dataset.slot.trim()) || rawItem.slot || '';
+    const source = dataset.source || 'inventory';
+    const currentTooltip = this.data && this.data.equipmentTooltip;
+    if (
+      currentTooltip &&
+      currentTooltip.item &&
+      rawItem.itemId &&
+      currentTooltip.item.itemId === rawItem.itemId &&
+      currentTooltip.source === source &&
+      currentTooltip.slot === slot
+    ) {
+      this.closeEquipmentTooltip();
       return;
     }
     const tooltip = {
       visible: true,
-      source: dataset.source || 'inventory',
-      slot: (typeof dataset.slot === 'string' && dataset.slot.trim()) || rawItem.slot || '',
+      source,
+      slot,
       slotLabel: dataset.slotLabel || rawItem.slotLabel || '',
       item: { ...rawItem }
     };

--- a/miniprogram/pages/role/index.wxml
+++ b/miniprogram/pages/role/index.wxml
@@ -129,7 +129,7 @@
             <view
               class="slot-card__icon"
               style="border-color: {{item.item ? item.item.qualityColor : 'rgba(86, 110, 210, 0.48)'}};"
-              bindlongpress="handleEquipmentLongPress"
+              bindtap="handleEquipmentTap"
               data-source="slot"
               data-slot="{{item.slot}}"
               data-slot-label="{{item.slotLabel}}"
@@ -177,7 +177,7 @@
               <view
                 class="inventory-card__icon"
                 style="border-color: {{item.qualityColor}};"
-                bindlongpress="handleEquipmentLongPress"
+                bindtap="handleEquipmentTap"
                 data-source="inventory"
                 data-slot="{{item.slot}}"
                 data-item="{{item}}"


### PR DESCRIPTION
## Summary
- open the equipment tooltip on tap instead of requiring a long press in the role page
- close the tooltip when tapping the same equipment again for quicker toggling

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dce7ceec8c8330a5f08a562ef37bf3