### PR TITLE
Revise storage tabs and shared capacity handling

### DIFF
--- a/cloudfunctions/pve/index.js
+++ b/cloudfunctions/pve/index.js
@@ -15,6 +15,18 @@ const MAX_SKILL_SLOTS = 3;
 const MAX_BATTLE_HISTORY = 15;
 const MAX_SKILL_HISTORY = 30;
 
+const STORAGE_CATEGORY_DEFINITIONS = [
+  { key: 'equipment', label: '装备', baseCapacity: 100, perUpgrade: 20 },
+  { key: 'quest', label: '任务', baseCapacity: 100, perUpgrade: 20 },
+  { key: 'material', label: '材料', baseCapacity: 100, perUpgrade: 20 },
+  { key: 'consumable', label: '道具', baseCapacity: 100, perUpgrade: 20 }
+];
+const STORAGE_CATEGORY_KEYS = STORAGE_CATEGORY_DEFINITIONS.map((item) => item.key);
+const STORAGE_DEFAULT_BASE_CAPACITY =
+  STORAGE_CATEGORY_DEFINITIONS.length > 0 ? STORAGE_CATEGORY_DEFINITIONS[0].baseCapacity : 100;
+const STORAGE_DEFAULT_PER_UPGRADE =
+  STORAGE_CATEGORY_DEFINITIONS.length > 0 ? STORAGE_CATEGORY_DEFINITIONS[0].perUpgrade : 20;
+
 const BASE_ATTRIBUTE_KEYS = ['constitution', 'strength', 'spirit', 'root', 'agility', 'insight'];
 const COMBAT_STAT_KEYS = [
   'maxHp',
@@ -308,6 +320,12 @@ const EQUIPMENT_SLOT_LABELS = Object.keys(EQUIPMENT_SLOTS).reduce((map, key) => 
   map[key] = EQUIPMENT_SLOTS[key].label;
   return map;
 }, {});
+
+const IGNORED_EQUIPMENT_SLOTS = new Set(['accessory', 'armor']);
+
+function isIgnoredEquipmentSlot(slot) {
+  return typeof slot === 'string' && IGNORED_EQUIPMENT_SLOTS.has(slot);
+}
 
 const EQUIPMENT_QUALITY_CONFIG = {
   mortal: { key: 'mortal', label: '凡品', color: '#8d9099', mainCoefficient: 0.8, subCount: 0, subTierRange: ['common'], dropWeight: 42 },
@@ -2025,6 +2043,8 @@ exports.main = async (event = {}) => {
       return equipSkill(actorId, event);
     case 'equipItem':
       return equipItem(actorId, event);
+    case 'upgradeStorage':
+      return upgradeStorage(actorId, event);
     case 'listEquipmentCatalog':
       return listEquipmentCatalog(actorId);
     case 'adminInspectProfile':
@@ -2065,7 +2085,7 @@ async function simulateBattle(actorId, enemyId) {
 
   const now = new Date();
   const updatedProfile = applyBattleOutcome(profile, result, enemy, now, member, levels);
-  const updates = { pveProfile: updatedProfile, updatedAt: now };
+  const updates = { pveProfile: _.set(updatedProfile), updatedAt: now };
   if (result.rewards && result.rewards.stones > 0) {
     updates.stoneBalance = _.inc(result.rewards.stones);
   }
@@ -2128,7 +2148,7 @@ async function drawSkill(actorId) {
 
   await db.collection(COLLECTIONS.MEMBERS).doc(actorId).update({
     data: {
-      pveProfile: profile,
+      pveProfile: _.set(profile),
       updatedAt: now
     }
   });
@@ -2197,7 +2217,7 @@ async function equipSkill(actorId, event) {
 
   await db.collection(COLLECTIONS.MEMBERS).doc(actorId).update({
     data: {
-      pveProfile: profile,
+      pveProfile: _.set(profile),
       updatedAt: now
     }
   });
@@ -2208,10 +2228,15 @@ async function equipSkill(actorId, event) {
 
 async function equipItem(actorId, event) {
   const { itemId, slot: rawSlot } = event;
+  const inventoryId =
+    event && typeof event.inventoryId === 'string' && event.inventoryId.trim() ? event.inventoryId.trim() : '';
   const member = await ensureMember(actorId);
   const profile = await ensurePveProfile(actorId, member);
   const inventory = Array.isArray(profile.equipment.inventory) ? profile.equipment.inventory : [];
-  const slots = profile.equipment.slots || {};
+  const slots =
+    profile.equipment && typeof profile.equipment.slots === 'object' && profile.equipment.slots
+      ? profile.equipment.slots
+      : createEmptySlotMap();
 
   const slot = typeof rawSlot === 'string' ? rawSlot.trim() : '';
 
@@ -2222,13 +2247,28 @@ async function equipItem(actorId, event) {
     if (!Object.prototype.hasOwnProperty.call(EQUIPMENT_SLOTS, slot)) {
       throw createError('INVALID_SLOT', '装备槽位不存在');
     }
-    const currentItemId = slots[slot];
-    if (!currentItemId) {
+    const currentEntry = slots[slot];
+    if (!currentEntry || !currentEntry.itemId) {
       throw createError('SLOT_EMPTY', '该槽位暂无装备');
     }
 
-    slots[slot] = '';
+    slots[slot] = null;
     profile.equipment.slots = slots;
+
+    if (currentEntry) {
+      const normalizedEntry = normalizeEquipmentInventoryItem(currentEntry, new Date()) || {
+        ...createEquipmentInventoryEntry(currentEntry.itemId, new Date())
+      };
+      if (normalizedEntry && normalizedEntry.inventoryId) {
+        const existingIndex = inventory.findIndex((entry) => entry.inventoryId === normalizedEntry.inventoryId);
+        if (existingIndex >= 0) {
+          inventory.splice(existingIndex, 1);
+        }
+      }
+      if (normalizedEntry) {
+        inventory.push(normalizedEntry);
+      }
+    }
 
     const now = new Date();
     profile.battleHistory = appendHistory(
@@ -2236,14 +2276,20 @@ async function equipItem(actorId, event) {
       {
         type: 'equipment-change',
         createdAt: now,
-        detail: { slot, itemId: currentItemId, action: 'unequip' }
+        detail: {
+          slot,
+          itemId: currentEntry.itemId,
+          inventoryId: currentEntry.inventoryId || '',
+          action: 'unequip'
+        }
       },
       MAX_BATTLE_HISTORY
     );
 
+    profile.equipment.inventory = inventory;
     await db.collection(COLLECTIONS.MEMBERS).doc(actorId).update({
       data: {
-        pveProfile: profile,
+        pveProfile: _.set(profile),
         updatedAt: now
       }
     });
@@ -2255,8 +2301,14 @@ async function equipItem(actorId, event) {
   if (!definition) {
     throw createError('ITEM_NOT_FOUND', '装备不存在');
   }
-  const hasItem = inventory.some((entry) => entry.itemId === itemId);
-  if (!hasItem) {
+  let index = -1;
+  if (inventoryId) {
+    index = inventory.findIndex((entry) => entry.inventoryId === inventoryId);
+  }
+  if (index < 0) {
+    index = inventory.findIndex((entry) => entry.itemId === itemId);
+  }
+  if (index < 0) {
     throw createError('ITEM_NOT_OWNED', '尚未拥有该装备，无法装备');
   }
 
@@ -2264,29 +2316,106 @@ async function equipItem(actorId, event) {
     throw createError('SLOT_MISMATCH', '装备与槽位不匹配');
   }
 
-  slots[definition.slot] = itemId;
-  profile.equipment.slots = slots;
-
   const now = new Date();
+  const entry = inventory.splice(index, 1)[0];
+  const normalizedEntry = normalizeEquipmentInventoryItem(entry, now) || createEquipmentInventoryEntry(itemId, now);
+  const targetSlot = definition.slot;
+  const previous = slots[targetSlot];
+  if (previous && previous.itemId) {
+    const previousNormalized = normalizeEquipmentInventoryItem(previous, now);
+    if (previousNormalized) {
+      if (previousNormalized.inventoryId) {
+        const existingIndex = inventory.findIndex((record) => record.inventoryId === previousNormalized.inventoryId);
+        if (existingIndex >= 0) {
+          inventory.splice(existingIndex, 1);
+        }
+      }
+      inventory.push(previousNormalized);
+    }
+  }
+  slots[targetSlot] = normalizedEntry ? { ...normalizedEntry } : null;
+  profile.equipment.slots = slots;
+  profile.equipment.inventory = inventory;
+
   profile.battleHistory = appendHistory(
     profile.battleHistory,
     {
       type: 'equipment-change',
       createdAt: now,
-      detail: { itemId, slot: definition.slot, action: 'equip' }
+      detail: {
+        itemId,
+        slot: definition.slot,
+        inventoryId: normalizedEntry && normalizedEntry.inventoryId ? normalizedEntry.inventoryId : '',
+        action: 'equip'
+      }
     },
     MAX_BATTLE_HISTORY
   );
 
   await db.collection(COLLECTIONS.MEMBERS).doc(actorId).update({
     data: {
-      pveProfile: profile,
+      pveProfile: _.set(profile),
       updatedAt: now
     }
   });
 
   const decorated = decorateProfile(member, profile);
   return { profile: decorated };
+}
+
+async function upgradeStorage(actorId, event = {}) {
+  const category =
+    event && typeof event.category === 'string' && event.category.trim() ? event.category.trim() : '';
+  if (!category) {
+    throw createError('CATEGORY_REQUIRED', '请选择要升级的储物类型');
+  }
+  if (!STORAGE_CATEGORY_KEYS.includes(category)) {
+    throw createError('INVALID_CATEGORY', '储物类型不存在');
+  }
+  const member = await ensureMember(actorId);
+  const profile = await ensurePveProfile(actorId, member);
+  const storage = profile.equipment && typeof profile.equipment.storage === 'object' ? profile.equipment.storage : {};
+  const current = Math.max(0, Math.floor(Number(storage.upgrades || 0)));
+  const rawAvailable =
+    storage && typeof storage.upgradeAvailable !== 'undefined' ? Number(storage.upgradeAvailable) : null;
+  const rawLimit = storage && typeof storage.upgradeLimit !== 'undefined' ? Number(storage.upgradeLimit) : null;
+  const available =
+    rawAvailable !== null && Number.isFinite(rawAvailable) ? Math.max(0, Math.floor(rawAvailable)) : null;
+  const limit = rawLimit !== null && Number.isFinite(rawLimit) ? Math.max(0, Math.floor(rawLimit)) : null;
+  if (available !== null && available <= 0) {
+    throw createError('NO_STORAGE_UPGRADES', '储物空间升级次数不足');
+  }
+  if (limit !== null && current >= limit) {
+    throw createError('NO_STORAGE_UPGRADES', '储物空间升级次数不足');
+  }
+  const next = current + 1;
+  const nextAvailable = available !== null ? Math.max(0, available - 1) : null;
+  const updatedStorage = { ...storage, upgrades: next };
+  if (nextAvailable !== null) {
+    updatedStorage.upgradeAvailable = nextAvailable;
+  }
+  profile.equipment.storage = updatedStorage;
+  const now = new Date();
+  await db.collection(COLLECTIONS.MEMBERS).doc(actorId).update({
+    data: {
+      pveProfile: _.set(profile),
+      updatedAt: now
+    }
+  });
+  const decorated = decorateProfile(member, profile);
+  const baseCapacity = STORAGE_DEFAULT_BASE_CAPACITY;
+  const perUpgrade = STORAGE_DEFAULT_PER_UPGRADE;
+  const capacity = baseCapacity + perUpgrade * next;
+  return {
+    profile: decorated,
+    storage: {
+      category,
+      upgrades: next,
+      capacity,
+      upgradeAvailable: nextAvailable,
+      upgradeLimit: limit
+    }
+  };
 }
 
 async function allocatePoints(actorId, allocations) {
@@ -2325,7 +2454,7 @@ async function allocatePoints(actorId, allocations) {
 
   await db.collection(COLLECTIONS.MEMBERS).doc(actorId).update({
     data: {
-      pveProfile: profile,
+      pveProfile: _.set(profile),
       updatedAt: now
     }
   });
@@ -2382,7 +2511,7 @@ async function resetAttributes(actorId) {
 
   await db.collection(COLLECTIONS.MEMBERS).doc(actorId).update({
     data: {
-      pveProfile: profile,
+      pveProfile: _.set(profile),
       updatedAt: now
     }
   });
@@ -2463,7 +2592,7 @@ async function grantEquipment(actorId, event = {}) {
 
   await db.collection(COLLECTIONS.MEMBERS).doc(memberId).update({
     data: {
-      pveProfile: profile,
+      pveProfile: _.set(profile),
       updatedAt: now
     }
   });
@@ -2503,10 +2632,23 @@ async function removeEquipment(actorId, event = {}) {
   const definition = EQUIPMENT_MAP[itemId];
   inventory.splice(index, 1);
   profile.equipment.inventory = inventory;
-  const slots = typeof profile.equipment.slots === 'object' && profile.equipment.slots ? profile.equipment.slots : {};
+  const slots =
+    profile.equipment && typeof profile.equipment.slots === 'object'
+      ? profile.equipment.slots
+      : createEmptySlotMap();
   Object.keys(slots).forEach((slotKey) => {
-    if (slots[slotKey] === itemId) {
-      slots[slotKey] = '';
+    const slotEntry = slots[slotKey];
+    if (!slotEntry) {
+      return;
+    }
+    if (inventoryId) {
+      if (slotEntry && slotEntry.inventoryId === inventoryId) {
+        slots[slotKey] = null;
+      }
+      return;
+    }
+    if (slotEntry.itemId === itemId) {
+      slots[slotKey] = null;
     }
   });
   profile.equipment.slots = slots;
@@ -2522,7 +2664,7 @@ async function removeEquipment(actorId, event = {}) {
 
   await db.collection(COLLECTIONS.MEMBERS).doc(memberId).update({
     data: {
-      pveProfile: profile,
+      pveProfile: _.set(profile),
       updatedAt: now
     }
   });
@@ -2619,7 +2761,7 @@ async function updateEquipmentAttributes(actorId, event = {}) {
 
   await db.collection(COLLECTIONS.MEMBERS).doc(memberId).update({
     data: {
-      pveProfile: profile,
+      pveProfile: _.set(profile),
       updatedAt: now
     }
   });
@@ -2702,7 +2844,7 @@ async function ensurePveProfile(actorId, member, levelCache) {
   if (changed) {
     await db.collection(COLLECTIONS.MEMBERS).doc(actorId).update({
       data: {
-        pveProfile: profile,
+        pveProfile: _.set(profile),
         updatedAt: now
       }
     });
@@ -2754,7 +2896,7 @@ function buildDefaultAttributes() {
 function createEmptySlotMap() {
   const slots = {};
   Object.keys(EQUIPMENT_SLOTS).forEach((slot) => {
-    slots[slot] = '';
+    slots[slot] = null;
   });
   return slots;
 }
@@ -2774,14 +2916,17 @@ function buildDefaultEquipment(now = new Date()) {
     'initiate_focus',
     'initiate_treasure'
   ];
-  const inventory = defaults
+  const generated = defaults
     .map((itemId) => createEquipmentInventoryEntry(itemId, now))
     .filter((entry) => !!entry);
   const slots = createEmptySlotMap();
-  inventory.forEach((entry) => {
+  const inventory = [];
+  generated.forEach((entry) => {
     const definition = EQUIPMENT_MAP[entry.itemId];
     if (definition && definition.slot && !slots[definition.slot]) {
-      slots[definition.slot] = entry.itemId;
+      slots[definition.slot] = { ...entry };
+    } else {
+      inventory.push({ ...entry });
     }
   });
   return { inventory, slots };
@@ -2880,82 +3025,159 @@ function normalizeEquipment(equipment, now = new Date(), options = {}) {
   const includeDefaults = options && options.includeDefaults !== false;
   const defaults = includeDefaults ? buildDefaultEquipment(now) : { inventory: [], slots: createEmptySlotMap() };
   const payload = typeof equipment === 'object' && equipment ? equipment : {};
-  const inventory = Array.isArray(payload.inventory) ? payload.inventory : [];
+  const rawInventory = Array.isArray(payload.inventory) ? payload.inventory : [];
   const normalizedInventory = [];
   const seenInventoryIds = new Set();
-  const itemCounts = {};
-  const trackEntry = (entry) => {
-    if (!entry) {
+
+  const trackInventory = (entry) => {
+    if (!entry || !entry.inventoryId || seenInventoryIds.has(entry.inventoryId)) {
       return;
     }
     normalizedInventory.push(entry);
-    if (entry && entry.inventoryId) {
-      seenInventoryIds.add(entry.inventoryId);
-    }
-    if (entry && entry.itemId) {
-      itemCounts[entry.itemId] = (itemCounts[entry.itemId] || 0) + 1;
-    }
+    seenInventoryIds.add(entry.inventoryId);
   };
-  inventory.forEach((item) => {
+
+  rawInventory.forEach((item) => {
     const normalizedItem = normalizeEquipmentInventoryItem(item, now);
-    if (normalizedItem && !seenInventoryIds.has(normalizedItem.inventoryId)) {
-      trackEntry(normalizedItem);
+    if (normalizedItem) {
+      trackInventory(normalizedItem);
     }
   });
-  if (includeDefaults) {
-    defaults.inventory.forEach((item) => {
-      if (!itemCounts[item.itemId]) {
-        trackEntry(item);
-      }
-    });
-  }
 
-  const slots = { ...defaults.slots };
+  (defaults.inventory || []).forEach((entry) => {
+    if (entry) {
+      trackInventory({ ...entry });
+    }
+  });
+
+  const availableById = new Map();
+  const availableByItemId = {};
+  normalizedInventory.forEach((entry) => {
+    availableById.set(entry.inventoryId, entry);
+    if (!availableByItemId[entry.itemId]) {
+      availableByItemId[entry.itemId] = [];
+    }
+    availableByItemId[entry.itemId].push(entry);
+  });
+
+  const claimEntry = (entry) => {
+    if (!entry || !entry.inventoryId) {
+      return entry || null;
+    }
+    const claimed = availableById.get(entry.inventoryId);
+    if (!claimed) {
+      return entry;
+    }
+    availableById.delete(entry.inventoryId);
+    const list = availableByItemId[entry.itemId] || [];
+    const index = list.findIndex((candidate) => candidate.inventoryId === entry.inventoryId);
+    if (index >= 0) {
+      list.splice(index, 1);
+    }
+    return claimed;
+  };
+
+  const claimByItemId = (itemId) => {
+    const list = availableByItemId[itemId];
+    if (!list || !list.length) {
+      return null;
+    }
+    const entry = list.shift();
+    if (entry && entry.inventoryId) {
+      availableById.delete(entry.inventoryId);
+    }
+    return entry ? { ...entry } : null;
+  };
+
+  const resolvedSlots = createEmptySlotMap();
   const rawSlots = payload.slots || {};
-  const ensureInventoryEntry = (itemId) => {
-    if (!itemId || itemCounts[itemId]) {
+
+  Object.keys(resolvedSlots).forEach((slot) => {
+    const raw = rawSlots[slot];
+    let normalizedEntry = null;
+    if (raw && typeof raw === 'object' && raw.itemId) {
+      const candidate = normalizeEquipmentInventoryItem(raw, now);
+      if (candidate) {
+        normalizedEntry = { ...candidate };
+      }
+    } else if (typeof raw === 'string' && raw) {
+      normalizedEntry = claimByItemId(raw);
+    }
+    if (!normalizedEntry && defaults.slots && defaults.slots[slot]) {
+      normalizedEntry = { ...defaults.slots[slot] };
+    }
+    if (normalizedEntry) {
+      const claimed = claimEntry(normalizedEntry);
+      resolvedSlots[slot] = claimed ? { ...claimed } : { ...normalizedEntry };
+    } else {
+      resolvedSlots[slot] = null;
+    }
+  });
+
+  Object.keys(rawSlots || {}).forEach((slot) => {
+    if (isIgnoredEquipmentSlot(slot)) {
       return;
     }
-    const entry = createEquipmentInventoryEntry(itemId, now);
-    if (entry && !seenInventoryIds.has(entry.inventoryId)) {
-      trackEntry(entry);
+    if (Object.prototype.hasOwnProperty.call(resolvedSlots, slot)) {
+      return;
     }
-  };
-  Object.keys(slots).forEach((slot) => {
-    const candidate = typeof rawSlots[slot] === 'string' ? rawSlots[slot] : '';
-    if (candidate && EQUIPMENT_MAP[candidate]) {
-      if (itemCounts[candidate]) {
-        slots[slot] = candidate;
-      } else if (includeDefaults) {
-        ensureInventoryEntry(candidate);
-        if (itemCounts[candidate]) {
-          slots[slot] = candidate;
-        }
-      } else {
-        slots[slot] = '';
+    const raw = rawSlots[slot];
+    let normalizedEntry = null;
+    if (raw && typeof raw === 'object' && raw.itemId) {
+      const candidate = normalizeEquipmentInventoryItem(raw, now);
+      if (candidate) {
+        normalizedEntry = { ...candidate };
       }
-    } else if (!includeDefaults) {
-      slots[slot] = '';
+    } else if (typeof raw === 'string' && raw) {
+      normalizedEntry = claimByItemId(raw);
     }
+    resolvedSlots[slot] = normalizedEntry ? { ...normalizedEntry } : null;
   });
 
-  if (!includeDefaults) {
-    Object.keys(rawSlots).forEach((slot) => {
-      if (Object.prototype.hasOwnProperty.call(slots, slot)) {
+  const remainingInventory = Array.from(availableById.values()).map((entry) => ({ ...entry }));
+
+  const rawStorage = payload.storage && typeof payload.storage === 'object' ? payload.storage : {};
+  let storageUpgrades = 0;
+  if (rawStorage && typeof rawStorage.upgrades === 'number') {
+    const numeric = Number(rawStorage.upgrades);
+    storageUpgrades = Number.isFinite(numeric) ? Math.max(0, Math.floor(numeric)) : 0;
+  } else if (rawStorage && typeof rawStorage.upgrades === 'object') {
+    storageUpgrades = STORAGE_CATEGORY_KEYS.reduce((acc, key) => {
+      const value = Number(rawStorage.upgrades[key]);
+      if (Number.isFinite(value) && value > acc) {
+        return Math.max(0, Math.floor(value));
+      }
+      return acc;
+    }, 0);
+  }
+  const normalizedStorage = {};
+  if (rawStorage && typeof rawStorage === 'object') {
+    Object.keys(rawStorage).forEach((key) => {
+      if (key === 'upgrades' || key === 'upgradeAvailable' || key === 'upgradeLimit') {
         return;
       }
-      const candidate = typeof rawSlots[slot] === 'string' ? rawSlots[slot] : '';
-      if (candidate && EQUIPMENT_MAP[candidate]) {
-        if (itemCounts[candidate]) {
-          slots[slot] = candidate;
-        }
-      } else {
-        slots[slot] = '';
-      }
+      normalizedStorage[key] = rawStorage[key];
     });
   }
+  normalizedStorage.upgrades = storageUpgrades;
+  if (rawStorage && typeof rawStorage.upgradeAvailable !== 'undefined') {
+    const availableNumeric = Number(rawStorage.upgradeAvailable);
+    if (Number.isFinite(availableNumeric)) {
+      normalizedStorage.upgradeAvailable = Math.max(0, Math.floor(availableNumeric));
+    }
+  }
+  if (rawStorage && typeof rawStorage.upgradeLimit !== 'undefined') {
+    const limitNumeric = Number(rawStorage.upgradeLimit);
+    if (Number.isFinite(limitNumeric)) {
+      normalizedStorage.upgradeLimit = Math.max(0, Math.floor(limitNumeric));
+    }
+  }
 
-  return { inventory: normalizedInventory, slots };
+  return {
+    inventory: remainingInventory,
+    slots: resolvedSlots,
+    storage: normalizedStorage
+  };
 }
 
 function normalizeSkills(skills, now = new Date()) {
@@ -3412,20 +3634,25 @@ function sumEquipmentBonuses(equipment) {
     return summary;
   }
   const slots = equipment.slots || {};
-  const inventory = Array.isArray(equipment.inventory) ? equipment.inventory : [];
-  const inventoryMap = inventory.reduce((map, item) => {
-    map[item.itemId] = item;
-    return map;
-  }, {});
   const setCounters = {};
 
   Object.keys(slots).forEach((slot) => {
-    const itemId = slots[slot];
+    if (isIgnoredEquipmentSlot(slot)) {
+      return;
+    }
+    const slotEntry = slots[slot];
+    const itemId =
+      typeof slotEntry === 'string'
+        ? slotEntry
+        : slotEntry && typeof slotEntry === 'object' && slotEntry.itemId
+        ? slotEntry.itemId
+        : '';
     if (!itemId) return;
     const definition = EQUIPMENT_MAP[itemId];
     if (!definition) return;
-    const owned = inventoryMap[itemId] || { itemId, refine: 0 };
-    const detail = calculateEquipmentStats(definition, owned.refine || 0);
+    const refine =
+      slotEntry && typeof slotEntry.refine === 'number' ? Math.max(0, Math.floor(slotEntry.refine)) : 0;
+    const detail = calculateEquipmentStats(definition, refine);
     const bonusStats = detail.stats || {};
     Object.keys(bonusStats).forEach((key) => {
       applyBonus(summary, key, bonusStats[key]);
@@ -3817,47 +4044,148 @@ function decorateEquipment(profile, summary = null) {
   const equipment = profile.equipment || {};
   const inventory = Array.isArray(equipment.inventory) ? equipment.inventory : [];
   const slots = equipment.slots || {};
-  const list = inventory
-    .map((entry) => decorateEquipmentInventoryEntry(entry, slots))
-    .filter((item) => !!item);
-  const slotItemIds = Object.values(slots || {}).filter((value) => typeof value === 'string' && value);
-  const equippedCounts = {};
-  slotItemIds.forEach((itemId) => {
-    equippedCounts[itemId] = (equippedCounts[itemId] || 0) + 1;
-  });
-  const equippedUsage = {};
-  list.forEach((item) => {
-    const limit = equippedCounts[item.itemId] || 0;
-    const used = equippedUsage[item.itemId] || 0;
-    item.equipped = used < limit;
-    equippedUsage[item.itemId] = used + 1;
-  });
-  const entriesByItemId = {};
-  list.forEach((item) => {
-    if (!entriesByItemId[item.itemId]) {
-      entriesByItemId[item.itemId] = [];
+  const equippedInventoryIds = new Set();
+  const slotDetails = [];
+  Object.keys(EQUIPMENT_SLOT_LABELS).forEach((slot) => {
+    if (isIgnoredEquipmentSlot(slot)) {
+      return;
     }
-    entriesByItemId[item.itemId].push(item);
-  });
-  const slotUsage = {};
-  const bonusSummary = summary || sumEquipmentBonuses(equipment);
-  const slotDetails = Object.keys(EQUIPMENT_SLOT_LABELS).map((slot) => {
-    const itemId = typeof slots[slot] === 'string' ? slots[slot] : '';
-    const usage = itemId ? slotUsage[itemId] || 0 : 0;
-    const candidates = itemId ? entriesByItemId[itemId] || [] : [];
-    const item = candidates[usage] || null;
-    if (itemId) {
-      slotUsage[itemId] = usage + 1;
+    const entry = slots[slot];
+    const decorated = entry
+      ? decorateEquipmentInventoryEntry(entry, { equipped: true, slotKey: slot })
+      : null;
+    if (decorated) {
+      if (decorated.inventoryId) {
+        equippedInventoryIds.add(decorated.inventoryId);
+      } else {
+        equippedInventoryIds.add(`slot:${slot}:${decorated.itemId}`);
+      }
     }
-    return {
+    slotDetails.push({
       slot,
       slotLabel: EQUIPMENT_SLOT_LABELS[slot],
-      item: item || null
+      item: decorated || null
+    });
+  });
+  Object.keys(slots).forEach((slot) => {
+    if (isIgnoredEquipmentSlot(slot)) {
+      return;
+    }
+    if (Object.prototype.hasOwnProperty.call(EQUIPMENT_SLOT_LABELS, slot)) {
+      return;
+    }
+    const entry = slots[slot];
+    const decorated = entry
+      ? decorateEquipmentInventoryEntry(entry, { equipped: true, slotKey: slot })
+      : null;
+    if (decorated) {
+      if (decorated.inventoryId) {
+        equippedInventoryIds.add(decorated.inventoryId);
+      } else {
+        equippedInventoryIds.add(`slot:${slot}:${decorated.itemId}`);
+      }
+    }
+    slotDetails.push({ slot, slotLabel: slot, item: decorated || null });
+  });
+
+  const list = inventory
+    .map((entry) => {
+      const decorated = decorateEquipmentInventoryEntry(entry, { equipped: false });
+      if (!decorated) {
+        return null;
+      }
+      if (decorated.inventoryId && equippedInventoryIds.has(decorated.inventoryId)) {
+        decorated.equipped = true;
+      }
+      return decorated;
+    })
+    .filter((item) => !!item);
+
+  const bonusSummary = summary || sumEquipmentBonuses(equipment);
+  const storagePayload = equipment.storage && typeof equipment.storage === 'object' ? equipment.storage : {};
+  const totalUpgrades = Math.max(0, Math.floor(Number(storagePayload.upgrades || 0)));
+  const baseCapacity = STORAGE_DEFAULT_BASE_CAPACITY;
+  const perUpgrade = STORAGE_DEFAULT_PER_UPGRADE;
+  const capacity = baseCapacity + perUpgrade * totalUpgrades;
+  const rawCategories = Array.isArray(storagePayload.categories) ? storagePayload.categories : [];
+  const categoryMap = {};
+  let totalUsed = 0;
+  rawCategories.forEach((category) => {
+    if (!category || typeof category !== 'object') {
+      return;
+    }
+    const key = typeof category.key === 'string' ? category.key : '';
+    if (!key) {
+      return;
+    }
+    const items = Array.isArray(category.items) ? category.items.map((item) => ({ ...item })) : [];
+    categoryMap[key] = items;
+    totalUsed += items.length;
+  });
+  const equipmentItems = list.map((item) => ({ ...item }));
+  const previousEquipment = categoryMap.equipment ? categoryMap.equipment.length : 0;
+  categoryMap.equipment = equipmentItems;
+  totalUsed = totalUsed - previousEquipment + equipmentItems.length;
+  const definedKeys = new Set(STORAGE_CATEGORY_DEFINITIONS.map((item) => item.key));
+  const storageCategories = STORAGE_CATEGORY_DEFINITIONS.map((definition) => {
+    const items = categoryMap[definition.key]
+      ? categoryMap[definition.key].map((item) => ({ ...item }))
+      : [];
+    return {
+      key: definition.key,
+      label: definition.label,
+      baseCapacity,
+      perUpgrade,
+      upgrades: totalUpgrades,
+      capacity,
+      used: items.length,
+      remaining: Math.max(capacity - items.length, 0),
+      items
     };
   });
+  rawCategories.forEach((category) => {
+    if (!category || typeof category !== 'object') {
+      return;
+    }
+    const key = typeof category.key === 'string' ? category.key : '';
+    if (!key || definedKeys.has(key)) {
+      return;
+    }
+    const items = categoryMap[key] ? categoryMap[key].map((item) => ({ ...item })) : [];
+    storageCategories.push({
+      key,
+      label: typeof category.label === 'string' ? category.label : key,
+      baseCapacity,
+      perUpgrade,
+      upgrades: totalUpgrades,
+      capacity,
+      used: items.length,
+      remaining: Math.max(capacity - items.length, 0),
+      items
+    });
+  });
+  const upgradeAvailableNumeric =
+    typeof storagePayload.upgradeAvailable !== 'undefined' ? Number(storagePayload.upgradeAvailable) : null;
+  const upgradeLimitNumeric =
+    typeof storagePayload.upgradeLimit !== 'undefined' ? Number(storagePayload.upgradeLimit) : null;
+  const summaryPayload = {
+    baseCapacity,
+    perUpgrade,
+    upgrades: totalUpgrades,
+    capacity,
+    used: totalUsed,
+    remaining: Math.max(capacity - totalUsed, 0)
+  };
+  if (upgradeAvailableNumeric !== null && Number.isFinite(upgradeAvailableNumeric)) {
+    summaryPayload.upgradeAvailable = Math.max(0, Math.floor(upgradeAvailableNumeric));
+  }
+  if (upgradeLimitNumeric !== null && Number.isFinite(upgradeLimitNumeric)) {
+    summaryPayload.upgradeLimit = Math.max(0, Math.floor(upgradeLimitNumeric));
+  }
   return {
     slots: slotDetails,
     inventory: list,
+    storage: { summary: summaryPayload, categories: storageCategories },
     bonus: {
       sets: Array.isArray(bonusSummary && bonusSummary.sets) ? bonusSummary.sets : [],
       notes: Array.isArray(bonusSummary && bonusSummary.notes) ? bonusSummary.notes : []
@@ -3865,12 +4193,16 @@ function decorateEquipment(profile, summary = null) {
   };
 }
 
-function decorateEquipmentInventoryEntry(entry, slots = {}) {
-  const definition = EQUIPMENT_MAP[entry.itemId];
+function decorateEquipmentInventoryEntry(entry, options = {}) {
+  if (!entry) {
+    return null;
+  }
+  const payload = typeof entry === 'object' ? entry : { itemId: entry };
+  const definition = EQUIPMENT_MAP[payload.itemId];
   if (!definition) {
     return null;
   }
-  const detail = calculateEquipmentStats(definition, entry.refine || 0);
+  const detail = calculateEquipmentStats(definition, payload.refine || 0);
   const stats = detail.stats || {};
   const statTexts = formatStatsText({ ...stats });
   const breakdownTexts = [];
@@ -3897,10 +4229,10 @@ function decorateEquipmentInventoryEntry(entry, slots = {}) {
   }
   const combinedTexts = [...statTexts, ...breakdownTexts];
   const displayTexts = combinedTexts.filter((text, index, list) => text && list.indexOf(text) === index);
-  const equipped = Object.values(slots || {}).includes(entry.itemId);
+  const equipped = !!(options && options.equipped);
   return {
-    inventoryId: entry.inventoryId,
-    itemId: entry.itemId,
+    inventoryId: payload.inventoryId,
+    itemId: payload.itemId,
     name: definition.name,
     quality: definition.quality,
     qualityLabel: resolveEquipmentQualityLabel(definition.quality),
@@ -3913,17 +4245,18 @@ function decorateEquipmentInventoryEntry(entry, slots = {}) {
     mainAttribute: detail.mainAttribute,
     subAttributes: detail.subAttributes,
     uniqueEffects: detail.uniqueEffects,
-    level: entry.level || 1,
-    refine: entry.refine || 0,
-    refineLabel: entry.refine ? `精炼 +${entry.refine}` : '未精炼',
+    level: payload.level || 1,
+    refine: payload.refine || 0,
+    refineLabel: payload.refine ? `精炼 +${payload.refine}` : '未精炼',
     levelRequirement: definition.levelRequirement || 1,
     tags: definition.tags || [],
-    obtainedAt: entry.obtainedAt,
-    obtainedAtText: formatDateTime(entry.obtainedAt),
+    obtainedAt: payload.obtainedAt,
+    obtainedAtText: formatDateTime(payload.obtainedAt),
     setId: definition.setId || null,
     setName: setDefinition ? setDefinition.name : '',
     equipped,
-    favorite: !!entry.favorite,
+    equippedSlot: options && options.slotKey ? options.slotKey : '',
+    favorite: !!payload.favorite,
     notes: notes.filter((note, index, list) => note && list.indexOf(note) === index)
   };
 }

--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -36,8 +36,8 @@ const app = getApp();
 const BASE_NAV_ITEMS = [
   { icon: '🧝', label: '角色', url: '/pages/role/index?tab=character' },
   { icon: '🛡️', label: '装备', url: '/pages/role/index?tab=equipment' },
+  { icon: '💍', label: '纳戒', url: '/pages/role/index?tab=storage' },
   { icon: '📜', label: '技能', url: '/pages/role/index?tab=skill' },
-  { icon: '🎁', label: '权益', url: '/pages/rights/rights' },
   { icon: '📅', label: '预订', url: '/pages/reservation/reservation' },
   { icon: '💰', label: '钱包', url: '/pages/wallet/wallet' },
   { icon: '🧙‍♀️', label: '造型', url: '/pages/avatar/avatar' }

--- a/miniprogram/pages/role/index.js
+++ b/miniprogram/pages/role/index.js
@@ -13,30 +13,229 @@ Page({
     resetting: false,
     stoneBalance: 0,
     formattedStoneBalance: formatStones(0),
-    equipmentTooltip: null
+    equipmentTooltip: null,
+    storageCategories: [],
+    activeStorageCategory: 'equipment',
+    activeStorageCategoryData: null,
+    storageSummary: null,
+    storageUpgrading: false
   },
 
   applyProfile(profile, extraState = {}) {
     const sanitizedProfile = sanitizeEquipmentProfile(profile);
-    const updates = { ...extraState, profile: sanitizedProfile };
+    const storageState = this.buildStorageState(sanitizedProfile);
+    const updates = { ...extraState, profile: sanitizedProfile, ...storageState };
     const tooltip = this.data ? this.data.equipmentTooltip : null;
     if (tooltip && tooltip.item) {
       const itemId = tooltip.item.itemId;
+      const inventoryId = tooltip.item.inventoryId || tooltip.inventoryId || '';
       const equipment = sanitizedProfile && sanitizedProfile.equipment;
       const inSlots =
         equipment &&
         Array.isArray(equipment.slots) &&
-        equipment.slots.some((slot) => slot && slot.item && slot.item.itemId === itemId);
+        equipment.slots.some((slot) => {
+          if (!slot || !slot.item) return false;
+          if (inventoryId) {
+            return slot.item.inventoryId === inventoryId;
+          }
+          return slot.item.itemId === itemId;
+        });
       const inInventory =
         equipment &&
         Array.isArray(equipment.inventory) &&
-        equipment.inventory.some((item) => item && item.itemId === itemId);
+        equipment.inventory.some((item) => {
+          if (!item) return false;
+          if (inventoryId) {
+            return item.inventoryId === inventoryId;
+          }
+          return item.itemId === itemId;
+        });
       if (!inSlots && !inInventory) {
         updates.equipmentTooltip = null;
       }
     }
     this.setData(updates);
     return sanitizedProfile;
+  },
+
+  buildStorageState(profile) {
+    const storageSummary = this.buildStorageSummary(profile);
+    const storageCategories = this.buildStorageCategories(profile, storageSummary);
+    const activeKey = this.resolveActiveStorageCategory(storageCategories);
+    const activeCategory = storageCategories.find((category) => category.key === activeKey) || null;
+    return {
+      storageCategories,
+      activeStorageCategory: activeKey,
+      activeStorageCategoryData: activeCategory,
+      storageSummary
+    };
+  },
+
+  resolveActiveStorageCategory(categories) {
+    const list = Array.isArray(categories) ? categories : [];
+    const current = this.data && this.data.activeStorageCategory;
+    if (current && list.some((category) => category.key === current)) {
+      return current;
+    }
+    const defaultCategory = list.find((category) => category.key === 'equipment');
+    if (defaultCategory) {
+      return defaultCategory.key;
+    }
+    return list.length ? list[0].key : '';
+  },
+
+  buildStorageCategories(profile, summary = null) {
+    const storage =
+      profile && profile.equipment && profile.equipment.storage && typeof profile.equipment.storage === 'object'
+        ? profile.equipment.storage
+        : {};
+    const categories = Array.isArray(storage.categories) ? storage.categories : [];
+    const summaryBaseCapacity =
+      summary && typeof summary.baseCapacity === 'number' ? Math.max(0, Math.floor(summary.baseCapacity)) : 0;
+    const summaryPerUpgrade =
+      summary && typeof summary.perUpgrade === 'number' ? Math.max(0, Math.floor(summary.perUpgrade)) : 0;
+    const upgrades = summary && typeof summary.upgrades === 'number' ? summary.upgrades : 0;
+    const capacity = summary && typeof summary.capacity === 'number' ? summary.capacity : 0;
+    const usagePercent = summary && typeof summary.usagePercent === 'number' ? summary.usagePercent : 0;
+    const nextCapacity =
+      summary && typeof summary.nextCapacity === 'number' ? summary.nextCapacity : capacity + summaryPerUpgrade;
+    return categories.map((category) => {
+      const key = category && typeof category.key === 'string' ? category.key : '';
+      const label = category && typeof category.label === 'string' ? category.label : '';
+      const categoryBaseCapacity = Math.max(
+        0,
+        Math.floor(Number(category && category.baseCapacity) || summaryBaseCapacity || 100)
+      );
+      const categoryPerUpgrade = Math.max(
+        0,
+        Math.floor(Number(category && category.perUpgrade) || summaryPerUpgrade || 20)
+      );
+      const rawCapacity = Math.max(0, Math.floor(Number(category && category.capacity) || categoryBaseCapacity));
+      const upgrades = Math.max(0, Math.floor(Number(category && category.upgrades) || 0));
+      const items = Array.isArray(category && category.items) ? category.items : [];
+      const normalizedItems = items.map((item, index) => {
+        const storageKey = `${key}-${item && item.inventoryId ? item.inventoryId : `${item && item.itemId ? item.itemId : 'item'}-${index}`}`;
+        return { ...item, storageKey };
+      });
+      const globalCapacity = capacity > 0 ? capacity : 0;
+      const slotBase = globalCapacity || rawCapacity || categoryBaseCapacity;
+      const slotCount = Math.max(slotBase, normalizedItems.length);
+      const slots = normalizedItems.map((item) => ({ ...item, placeholder: false }));
+      for (let i = normalizedItems.length; i < slotCount; i += 1) {
+        slots.push({ placeholder: true, storageKey: `${key}-placeholder-${i}` });
+      }
+      const used = typeof category.used === 'number' ? Math.max(0, Math.floor(category.used)) : normalizedItems.length;
+      const remaining =
+        typeof category.remaining === 'number'
+          ? Math.max(0, Math.floor(category.remaining))
+          : Math.max(slotCount - normalizedItems.length, 0);
+      const categoryUsagePercent = usagePercent || (slotCount ? Math.min(100, Math.round((normalizedItems.length / slotCount) * 100)) : 0);
+      const nextCapacityValue = nextCapacity || slotCount + categoryPerUpgrade;
+      return {
+        key,
+        label,
+        baseCapacity: summaryBaseCapacity || categoryBaseCapacity,
+        perUpgrade: summaryPerUpgrade || categoryPerUpgrade,
+        upgrades,
+        capacity: slotCount,
+        used: Math.min(used, slotCount),
+        remaining,
+        usagePercent: categoryUsagePercent,
+        nextCapacity: nextCapacityValue,
+        items: normalizedItems,
+        slots
+      };
+    });
+  },
+
+  buildStorageSummary(profile) {
+    const storage =
+      profile && profile.equipment && profile.equipment.storage && typeof profile.equipment.storage === 'object'
+        ? profile.equipment.storage
+        : null;
+    if (!storage) {
+      return null;
+    }
+    const categories = Array.isArray(storage.categories) ? storage.categories : [];
+    const summary = storage.summary && typeof storage.summary === 'object' ? storage.summary : null;
+    let baseCapacity =
+      summary && typeof summary.baseCapacity === 'number' ? Math.max(0, Math.floor(summary.baseCapacity)) : 0;
+    if (!baseCapacity && categories.length) {
+      baseCapacity = Math.max(0, Math.floor(Number(categories[0] && categories[0].baseCapacity) || 0));
+    }
+    if (!baseCapacity) {
+      baseCapacity = 100;
+    }
+    let perUpgrade =
+      summary && typeof summary.perUpgrade === 'number' ? Math.max(0, Math.floor(summary.perUpgrade)) : 0;
+    if (!perUpgrade && categories.length) {
+      perUpgrade = Math.max(0, Math.floor(Number(categories[0] && categories[0].perUpgrade) || 0));
+    }
+    if (!perUpgrade) {
+      perUpgrade = 20;
+    }
+    let upgrades =
+      summary && typeof summary.upgrades === 'number' ? Math.max(0, Math.floor(summary.upgrades)) : 0;
+    if (!upgrades && typeof storage.upgrades === 'number') {
+      upgrades = Math.max(0, Math.floor(Number(storage.upgrades) || 0));
+    }
+    let capacity =
+      summary && typeof summary.capacity === 'number' ? Math.max(0, Math.floor(summary.capacity)) : 0;
+    if (!capacity && categories.length) {
+      capacity = Math.max(0, Math.floor(Number(categories[0] && categories[0].capacity) || 0));
+    }
+    if (!capacity) {
+      capacity = baseCapacity + perUpgrade * upgrades;
+    }
+    let used = summary && typeof summary.used === 'number' ? Math.max(0, Math.floor(summary.used)) : 0;
+    if (!used && categories.length) {
+      used = categories.reduce((acc, category) => {
+        const items = Array.isArray(category && category.items) ? category.items : [];
+        return acc + items.length;
+      }, 0);
+    }
+    if (capacity < used) {
+      capacity = used;
+    }
+    let remaining =
+      summary && typeof summary.remaining === 'number'
+        ? Math.max(0, Math.floor(summary.remaining))
+        : Math.max(capacity - used, 0);
+    const upgradeAvailableValue =
+      summary && typeof summary.upgradeAvailable === 'number'
+        ? Math.max(0, Math.floor(summary.upgradeAvailable))
+        : typeof storage.upgradeAvailable !== 'undefined'
+        ? Math.max(0, Math.floor(Number(storage.upgradeAvailable) || 0))
+        : null;
+    const upgradeLimitValue =
+      summary && typeof summary.upgradeLimit === 'number'
+        ? Math.max(0, Math.floor(summary.upgradeLimit))
+        : typeof storage.upgradeLimit !== 'undefined'
+        ? Math.max(0, Math.floor(Number(storage.upgradeLimit) || 0))
+        : null;
+    const usagePercent = capacity ? Math.min(100, Math.round((used / capacity) * 100)) : 0;
+    const nextCapacity = capacity + perUpgrade;
+    let upgradeRemaining = null;
+    if (upgradeAvailableValue !== null) {
+      upgradeRemaining = upgradeAvailableValue;
+    } else if (upgradeLimitValue !== null) {
+      upgradeRemaining = Math.max(upgradeLimitValue - upgrades, 0);
+    }
+    const canUpgrade = upgradeRemaining === null ? true : upgradeRemaining > 0;
+    return {
+      baseCapacity,
+      perUpgrade,
+      upgrades,
+      capacity,
+      used,
+      remaining,
+      usagePercent,
+      nextCapacity,
+      upgradeAvailable: upgradeAvailableValue,
+      upgradeLimit: upgradeLimitValue,
+      upgradeRemaining,
+      canUpgrade
+    };
   },
 
   onLoad(options = {}) {
@@ -85,8 +284,11 @@ Page({
     if (value === 'character' || value === 'role') {
       return 'character';
     }
-    if (value === 'equipment' || value === 'equip' || value === 'bag') {
+    if (value === 'equipment' || value === 'equip') {
       return 'equipment';
+    }
+    if (value === 'storage' || value === 'bag' || value === 'inventory' || value === 'najie') {
+      return 'storage';
     }
     if (value === 'skill' || value === 'skills') {
       return 'skill';
@@ -184,9 +386,10 @@ Page({
       (options && typeof options === 'object' ? options : {}) || {};
     const itemId = typeof dataset.itemId === 'string' ? dataset.itemId : '';
     const slot = typeof dataset.slot === 'string' ? dataset.slot.trim() : '';
+    const inventoryId = typeof dataset.inventoryId === 'string' ? dataset.inventoryId : '';
     if (!itemId) return false;
     try {
-      const res = await PveService.equipItem({ itemId, slot });
+      const res = await PveService.equipItem({ itemId, slot, inventoryId });
       this.applyProfile(res.profile);
       wx.showToast({ title: '装备成功', icon: 'success', duration: 1200 });
       return true;
@@ -241,7 +444,8 @@ Page({
       source,
       slot,
       slotLabel: dataset.slotLabel || rawItem.slotLabel || '',
-      item: { ...rawItem }
+      item: { ...rawItem },
+      inventoryId: dataset.inventoryId || rawItem.inventoryId || ''
     };
     this.setData({ equipmentTooltip: tooltip });
   },
@@ -258,9 +462,11 @@ Page({
     const slot =
       (typeof tooltip.slot === 'string' && tooltip.slot.trim()) ||
       (typeof tooltip.item.slot === 'string' ? tooltip.item.slot : '');
+    const inventoryId = tooltip.item.inventoryId || tooltip.inventoryId || '';
     const success = await this.handleEquipItem({
       itemId: tooltip.item.itemId,
-      slot
+      slot,
+      inventoryId
     });
     if (success) {
       this.closeEquipmentTooltip();
@@ -280,6 +486,46 @@ Page({
     const success = await this.handleUnequipItem({ slot });
     if (success) {
       this.closeEquipmentTooltip();
+    }
+  },
+
+  handleStorageCategoryChange(event) {
+    const dataset = (event && event.currentTarget && event.currentTarget.dataset) || {};
+    const key = typeof dataset.key === 'string' ? dataset.key : '';
+    if (!key || key === this.data.activeStorageCategory) {
+      return;
+    }
+    const categories = Array.isArray(this.data.storageCategories) ? this.data.storageCategories : [];
+    if (!categories.some((category) => category.key === key)) {
+      return;
+    }
+    const activeCategory = categories.find((category) => category.key === key) || null;
+    this.setData({
+      activeStorageCategory: key,
+      activeStorageCategoryData: activeCategory
+    });
+  },
+
+  async handleUpgradeStorage() {
+    const category = this.data.activeStorageCategory;
+    if (!category || this.data.storageUpgrading) {
+      return;
+    }
+    const summary = this.data.storageSummary;
+    if (summary && summary.canUpgrade === false) {
+      wx.showToast({ title: '升级次数不足', icon: 'none' });
+      return;
+    }
+    this.setData({ storageUpgrading: true });
+    try {
+      const res = await PveService.upgradeStorage({ category });
+      const updatedProfile = (res && res.profile) || this.data.profile;
+      this.applyProfile(updatedProfile, { storageUpgrading: false });
+      wx.showToast({ title: '储物空间已扩展', icon: 'success', duration: 1200 });
+    } catch (error) {
+      console.error('[role] upgrade storage failed', error);
+      wx.showToast({ title: error.errMsg || '升级失败', icon: 'none' });
+      this.setData({ storageUpgrading: false });
     }
   },
 

--- a/miniprogram/pages/role/index.wxml
+++ b/miniprogram/pages/role/index.wxml
@@ -14,6 +14,12 @@
       bindtap="handleTabChange"
     >装备</view>
     <view
+      class="tab-item {{activeTab === 'storage' ? 'tab-item--active' : ''}}"
+      data-tab="storage"
+      hover-class="tab-item--hover"
+      bindtap="handleTabChange"
+    >纳戒</view>
+    <view
       class="tab-item {{activeTab === 'skill' ? 'tab-item--active' : ''}}"
       data-tab="skill"
       hover-class="tab-item--hover"
@@ -112,6 +118,83 @@
       </view>
     </block>
 
+    <block wx:elif="{{activeTab === 'storage'}}">
+      <view class="section-card storage-section">
+        <view class="section-header">
+          <view class="section-title">纳戒储物</view>
+        </view>
+        <view wx:if="{{storageCategories.length}}" class="storage-tabs">
+          <view
+            wx:for="{{storageCategories}}"
+            wx:key="key"
+            class="storage-tab {{activeStorageCategory === item.key ? 'storage-tab--active' : ''}}"
+            data-key="{{item.key}}"
+            bindtap="handleStorageCategoryChange"
+          >
+            <text class="storage-tab__label">{{item.label}}</text>
+          </view>
+        </view>
+        <block wx:if="{{activeStorageCategoryData}}">
+          <view class="storage-summary">
+            <view class="storage-summary__line">
+              <text>已用 {{storageSummary ? storageSummary.used : 0}} / {{storageSummary ? storageSummary.capacity : 0}}</text>
+              <text>剩余 {{storageSummary ? storageSummary.remaining : 0}}</text>
+            </view>
+            <progress
+              class="storage-summary__progress"
+              percent="{{storageSummary ? storageSummary.usagePercent : 0}}"
+              stroke-width="6"
+              backgroundColor="#1b2036"
+              activeColor="#566ed2"
+              show-info="{{false}}"
+            ></progress>
+            <view class="storage-summary__actions">
+              <button
+                class="pill-btn pill-btn--primary pill-btn--compact storage-summary__upgrade"
+                hover-class="pill-btn--primary-hover"
+                size="mini"
+                loading="{{storageUpgrading}}"
+                disabled="{{storageUpgrading || (storageSummary && storageSummary.canUpgrade === false)}}"
+                bindtap="handleUpgradeStorage"
+              >升级储物空间</button>
+              <view class="storage-summary__meta">
+                <text>下次升级容量 {{storageSummary ? storageSummary.nextCapacity : 0}}</text>
+                <text wx:if="{{storageSummary && storageSummary.upgradeRemaining !== null}}"
+                  >剩余升级次数 {{storageSummary.upgradeRemaining}}</text>
+              </view>
+            </view>
+          </view>
+          <view class="storage-grid">
+            <block wx:for="{{activeStorageCategoryData.slots}}" wx:key="storageKey">
+              <view wx:if="{{!item.placeholder}}" class="storage-slot">
+                <view class="storage-slot__badge">{{item.slotLabel}}</view>
+                <view
+                  class="storage-slot__frame"
+                  hover-class="storage-slot__frame--hover"
+                  bindtap="handleEquipmentTap"
+                  data-source="storage"
+                  data-slot="{{item.slot}}"
+                  data-slot-label="{{item.slotLabel}}"
+                  data-item="{{item}}"
+                  data-inventory-id="{{item.inventoryId || ''}}"
+                >
+                  <view class="storage-slot__icon" style="border-color: {{item.qualityColor}};">
+                    <view class="storage-slot__name">{{item.shortName || item.name}}</view>
+                  </view>
+                </view>
+              </view>
+              <view wx:else class="storage-slot storage-slot--empty">
+                <view class="storage-slot__frame storage-slot__frame--empty">
+                  <view class="storage-slot__placeholder">空</view>
+                </view>
+              </view>
+            </block>
+          </view>
+        </block>
+        <view wx:else class="empty-tip storage-empty">暂无储物数据</view>
+      </view>
+    </block>
+
     <block wx:elif="{{activeTab === 'equipment'}}">
       <view class="section-card">
         <view class="section-header">
@@ -170,7 +253,7 @@
           <view
             class="inventory-card {{item.equipped ? 'inventory-card--equipped' : ''}}"
             wx:for="{{(profile.equipment && profile.equipment.inventory) || []}}"
-            wx:key="itemId"
+            wx:key="inventoryId"
           >
             <view class="inventory-card__badge">{{item.slotLabel}}</view>
             <view class="inventory-card__frame">
@@ -181,6 +264,7 @@
                 data-source="inventory"
                 data-slot="{{item.slot}}"
                 data-item="{{item}}"
+                data-inventory-id="{{item.inventoryId || ''}}"
               >
                 <view class="inventory-card__icon-name">{{item.shortName || item.name}}</view>
                 <view wx:if="{{item.equipped}}" class="inventory-card__status">已装备</view>

--- a/miniprogram/pages/role/index.wxss
+++ b/miniprogram/pages/role/index.wxss
@@ -486,6 +486,188 @@ button.pill-btn[disabled] {
   box-shadow: 0 0 0 4rpx rgba(120, 176, 255, 0.32);
 }
 
+.storage-section {
+  position: relative;
+}
+
+.storage-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16rpx;
+  margin-bottom: 24rpx;
+}
+
+.storage-tab {
+  padding: 14rpx 24rpx;
+  border-radius: 999rpx;
+  border: 1rpx solid rgba(86, 112, 220, 0.32);
+  background: rgba(20, 34, 84, 0.62);
+  color: rgba(198, 210, 255, 0.82);
+  font-size: 24rpx;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  line-height: 1;
+  transition: all 0.2s ease;
+}
+
+.storage-tab__label {
+  font-weight: 600;
+}
+
+.storage-tab--active {
+  border-color: rgba(130, 156, 255, 0.6);
+  background: linear-gradient(120deg, rgba(94, 124, 248, 0.92), rgba(144, 94, 255, 0.92));
+  color: #f8faff;
+  box-shadow: 0 10rpx 22rpx rgba(86, 108, 228, 0.28);
+}
+
+.storage-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 16rpx;
+  padding: 20rpx 24rpx;
+  border-radius: 24rpx;
+  background: rgba(24, 38, 88, 0.72);
+  border: 1rpx solid rgba(94, 122, 230, 0.28);
+  margin-bottom: 28rpx;
+}
+
+.storage-summary__line {
+  display: flex;
+  justify-content: space-between;
+  font-size: 24rpx;
+  color: rgba(205, 214, 255, 0.82);
+}
+
+.storage-summary__progress {
+  width: 100%;
+}
+
+.storage-summary__actions {
+  display: flex;
+  align-items: flex-start;
+  gap: 16rpx;
+  flex-wrap: wrap;
+}
+
+.pill-btn--compact {
+  min-width: 0;
+  padding: 0 24rpx;
+  height: 52rpx;
+  line-height: 52rpx;
+  font-size: 24rpx;
+}
+
+.storage-summary__upgrade {
+  margin-right: 0;
+}
+
+.storage-summary__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6rpx;
+  font-size: 22rpx;
+  color: rgba(186, 198, 255, 0.76);
+}
+
+.storage-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16rpx;
+}
+
+.storage-slot {
+  position: relative;
+  background: rgba(16, 28, 70, 0.85);
+  border-radius: 20rpx;
+  border: 1rpx solid rgba(86, 116, 210, 0.34);
+  box-sizing: border-box;
+  min-height: 0;
+}
+
+.storage-slot::before {
+  content: '';
+  display: block;
+  padding-top: 100%;
+}
+
+.storage-slot__badge {
+  position: absolute;
+  top: 12rpx;
+  left: 12rpx;
+  padding: 4rpx 12rpx;
+  font-size: 20rpx;
+  border-radius: 999rpx;
+  background: rgba(72, 94, 200, 0.42);
+  color: rgba(214, 224, 255, 0.88);
+  line-height: 1;
+  z-index: 2;
+}
+
+.storage-slot__frame {
+  position: absolute;
+  inset: 12rpx;
+  border-radius: 16rpx;
+  border: 4rpx solid rgba(118, 146, 250, 0.58);
+  background: rgba(10, 18, 48, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12rpx;
+  box-sizing: border-box;
+  transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.storage-slot__frame--hover {
+  border-color: rgba(150, 176, 255, 0.68);
+  box-shadow: 0 10rpx 24rpx rgba(90, 118, 240, 0.32);
+  transform: translateY(-2rpx);
+}
+
+.storage-slot__frame--empty {
+  border: 2rpx dashed rgba(102, 128, 210, 0.32);
+  background: rgba(12, 18, 40, 0.65);
+}
+
+.storage-slot__icon {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #f4f6ff;
+}
+
+.storage-slot__name {
+  font-size: 20rpx;
+  font-weight: 600;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+
+.storage-slot__placeholder {
+  font-size: 22rpx;
+  color: rgba(168, 186, 255, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.storage-slot--empty {
+  border: 1rpx dashed rgba(94, 122, 210, 0.32);
+  background: rgba(14, 22, 48, 0.6);
+}
+
+.storage-empty {
+  margin-top: 24rpx;
+}
+
 .equipment-summary {
   margin-top: 28rpx;
   padding: 24rpx;

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -279,17 +279,28 @@ export const PveService = {
     }
     return callCloud(CLOUD_FUNCTIONS.PVE, payload);
   },
-  async equipItem({ itemId = '', slot = '' } = {}) {
+  async equipItem({ itemId = '', slot = '', inventoryId = '' } = {}) {
     const payload = { action: 'equipItem' };
     const normalizedItemId = typeof itemId === 'string' ? itemId : '';
     const normalizedSlot = typeof slot === 'string' ? slot.trim() : '';
+    const normalizedInventoryId = typeof inventoryId === 'string' ? inventoryId.trim() : '';
     if (normalizedItemId) {
       payload.itemId = normalizedItemId;
     }
     if (normalizedSlot) {
       payload.slot = normalizedSlot;
     }
+    if (normalizedInventoryId) {
+      payload.inventoryId = normalizedInventoryId;
+    }
     return callCloud(CLOUD_FUNCTIONS.PVE, payload);
+  },
+  async upgradeStorage({ category = '' } = {}) {
+    const normalizedCategory = typeof category === 'string' ? category.trim() : '';
+    return callCloud(CLOUD_FUNCTIONS.PVE, {
+      action: 'upgradeStorage',
+      category: normalizedCategory
+    });
   },
   async allocatePoints(allocations = {}) {
     return callCloud(CLOUD_FUNCTIONS.PVE, { action: 'allocatePoints', allocations });

--- a/miniprogram/utils/equipment.js
+++ b/miniprogram/utils/equipment.js
@@ -15,6 +15,8 @@ const DEFAULT_EQUIPMENT_IDS = [
 
 const DEFAULT_EQUIPMENT_ID_SET = new Set(DEFAULT_EQUIPMENT_IDS);
 
+const EXCLUDED_SLOT_KEYS = new Set(['accessory', 'armor']);
+
 function cloneItem(item) {
   return item && typeof item === 'object' ? { ...item } : null;
 }
@@ -46,15 +48,23 @@ export function sanitizeEquipmentProfile(profile) {
   const equipment = profile.equipment && typeof profile.equipment === 'object' ? profile.equipment : {};
   const rawSlots = Array.isArray(equipment.slots) ? equipment.slots : [];
   const rawInventory = Array.isArray(equipment.inventory) ? equipment.inventory : [];
+  const rawStorage = equipment.storage && typeof equipment.storage === 'object' ? equipment.storage : {};
 
-  const sanitizedSlots = rawSlots.map((slot) => {
-    if (!slot || typeof slot !== 'object') {
-      return { slot: '', slotLabel: '', item: null };
-    }
-    const rawItem = slot.item && typeof slot.item === 'object' ? slot.item : null;
-    const item = rawItem && rawItem.itemId && !isDefaultEquipmentId(rawItem.itemId) ? cloneItem(rawItem) : null;
-    return { ...slot, item };
-  });
+  const sanitizedSlots = rawSlots
+    .map((slot) => {
+      if (!slot || typeof slot !== 'object') {
+        return { slot: '', slotLabel: '', item: null };
+      }
+      const rawItem = slot.item && typeof slot.item === 'object' ? slot.item : null;
+      const item = rawItem && rawItem.itemId && !isDefaultEquipmentId(rawItem.itemId) ? cloneItem(rawItem) : null;
+      return { ...slot, item };
+    })
+    .filter((slot) => {
+      if (!slot || !slot.slot) {
+        return true;
+      }
+      return !EXCLUDED_SLOT_KEYS.has(slot.slot);
+    });
 
   const sanitizedInventory = rawInventory
     .filter((item) => item && typeof item === 'object' && item.itemId && !isDefaultEquipmentId(item.itemId))
@@ -87,10 +97,90 @@ export function sanitizeEquipmentProfile(profile) {
 
   const notes = extractNotesFromSlots(sanitizedSlots);
 
+  const storageCategories = Array.isArray(rawStorage.categories) ? rawStorage.categories : [];
+  const sanitizedCategories = storageCategories
+    .map((category) => {
+      if (!category || typeof category !== 'object') {
+        return null;
+      }
+      const items = Array.isArray(category.items)
+        ? category.items
+            .filter((item) => {
+              if (!item || typeof item !== 'object') {
+                return false;
+              }
+              if (item.itemId) {
+                return !isDefaultEquipmentId(item.itemId);
+              }
+              return true;
+            })
+            .map((item) => cloneItem(item))
+        : [];
+      const capacity = Math.max(0, Math.floor(Number(category.capacity) || 0));
+      const used = Math.max(0, Math.floor(Number(category.used) || items.length));
+      const remaining = Math.max(0, Math.floor(Number(category.remaining) || Math.max(capacity - items.length, 0)));
+      const upgrades = Math.max(0, Math.floor(Number(category.upgrades) || 0));
+      const baseCapacity = Math.max(0, Math.floor(Number(category.baseCapacity) || 0));
+      const perUpgrade = Math.max(0, Math.floor(Number(category.perUpgrade) || 0));
+      return {
+        ...category,
+        baseCapacity,
+        perUpgrade,
+        upgrades,
+        capacity,
+        used,
+        remaining,
+        items
+      };
+    })
+    .filter((category) => !!category);
+
+  const rawSummary = rawStorage && typeof rawStorage.summary === 'object' ? rawStorage.summary : null;
+  let sanitizedSummary = null;
+  if (rawSummary) {
+    const baseCapacity = Math.max(0, Math.floor(Number(rawSummary.baseCapacity) || 0));
+    const perUpgrade = Math.max(0, Math.floor(Number(rawSummary.perUpgrade) || 0));
+    const upgrades = Math.max(0, Math.floor(Number(rawSummary.upgrades) || 0));
+    const capacity = Math.max(0, Math.floor(Number(rawSummary.capacity) || baseCapacity + perUpgrade * upgrades));
+    const used = Math.max(0, Math.floor(Number(rawSummary.used) || 0));
+    const remaining = Math.max(0, Math.floor(Number(rawSummary.remaining) || Math.max(capacity - used, 0)));
+    const upgradeAvailable =
+      typeof rawSummary.upgradeAvailable !== 'undefined'
+        ? Math.max(0, Math.floor(Number(rawSummary.upgradeAvailable) || 0))
+        : null;
+    const upgradeLimit =
+      typeof rawSummary.upgradeLimit !== 'undefined'
+        ? Math.max(0, Math.floor(Number(rawSummary.upgradeLimit) || 0))
+        : null;
+    sanitizedSummary = {
+      baseCapacity,
+      perUpgrade,
+      upgrades,
+      capacity,
+      used,
+      remaining
+    };
+    if (upgradeAvailable !== null) {
+      sanitizedSummary.upgradeAvailable = upgradeAvailable;
+    }
+    if (upgradeLimit !== null) {
+      sanitizedSummary.upgradeLimit = upgradeLimit;
+    }
+  }
+
+  const sanitizedStorage = { categories: sanitizedCategories };
+  if (typeof rawStorage.upgrades !== 'undefined') {
+    sanitizedStorage.upgrades = Math.max(0, Math.floor(Number(rawStorage.upgrades) || 0));
+  }
+  if (sanitizedSummary) {
+    sanitizedStorage.summary = sanitizedSummary;
+  }
+
   const sanitizedEquipment = {
     ...equipment,
     slots: sanitizedSlots,
     inventory: sanitizedInventory,
+    storage: sanitizedStorage,
     bonus: {
       sets: sanitizedSets,
       notes


### PR DESCRIPTION
## Summary
- add a quest storage category and treat storage upgrades as a shared pool with availability checks in the PVE cloud function
- surface shared capacity/upgrades in the role page storage tab with text-only tabs and a compact upgrade control
- sanitize storage payloads to retain summary fields and non-equipment items for the new shared view

## Testing
- Not run (WeChat mini program tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dcfa00b1588330ac94590205147e86