### PR TITLE
Refine storage tabs and upgrade flow

### DIFF
--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -36,8 +36,8 @@ const app = getApp();
 const BASE_NAV_ITEMS = [
   { icon: '🧝', label: '角色', url: '/pages/role/index?tab=character' },
   { icon: '🛡️', label: '装备', url: '/pages/role/index?tab=equipment' },
+  { icon: '💍', label: '纳戒', url: '/pages/role/index?tab=storage' },
   { icon: '📜', label: '技能', url: '/pages/role/index?tab=skill' },
-  { icon: '🎁', label: '权益', url: '/pages/rights/rights' },
   { icon: '📅', label: '预订', url: '/pages/reservation/reservation' },
   { icon: '💰', label: '钱包', url: '/pages/wallet/wallet' },
   { icon: '🧙‍♀️', label: '造型', url: '/pages/avatar/avatar' }

--- a/miniprogram/pages/role/index.wxml
+++ b/miniprogram/pages/role/index.wxml
@@ -14,6 +14,12 @@
       bindtap="handleTabChange"
     >装备</view>
     <view
+      class="tab-item {{activeTab === 'storage' ? 'tab-item--active' : ''}}"
+      data-tab="storage"
+      hover-class="tab-item--hover"
+      bindtap="handleTabChange"
+    >纳戒</view>
+    <view
       class="tab-item {{activeTab === 'skill' ? 'tab-item--active' : ''}}"
       data-tab="skill"
       hover-class="tab-item--hover"
@@ -112,6 +118,87 @@
       </view>
     </block>
 
+    <block wx:elif="{{activeTab === 'storage'}}">
+      <view class="section-card storage-section">
+        <view class="section-header">
+          <view class="section-title">纳戒储物</view>
+        </view>
+        <view wx:if="{{storageCategories.length}}" class="storage-tabs">
+          <view
+            wx:for="{{storageCategories}}"
+            wx:key="key"
+            class="storage-tab {{activeStorageCategory === item.key ? 'storage-tab--active' : ''}}"
+            data-key="{{item.key}}"
+            bindtap="handleStorageCategoryChange"
+          >
+            <text class="storage-tab__label">{{item.label}}</text>
+          </view>
+        </view>
+        <block wx:if="{{activeStorageCategoryData}}">
+          <view class="storage-summary">
+            <view class="storage-summary__line">
+              <text>已用 {{storageMetadata ? storageMetadata.totalItems : activeStorageCategoryData.items.length}} / {{storageMetadata ? storageMetadata.capacity : activeStorageCategoryData.capacity}}</text>
+              <text>剩余 {{storageMetadata ? storageMetadata.remainingSlots : activeStorageCategoryData.remaining}}</text>
+            </view>
+            <progress
+              class="storage-summary__progress"
+              percent="{{storageMetadata ? storageMetadata.usagePercent : activeStorageCategoryData.usagePercent}}"
+              stroke-width="6"
+              backgroundColor="#1b2036"
+              activeColor="#566ed2"
+              show-info="{{false}}"
+            ></progress>
+            <view class="storage-summary__actions">
+              <button
+                class="pill-btn pill-btn--primary storage-summary__upgrade"
+                hover-class="pill-btn--primary-hover"
+                size="mini"
+                loading="{{storageUpgrading}}"
+                disabled="{{storageUpgrading}}"
+                bindtap="handleUpgradeStorage"
+              >升级储物空间</button>
+              <view class="storage-summary__info">
+                <text wx:if="{{storageMetadata && storageMetadata.remainingUpgrades !== null}}"
+                  >剩余升级次数 {{storageMetadata.remainingUpgrades}}</text
+                >
+                <text class="storage-summary__hint"
+                  >下次升级容量
+                  {{storageMetadata ? storageMetadata.nextCapacity : activeStorageCategoryData.nextCapacity}}</text
+                >
+              </view>
+            </view>
+          </view>
+          <view class="storage-grid">
+            <block wx:for="{{activeStorageCategoryData.slots}}" wx:key="storageKey">
+              <view wx:if="{{!item.placeholder}}" class="storage-slot">
+                <view class="storage-slot__badge">{{item.slotLabel}}</view>
+                <view
+                  class="storage-slot__frame"
+                  hover-class="storage-slot__frame--hover"
+                  bindtap="handleEquipmentTap"
+                  data-source="storage"
+                  data-slot="{{item.slot}}"
+                  data-slot-label="{{item.slotLabel}}"
+                  data-item="{{item}}"
+                  data-inventory-id="{{item.inventoryId || ''}}"
+                >
+                  <view class="storage-slot__icon" style="border-color: {{item.qualityColor}};">
+                    <view class="storage-slot__name">{{item.shortName || item.name}}</view>
+                  </view>
+                </view>
+              </view>
+              <view wx:else class="storage-slot storage-slot--empty">
+                <view class="storage-slot__frame storage-slot__frame--empty">
+                  <view class="storage-slot__placeholder">空</view>
+                </view>
+              </view>
+            </block>
+          </view>
+        </block>
+        <view wx:else class="empty-tip storage-empty">暂无储物数据</view>
+      </view>
+    </block>
+
     <block wx:elif="{{activeTab === 'equipment'}}">
       <view class="section-card">
         <view class="section-header">
@@ -170,7 +257,7 @@
           <view
             class="inventory-card {{item.equipped ? 'inventory-card--equipped' : ''}}"
             wx:for="{{(profile.equipment && profile.equipment.inventory) || []}}"
-            wx:key="itemId"
+            wx:key="inventoryId"
           >
             <view class="inventory-card__badge">{{item.slotLabel}}</view>
             <view class="inventory-card__frame">
@@ -181,6 +268,7 @@
                 data-source="inventory"
                 data-slot="{{item.slot}}"
                 data-item="{{item}}"
+                data-inventory-id="{{item.inventoryId || ''}}"
               >
                 <view class="inventory-card__icon-name">{{item.shortName || item.name}}</view>
                 <view wx:if="{{item.equipped}}" class="inventory-card__status">已装备</view>

--- a/miniprogram/pages/role/index.wxss
+++ b/miniprogram/pages/role/index.wxss
@@ -486,6 +486,190 @@ button.pill-btn[disabled] {
   box-shadow: 0 0 0 4rpx rgba(120, 176, 255, 0.32);
 }
 
+.storage-section {
+  position: relative;
+}
+
+.storage-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16rpx;
+  margin-bottom: 24rpx;
+}
+
+.storage-tab {
+  padding: 14rpx 24rpx;
+  border-radius: 999rpx;
+  border: 1rpx solid rgba(86, 112, 220, 0.32);
+  background: rgba(20, 34, 84, 0.62);
+  color: rgba(198, 210, 255, 0.82);
+  font-size: 24rpx;
+  display: inline-flex;
+  align-items: center;
+  gap: 10rpx;
+  line-height: 1;
+  transition: all 0.2s ease;
+}
+
+.storage-tab__label {
+  font-weight: 600;
+}
+
+.storage-tab--active {
+  border-color: rgba(130, 156, 255, 0.6);
+  background: linear-gradient(120deg, rgba(94, 124, 248, 0.92), rgba(144, 94, 255, 0.92));
+  color: #f8faff;
+  box-shadow: 0 10rpx 22rpx rgba(86, 108, 228, 0.28);
+}
+
+.storage-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 16rpx;
+  padding: 20rpx 24rpx;
+  border-radius: 24rpx;
+  background: rgba(24, 38, 88, 0.72);
+  border: 1rpx solid rgba(94, 122, 230, 0.28);
+  margin-bottom: 28rpx;
+}
+
+.storage-summary__line {
+  display: flex;
+  justify-content: space-between;
+  font-size: 24rpx;
+  color: rgba(205, 214, 255, 0.82);
+}
+
+.storage-summary__progress {
+  width: 100%;
+}
+
+.storage-summary__actions {
+  display: flex;
+  align-items: flex-start;
+  gap: 16rpx;
+  flex-wrap: wrap;
+}
+
+.storage-summary__hint {
+  font-size: 22rpx;
+  color: rgba(186, 198, 255, 0.76);
+}
+
+.storage-summary__upgrade {
+  padding: 10rpx 20rpx;
+  min-width: auto;
+  font-size: 22rpx;
+}
+
+.storage-summary__info {
+  display: flex;
+  flex-direction: column;
+  gap: 6rpx;
+  font-size: 22rpx;
+  color: rgba(186, 198, 255, 0.76);
+}
+
+.storage-summary__info text {
+  color: rgba(186, 198, 255, 0.76);
+}
+
+.storage-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16rpx;
+}
+
+.storage-slot {
+  position: relative;
+  background: rgba(16, 28, 70, 0.85);
+  border-radius: 20rpx;
+  border: 1rpx solid rgba(86, 116, 210, 0.34);
+  box-sizing: border-box;
+  min-height: 0;
+}
+
+.storage-slot::before {
+  content: '';
+  display: block;
+  padding-top: 100%;
+}
+
+.storage-slot__badge {
+  position: absolute;
+  top: 12rpx;
+  left: 12rpx;
+  padding: 4rpx 12rpx;
+  font-size: 20rpx;
+  border-radius: 999rpx;
+  background: rgba(72, 94, 200, 0.42);
+  color: rgba(214, 224, 255, 0.88);
+  line-height: 1;
+  z-index: 2;
+}
+
+.storage-slot__frame {
+  position: absolute;
+  inset: 12rpx;
+  border-radius: 16rpx;
+  border: 4rpx solid rgba(118, 146, 250, 0.58);
+  background: rgba(10, 18, 48, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12rpx;
+  box-sizing: border-box;
+  transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.storage-slot__frame--hover {
+  border-color: rgba(150, 176, 255, 0.68);
+  box-shadow: 0 10rpx 24rpx rgba(90, 118, 240, 0.32);
+  transform: translateY(-2rpx);
+}
+
+.storage-slot__frame--empty {
+  border: 2rpx dashed rgba(102, 128, 210, 0.32);
+  background: rgba(12, 18, 40, 0.65);
+}
+
+.storage-slot__icon {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #f4f6ff;
+}
+
+.storage-slot__name {
+  font-size: 20rpx;
+  font-weight: 600;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+
+.storage-slot__placeholder {
+  font-size: 22rpx;
+  color: rgba(168, 186, 255, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.storage-slot--empty {
+  border: 1rpx dashed rgba(94, 122, 210, 0.32);
+  background: rgba(14, 22, 48, 0.6);
+}
+
+.storage-empty {
+  margin-top: 24rpx;
+}
+
 .equipment-summary {
   margin-top: 28rpx;
   padding: 24rpx;

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -279,17 +279,28 @@ export const PveService = {
     }
     return callCloud(CLOUD_FUNCTIONS.PVE, payload);
   },
-  async equipItem({ itemId = '', slot = '' } = {}) {
+  async equipItem({ itemId = '', slot = '', inventoryId = '' } = {}) {
     const payload = { action: 'equipItem' };
     const normalizedItemId = typeof itemId === 'string' ? itemId : '';
     const normalizedSlot = typeof slot === 'string' ? slot.trim() : '';
+    const normalizedInventoryId = typeof inventoryId === 'string' ? inventoryId.trim() : '';
     if (normalizedItemId) {
       payload.itemId = normalizedItemId;
     }
     if (normalizedSlot) {
       payload.slot = normalizedSlot;
     }
+    if (normalizedInventoryId) {
+      payload.inventoryId = normalizedInventoryId;
+    }
     return callCloud(CLOUD_FUNCTIONS.PVE, payload);
+  },
+  async upgradeStorage({ category = '' } = {}) {
+    const normalizedCategory = typeof category === 'string' ? category.trim() : '';
+    return callCloud(CLOUD_FUNCTIONS.PVE, {
+      action: 'upgradeStorage',
+      category: normalizedCategory
+    });
   },
   async allocatePoints(allocations = {}) {
     return callCloud(CLOUD_FUNCTIONS.PVE, { action: 'allocatePoints', allocations });


### PR DESCRIPTION
## Summary
- add the quest storage category and compute shared capacity metadata on the backend while enforcing upgrade limits
- rebuild the mini program storage state to use shared metadata, drop per-tab counts, and expose remaining upgrade information with a smaller button
- retain storage metadata during sanitization so the client can render unified slot counts and limits

## Testing
- Not run (WeChat mini program tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dcfa00b1588330ac94590205147e86