### PR TITLE
Unify storage capacity and add quest tab

### DIFF
--- a/cloudfunctions/pve/index.js
+++ b/cloudfunctions/pve/index.js
@@ -15,6 +15,14 @@ const MAX_SKILL_SLOTS = 3;
 const MAX_BATTLE_HISTORY = 15;
 const MAX_SKILL_HISTORY = 30;
 
+const STORAGE_CATEGORY_DEFINITIONS = [
+  { key: 'equipment', label: '装备', baseCapacity: 100, perUpgrade: 20 },
+  { key: 'quest', label: '任务', baseCapacity: 100, perUpgrade: 20 },
+  { key: 'material', label: '材料', baseCapacity: 100, perUpgrade: 20 },
+  { key: 'consumable', label: '道具', baseCapacity: 100, perUpgrade: 20 }
+];
+const STORAGE_CATEGORY_KEYS = STORAGE_CATEGORY_DEFINITIONS.map((item) => item.key);
+
 const BASE_ATTRIBUTE_KEYS = ['constitution', 'strength', 'spirit', 'root', 'agility', 'insight'];
 const COMBAT_STAT_KEYS = [
   'maxHp',
@@ -308,6 +316,12 @@ const EQUIPMENT_SLOT_LABELS = Object.keys(EQUIPMENT_SLOTS).reduce((map, key) => 
   map[key] = EQUIPMENT_SLOTS[key].label;
   return map;
 }, {});
+
+const IGNORED_EQUIPMENT_SLOTS = new Set(['accessory', 'armor']);
+
+function isIgnoredEquipmentSlot(slot) {
+  return typeof slot === 'string' && IGNORED_EQUIPMENT_SLOTS.has(slot);
+}
 
 const EQUIPMENT_QUALITY_CONFIG = {
   mortal: { key: 'mortal', label: '凡品', color: '#8d9099', mainCoefficient: 0.8, subCount: 0, subTierRange: ['common'], dropWeight: 42 },
@@ -2025,6 +2039,8 @@ exports.main = async (event = {}) => {
       return equipSkill(actorId, event);
     case 'equipItem':
       return equipItem(actorId, event);
+    case 'upgradeStorage':
+      return upgradeStorage(actorId);
     case 'listEquipmentCatalog':
       return listEquipmentCatalog(actorId);
     case 'adminInspectProfile':
@@ -2065,7 +2081,7 @@ async function simulateBattle(actorId, enemyId) {
 
   const now = new Date();
   const updatedProfile = applyBattleOutcome(profile, result, enemy, now, member, levels);
-  const updates = { pveProfile: updatedProfile, updatedAt: now };
+  const updates = { pveProfile: _.set(updatedProfile), updatedAt: now };
   if (result.rewards && result.rewards.stones > 0) {
     updates.stoneBalance = _.inc(result.rewards.stones);
   }
@@ -2128,7 +2144,7 @@ async function drawSkill(actorId) {
 
   await db.collection(COLLECTIONS.MEMBERS).doc(actorId).update({
     data: {
-      pveProfile: profile,
+      pveProfile: _.set(profile),
       updatedAt: now
     }
   });
@@ -2197,7 +2213,7 @@ async function equipSkill(actorId, event) {
 
   await db.collection(COLLECTIONS.MEMBERS).doc(actorId).update({
     data: {
-      pveProfile: profile,
+      pveProfile: _.set(profile),
       updatedAt: now
     }
   });
@@ -2208,10 +2224,15 @@ async function equipSkill(actorId, event) {
 
 async function equipItem(actorId, event) {
   const { itemId, slot: rawSlot } = event;
+  const inventoryId =
+    event && typeof event.inventoryId === 'string' && event.inventoryId.trim() ? event.inventoryId.trim() : '';
   const member = await ensureMember(actorId);
   const profile = await ensurePveProfile(actorId, member);
   const inventory = Array.isArray(profile.equipment.inventory) ? profile.equipment.inventory : [];
-  const slots = profile.equipment.slots || {};
+  const slots =
+    profile.equipment && typeof profile.equipment.slots === 'object' && profile.equipment.slots
+      ? profile.equipment.slots
+      : createEmptySlotMap();
 
   const slot = typeof rawSlot === 'string' ? rawSlot.trim() : '';
 
@@ -2222,13 +2243,28 @@ async function equipItem(actorId, event) {
     if (!Object.prototype.hasOwnProperty.call(EQUIPMENT_SLOTS, slot)) {
       throw createError('INVALID_SLOT', '装备槽位不存在');
     }
-    const currentItemId = slots[slot];
-    if (!currentItemId) {
+    const currentEntry = slots[slot];
+    if (!currentEntry || !currentEntry.itemId) {
       throw createError('SLOT_EMPTY', '该槽位暂无装备');
     }
 
-    slots[slot] = '';
+    slots[slot] = null;
     profile.equipment.slots = slots;
+
+    if (currentEntry) {
+      const normalizedEntry = normalizeEquipmentInventoryItem(currentEntry, new Date()) || {
+        ...createEquipmentInventoryEntry(currentEntry.itemId, new Date())
+      };
+      if (normalizedEntry && normalizedEntry.inventoryId) {
+        const existingIndex = inventory.findIndex((entry) => entry.inventoryId === normalizedEntry.inventoryId);
+        if (existingIndex >= 0) {
+          inventory.splice(existingIndex, 1);
+        }
+      }
+      if (normalizedEntry) {
+        inventory.push(normalizedEntry);
+      }
+    }
 
     const now = new Date();
     profile.battleHistory = appendHistory(
@@ -2236,14 +2272,20 @@ async function equipItem(actorId, event) {
       {
         type: 'equipment-change',
         createdAt: now,
-        detail: { slot, itemId: currentItemId, action: 'unequip' }
+        detail: {
+          slot,
+          itemId: currentEntry.itemId,
+          inventoryId: currentEntry.inventoryId || '',
+          action: 'unequip'
+        }
       },
       MAX_BATTLE_HISTORY
     );
 
+    profile.equipment.inventory = inventory;
     await db.collection(COLLECTIONS.MEMBERS).doc(actorId).update({
       data: {
-        pveProfile: profile,
+        pveProfile: _.set(profile),
         updatedAt: now
       }
     });
@@ -2255,8 +2297,14 @@ async function equipItem(actorId, event) {
   if (!definition) {
     throw createError('ITEM_NOT_FOUND', '装备不存在');
   }
-  const hasItem = inventory.some((entry) => entry.itemId === itemId);
-  if (!hasItem) {
+  let index = -1;
+  if (inventoryId) {
+    index = inventory.findIndex((entry) => entry.inventoryId === inventoryId);
+  }
+  if (index < 0) {
+    index = inventory.findIndex((entry) => entry.itemId === itemId);
+  }
+  if (index < 0) {
     throw createError('ITEM_NOT_OWNED', '尚未拥有该装备，无法装备');
   }
 
@@ -2264,29 +2312,125 @@ async function equipItem(actorId, event) {
     throw createError('SLOT_MISMATCH', '装备与槽位不匹配');
   }
 
-  slots[definition.slot] = itemId;
-  profile.equipment.slots = slots;
-
   const now = new Date();
+  const entry = inventory.splice(index, 1)[0];
+  const normalizedEntry = normalizeEquipmentInventoryItem(entry, now) || createEquipmentInventoryEntry(itemId, now);
+  const targetSlot = definition.slot;
+  const previous = slots[targetSlot];
+  if (previous && previous.itemId) {
+    const previousNormalized = normalizeEquipmentInventoryItem(previous, now);
+    if (previousNormalized) {
+      if (previousNormalized.inventoryId) {
+        const existingIndex = inventory.findIndex((record) => record.inventoryId === previousNormalized.inventoryId);
+        if (existingIndex >= 0) {
+          inventory.splice(existingIndex, 1);
+        }
+      }
+      inventory.push(previousNormalized);
+    }
+  }
+  slots[targetSlot] = normalizedEntry ? { ...normalizedEntry } : null;
+  profile.equipment.slots = slots;
+  profile.equipment.inventory = inventory;
+
   profile.battleHistory = appendHistory(
     profile.battleHistory,
     {
       type: 'equipment-change',
       createdAt: now,
-      detail: { itemId, slot: definition.slot, action: 'equip' }
+      detail: {
+        itemId,
+        slot: definition.slot,
+        inventoryId: normalizedEntry && normalizedEntry.inventoryId ? normalizedEntry.inventoryId : '',
+        action: 'equip'
+      }
     },
     MAX_BATTLE_HISTORY
   );
 
   await db.collection(COLLECTIONS.MEMBERS).doc(actorId).update({
     data: {
-      pveProfile: profile,
+      pveProfile: _.set(profile),
       updatedAt: now
     }
   });
 
   const decorated = decorateProfile(member, profile);
   return { profile: decorated };
+}
+
+async function upgradeStorage(actorId) {
+  const member = await ensureMember(actorId);
+  const profile = await ensurePveProfile(actorId, member);
+  const storage =
+    profile.equipment && typeof profile.equipment.storage === 'object' ? profile.equipment.storage : {};
+  const storageDefaults = STORAGE_CATEGORY_DEFINITIONS[0] || { baseCapacity: 100, perUpgrade: 20 };
+  const baseCapacity = Math.max(
+    0,
+    Math.floor(Number(storage.baseCapacity != null ? storage.baseCapacity : storageDefaults.baseCapacity || 100))
+  );
+  const perUpgrade = Math.max(
+    0,
+    Math.floor(Number(storage.perUpgrade != null ? storage.perUpgrade : storageDefaults.perUpgrade || 20))
+  );
+  let current = 0;
+  if (typeof storage.upgrades === 'number') {
+    current = Math.max(0, Math.floor(storage.upgrades));
+  } else if (storage.upgrades && typeof storage.upgrades === 'object') {
+    STORAGE_CATEGORY_KEYS.forEach((key) => {
+      const value = Math.max(0, Math.floor(Number(storage.upgrades[key] || 0)));
+      if (value > current) {
+        current = value;
+      }
+    });
+  }
+  const availableRaw = storage.upgradeAvailable;
+  const hasLimit = typeof availableRaw !== 'undefined' && availableRaw !== null;
+  const available = hasLimit ? Math.max(0, Math.floor(Number(availableRaw))) : null;
+  if (hasLimit && available <= 0) {
+    throw createError('NO_STORAGE_UPGRADES', '储物空间升级次数不足');
+  }
+  const next = current + 1;
+  let updatedUpgrades;
+  if (storage.upgrades && typeof storage.upgrades === 'object') {
+    updatedUpgrades = { ...storage.upgrades };
+    STORAGE_CATEGORY_KEYS.forEach((key) => {
+      updatedUpgrades[key] = next;
+    });
+  } else {
+    updatedUpgrades = next;
+  }
+  const updatedStorage = { ...storage, upgrades: updatedUpgrades };
+  if (typeof updatedStorage.baseCapacity === 'undefined') {
+    updatedStorage.baseCapacity = baseCapacity;
+  }
+  if (typeof updatedStorage.perUpgrade === 'undefined') {
+    updatedStorage.perUpgrade = perUpgrade;
+  }
+  if (Object.prototype.hasOwnProperty.call(updatedStorage, 'overview')) {
+    delete updatedStorage.overview;
+  }
+  if (hasLimit) {
+    updatedStorage.upgradeAvailable = Math.max(available - 1, 0);
+  }
+  profile.equipment.storage = updatedStorage;
+  const now = new Date();
+  await db.collection(COLLECTIONS.MEMBERS).doc(actorId).update({
+    data: {
+      pveProfile: _.set(profile),
+      updatedAt: now
+    }
+  });
+  const decorated = decorateProfile(member, profile);
+  const capacity = baseCapacity + perUpgrade * next;
+  return {
+    profile: decorated,
+    storage: {
+      upgrades: next,
+      capacity,
+      remainingUpgrades: hasLimit ? Math.max(available - 1, 0) : null
+    }
+  };
 }
 
 async function allocatePoints(actorId, allocations) {
@@ -2325,7 +2469,7 @@ async function allocatePoints(actorId, allocations) {
 
   await db.collection(COLLECTIONS.MEMBERS).doc(actorId).update({
     data: {
-      pveProfile: profile,
+      pveProfile: _.set(profile),
       updatedAt: now
     }
   });
@@ -2382,7 +2526,7 @@ async function resetAttributes(actorId) {
 
   await db.collection(COLLECTIONS.MEMBERS).doc(actorId).update({
     data: {
-      pveProfile: profile,
+      pveProfile: _.set(profile),
       updatedAt: now
     }
   });
@@ -2463,7 +2607,7 @@ async function grantEquipment(actorId, event = {}) {
 
   await db.collection(COLLECTIONS.MEMBERS).doc(memberId).update({
     data: {
-      pveProfile: profile,
+      pveProfile: _.set(profile),
       updatedAt: now
     }
   });
@@ -2503,10 +2647,23 @@ async function removeEquipment(actorId, event = {}) {
   const definition = EQUIPMENT_MAP[itemId];
   inventory.splice(index, 1);
   profile.equipment.inventory = inventory;
-  const slots = typeof profile.equipment.slots === 'object' && profile.equipment.slots ? profile.equipment.slots : {};
+  const slots =
+    profile.equipment && typeof profile.equipment.slots === 'object'
+      ? profile.equipment.slots
+      : createEmptySlotMap();
   Object.keys(slots).forEach((slotKey) => {
-    if (slots[slotKey] === itemId) {
-      slots[slotKey] = '';
+    const slotEntry = slots[slotKey];
+    if (!slotEntry) {
+      return;
+    }
+    if (inventoryId) {
+      if (slotEntry && slotEntry.inventoryId === inventoryId) {
+        slots[slotKey] = null;
+      }
+      return;
+    }
+    if (slotEntry.itemId === itemId) {
+      slots[slotKey] = null;
     }
   });
   profile.equipment.slots = slots;
@@ -2522,7 +2679,7 @@ async function removeEquipment(actorId, event = {}) {
 
   await db.collection(COLLECTIONS.MEMBERS).doc(memberId).update({
     data: {
-      pveProfile: profile,
+      pveProfile: _.set(profile),
       updatedAt: now
     }
   });
@@ -2619,7 +2776,7 @@ async function updateEquipmentAttributes(actorId, event = {}) {
 
   await db.collection(COLLECTIONS.MEMBERS).doc(memberId).update({
     data: {
-      pveProfile: profile,
+      pveProfile: _.set(profile),
       updatedAt: now
     }
   });
@@ -2702,7 +2859,7 @@ async function ensurePveProfile(actorId, member, levelCache) {
   if (changed) {
     await db.collection(COLLECTIONS.MEMBERS).doc(actorId).update({
       data: {
-        pveProfile: profile,
+        pveProfile: _.set(profile),
         updatedAt: now
       }
     });
@@ -2754,7 +2911,7 @@ function buildDefaultAttributes() {
 function createEmptySlotMap() {
   const slots = {};
   Object.keys(EQUIPMENT_SLOTS).forEach((slot) => {
-    slots[slot] = '';
+    slots[slot] = null;
   });
   return slots;
 }
@@ -2774,14 +2931,17 @@ function buildDefaultEquipment(now = new Date()) {
     'initiate_focus',
     'initiate_treasure'
   ];
-  const inventory = defaults
+  const generated = defaults
     .map((itemId) => createEquipmentInventoryEntry(itemId, now))
     .filter((entry) => !!entry);
   const slots = createEmptySlotMap();
-  inventory.forEach((entry) => {
+  const inventory = [];
+  generated.forEach((entry) => {
     const definition = EQUIPMENT_MAP[entry.itemId];
     if (definition && definition.slot && !slots[definition.slot]) {
-      slots[definition.slot] = entry.itemId;
+      slots[definition.slot] = { ...entry };
+    } else {
+      inventory.push({ ...entry });
     }
   });
   return { inventory, slots };
@@ -2880,82 +3040,150 @@ function normalizeEquipment(equipment, now = new Date(), options = {}) {
   const includeDefaults = options && options.includeDefaults !== false;
   const defaults = includeDefaults ? buildDefaultEquipment(now) : { inventory: [], slots: createEmptySlotMap() };
   const payload = typeof equipment === 'object' && equipment ? equipment : {};
-  const inventory = Array.isArray(payload.inventory) ? payload.inventory : [];
+  const rawInventory = Array.isArray(payload.inventory) ? payload.inventory : [];
   const normalizedInventory = [];
   const seenInventoryIds = new Set();
-  const itemCounts = {};
-  const trackEntry = (entry) => {
-    if (!entry) {
+
+  const trackInventory = (entry) => {
+    if (!entry || !entry.inventoryId || seenInventoryIds.has(entry.inventoryId)) {
       return;
     }
     normalizedInventory.push(entry);
-    if (entry && entry.inventoryId) {
-      seenInventoryIds.add(entry.inventoryId);
-    }
-    if (entry && entry.itemId) {
-      itemCounts[entry.itemId] = (itemCounts[entry.itemId] || 0) + 1;
-    }
+    seenInventoryIds.add(entry.inventoryId);
   };
-  inventory.forEach((item) => {
+
+  rawInventory.forEach((item) => {
     const normalizedItem = normalizeEquipmentInventoryItem(item, now);
-    if (normalizedItem && !seenInventoryIds.has(normalizedItem.inventoryId)) {
-      trackEntry(normalizedItem);
+    if (normalizedItem) {
+      trackInventory(normalizedItem);
     }
   });
-  if (includeDefaults) {
-    defaults.inventory.forEach((item) => {
-      if (!itemCounts[item.itemId]) {
-        trackEntry(item);
-      }
-    });
-  }
 
-  const slots = { ...defaults.slots };
+  (defaults.inventory || []).forEach((entry) => {
+    if (entry) {
+      trackInventory({ ...entry });
+    }
+  });
+
+  const availableById = new Map();
+  const availableByItemId = {};
+  normalizedInventory.forEach((entry) => {
+    availableById.set(entry.inventoryId, entry);
+    if (!availableByItemId[entry.itemId]) {
+      availableByItemId[entry.itemId] = [];
+    }
+    availableByItemId[entry.itemId].push(entry);
+  });
+
+  const claimEntry = (entry) => {
+    if (!entry || !entry.inventoryId) {
+      return entry || null;
+    }
+    const claimed = availableById.get(entry.inventoryId);
+    if (!claimed) {
+      return entry;
+    }
+    availableById.delete(entry.inventoryId);
+    const list = availableByItemId[entry.itemId] || [];
+    const index = list.findIndex((candidate) => candidate.inventoryId === entry.inventoryId);
+    if (index >= 0) {
+      list.splice(index, 1);
+    }
+    return claimed;
+  };
+
+  const claimByItemId = (itemId) => {
+    const list = availableByItemId[itemId];
+    if (!list || !list.length) {
+      return null;
+    }
+    const entry = list.shift();
+    if (entry && entry.inventoryId) {
+      availableById.delete(entry.inventoryId);
+    }
+    return entry ? { ...entry } : null;
+  };
+
+  const resolvedSlots = createEmptySlotMap();
   const rawSlots = payload.slots || {};
-  const ensureInventoryEntry = (itemId) => {
-    if (!itemId || itemCounts[itemId]) {
+
+  Object.keys(resolvedSlots).forEach((slot) => {
+    const raw = rawSlots[slot];
+    let normalizedEntry = null;
+    if (raw && typeof raw === 'object' && raw.itemId) {
+      const candidate = normalizeEquipmentInventoryItem(raw, now);
+      if (candidate) {
+        normalizedEntry = { ...candidate };
+      }
+    } else if (typeof raw === 'string' && raw) {
+      normalizedEntry = claimByItemId(raw);
+    }
+    if (!normalizedEntry && defaults.slots && defaults.slots[slot]) {
+      normalizedEntry = { ...defaults.slots[slot] };
+    }
+    if (normalizedEntry) {
+      const claimed = claimEntry(normalizedEntry);
+      resolvedSlots[slot] = claimed ? { ...claimed } : { ...normalizedEntry };
+    } else {
+      resolvedSlots[slot] = null;
+    }
+  });
+
+  Object.keys(rawSlots || {}).forEach((slot) => {
+    if (isIgnoredEquipmentSlot(slot)) {
       return;
     }
-    const entry = createEquipmentInventoryEntry(itemId, now);
-    if (entry && !seenInventoryIds.has(entry.inventoryId)) {
-      trackEntry(entry);
+    if (Object.prototype.hasOwnProperty.call(resolvedSlots, slot)) {
+      return;
     }
-  };
-  Object.keys(slots).forEach((slot) => {
-    const candidate = typeof rawSlots[slot] === 'string' ? rawSlots[slot] : '';
-    if (candidate && EQUIPMENT_MAP[candidate]) {
-      if (itemCounts[candidate]) {
-        slots[slot] = candidate;
-      } else if (includeDefaults) {
-        ensureInventoryEntry(candidate);
-        if (itemCounts[candidate]) {
-          slots[slot] = candidate;
-        }
-      } else {
-        slots[slot] = '';
+    const raw = rawSlots[slot];
+    let normalizedEntry = null;
+    if (raw && typeof raw === 'object' && raw.itemId) {
+      const candidate = normalizeEquipmentInventoryItem(raw, now);
+      if (candidate) {
+        normalizedEntry = { ...candidate };
       }
-    } else if (!includeDefaults) {
-      slots[slot] = '';
+    } else if (typeof raw === 'string' && raw) {
+      normalizedEntry = claimByItemId(raw);
     }
+    resolvedSlots[slot] = normalizedEntry ? { ...normalizedEntry } : null;
   });
 
-  if (!includeDefaults) {
-    Object.keys(rawSlots).forEach((slot) => {
-      if (Object.prototype.hasOwnProperty.call(slots, slot)) {
-        return;
-      }
-      const candidate = typeof rawSlots[slot] === 'string' ? rawSlots[slot] : '';
-      if (candidate && EQUIPMENT_MAP[candidate]) {
-        if (itemCounts[candidate]) {
-          slots[slot] = candidate;
+  const remainingInventory = Array.from(availableById.values()).map((entry) => ({ ...entry }));
+
+  const rawStorage = payload.storage && typeof payload.storage === 'object' ? payload.storage : {};
+  let storageUpgradeLevel = 0;
+  if (typeof rawStorage.upgrades === 'number') {
+    storageUpgradeLevel = Math.max(0, Math.floor(rawStorage.upgrades));
+  } else if (rawStorage.upgrades && typeof rawStorage.upgrades === 'object') {
+    STORAGE_CATEGORY_KEYS.forEach((key) => {
+      const value = Number(rawStorage.upgrades[key]);
+      if (Number.isFinite(value)) {
+        const normalized = Math.max(0, Math.floor(value));
+        if (normalized > storageUpgradeLevel) {
+          storageUpgradeLevel = normalized;
         }
-      } else {
-        slots[slot] = '';
       }
     });
   }
+  const storageData = { upgrades: storageUpgradeLevel };
+  if (typeof rawStorage.upgradeAvailable === 'number' && Number.isFinite(rawStorage.upgradeAvailable)) {
+    storageData.upgradeAvailable = Math.max(0, Math.floor(rawStorage.upgradeAvailable));
+  } else if (rawStorage.upgradeAvailable === null) {
+    storageData.upgradeAvailable = null;
+  }
+  if (typeof rawStorage.baseCapacity === 'number' && Number.isFinite(rawStorage.baseCapacity)) {
+    storageData.baseCapacity = Math.max(0, Math.floor(rawStorage.baseCapacity));
+  }
+  if (typeof rawStorage.perUpgrade === 'number' && Number.isFinite(rawStorage.perUpgrade)) {
+    storageData.perUpgrade = Math.max(0, Math.floor(rawStorage.perUpgrade));
+  }
 
-  return { inventory: normalizedInventory, slots };
+  return {
+    inventory: remainingInventory,
+    slots: resolvedSlots,
+    storage: storageData
+  };
 }
 
 function normalizeSkills(skills, now = new Date()) {
@@ -3412,20 +3640,25 @@ function sumEquipmentBonuses(equipment) {
     return summary;
   }
   const slots = equipment.slots || {};
-  const inventory = Array.isArray(equipment.inventory) ? equipment.inventory : [];
-  const inventoryMap = inventory.reduce((map, item) => {
-    map[item.itemId] = item;
-    return map;
-  }, {});
   const setCounters = {};
 
   Object.keys(slots).forEach((slot) => {
-    const itemId = slots[slot];
+    if (isIgnoredEquipmentSlot(slot)) {
+      return;
+    }
+    const slotEntry = slots[slot];
+    const itemId =
+      typeof slotEntry === 'string'
+        ? slotEntry
+        : slotEntry && typeof slotEntry === 'object' && slotEntry.itemId
+        ? slotEntry.itemId
+        : '';
     if (!itemId) return;
     const definition = EQUIPMENT_MAP[itemId];
     if (!definition) return;
-    const owned = inventoryMap[itemId] || { itemId, refine: 0 };
-    const detail = calculateEquipmentStats(definition, owned.refine || 0);
+    const refine =
+      slotEntry && typeof slotEntry.refine === 'number' ? Math.max(0, Math.floor(slotEntry.refine)) : 0;
+    const detail = calculateEquipmentStats(definition, refine);
     const bonusStats = detail.stats || {};
     Object.keys(bonusStats).forEach((key) => {
       applyBonus(summary, key, bonusStats[key]);
@@ -3817,47 +4050,158 @@ function decorateEquipment(profile, summary = null) {
   const equipment = profile.equipment || {};
   const inventory = Array.isArray(equipment.inventory) ? equipment.inventory : [];
   const slots = equipment.slots || {};
-  const list = inventory
-    .map((entry) => decorateEquipmentInventoryEntry(entry, slots))
-    .filter((item) => !!item);
-  const slotItemIds = Object.values(slots || {}).filter((value) => typeof value === 'string' && value);
-  const equippedCounts = {};
-  slotItemIds.forEach((itemId) => {
-    equippedCounts[itemId] = (equippedCounts[itemId] || 0) + 1;
-  });
-  const equippedUsage = {};
-  list.forEach((item) => {
-    const limit = equippedCounts[item.itemId] || 0;
-    const used = equippedUsage[item.itemId] || 0;
-    item.equipped = used < limit;
-    equippedUsage[item.itemId] = used + 1;
-  });
-  const entriesByItemId = {};
-  list.forEach((item) => {
-    if (!entriesByItemId[item.itemId]) {
-      entriesByItemId[item.itemId] = [];
+  const equippedInventoryIds = new Set();
+  const slotDetails = [];
+  Object.keys(EQUIPMENT_SLOT_LABELS).forEach((slot) => {
+    if (isIgnoredEquipmentSlot(slot)) {
+      return;
     }
-    entriesByItemId[item.itemId].push(item);
-  });
-  const slotUsage = {};
-  const bonusSummary = summary || sumEquipmentBonuses(equipment);
-  const slotDetails = Object.keys(EQUIPMENT_SLOT_LABELS).map((slot) => {
-    const itemId = typeof slots[slot] === 'string' ? slots[slot] : '';
-    const usage = itemId ? slotUsage[itemId] || 0 : 0;
-    const candidates = itemId ? entriesByItemId[itemId] || [] : [];
-    const item = candidates[usage] || null;
-    if (itemId) {
-      slotUsage[itemId] = usage + 1;
+    const entry = slots[slot];
+    const decorated = entry
+      ? decorateEquipmentInventoryEntry(entry, { equipped: true, slotKey: slot })
+      : null;
+    if (decorated) {
+      if (decorated.inventoryId) {
+        equippedInventoryIds.add(decorated.inventoryId);
+      } else {
+        equippedInventoryIds.add(`slot:${slot}:${decorated.itemId}`);
+      }
     }
-    return {
+    slotDetails.push({
       slot,
       slotLabel: EQUIPMENT_SLOT_LABELS[slot],
-      item: item || null
+      item: decorated || null
+    });
+  });
+  Object.keys(slots).forEach((slot) => {
+    if (isIgnoredEquipmentSlot(slot)) {
+      return;
+    }
+    if (Object.prototype.hasOwnProperty.call(EQUIPMENT_SLOT_LABELS, slot)) {
+      return;
+    }
+    const entry = slots[slot];
+    const decorated = entry
+      ? decorateEquipmentInventoryEntry(entry, { equipped: true, slotKey: slot })
+      : null;
+    if (decorated) {
+      if (decorated.inventoryId) {
+        equippedInventoryIds.add(decorated.inventoryId);
+      } else {
+        equippedInventoryIds.add(`slot:${slot}:${decorated.itemId}`);
+      }
+    }
+    slotDetails.push({ slot, slotLabel: slot, item: decorated || null });
+  });
+
+  const list = inventory
+    .map((entry) => {
+      const decorated = decorateEquipmentInventoryEntry(entry, { equipped: false });
+      if (!decorated) {
+        return null;
+      }
+      if (decorated.inventoryId && equippedInventoryIds.has(decorated.inventoryId)) {
+        decorated.equipped = true;
+      }
+      return decorated;
+    })
+    .filter((item) => !!item);
+
+  const bonusSummary = summary || sumEquipmentBonuses(equipment);
+  const storage = equipment.storage && typeof equipment.storage === 'object' ? equipment.storage : {};
+  const storedCategories = Array.isArray(storage.categories) ? storage.categories : [];
+  const storedCategoryMap = new Map();
+  storedCategories.forEach((category) => {
+    if (!category || typeof category !== 'object' || typeof category.key !== 'string') {
+      return;
+    }
+    storedCategoryMap.set(category.key, category);
+  });
+  const storageDefaults = STORAGE_CATEGORY_DEFINITIONS[0] || { baseCapacity: 100, perUpgrade: 20 };
+  const sharedBaseCapacity = Math.max(
+    0,
+    Math.floor(Number(storage.baseCapacity != null ? storage.baseCapacity : storageDefaults.baseCapacity || 100))
+  );
+  const sharedPerUpgrade = Math.max(
+    0,
+    Math.floor(Number(storage.perUpgrade != null ? storage.perUpgrade : storageDefaults.perUpgrade || 20))
+  );
+  const rawUpgrades = storage.upgrades;
+  const upgradesByKey = {};
+  let sharedUpgrades = 0;
+  if (typeof rawUpgrades === 'number') {
+    sharedUpgrades = Math.max(0, Math.floor(rawUpgrades));
+    STORAGE_CATEGORY_DEFINITIONS.forEach((definition) => {
+      upgradesByKey[definition.key] = sharedUpgrades;
+    });
+  } else if (rawUpgrades && typeof rawUpgrades === 'object') {
+    STORAGE_CATEGORY_DEFINITIONS.forEach((definition) => {
+      const value = Math.max(0, Math.floor(Number(rawUpgrades[definition.key] || 0)));
+      upgradesByKey[definition.key] = value;
+      if (value > sharedUpgrades) {
+        sharedUpgrades = value;
+      }
+    });
+  } else {
+    STORAGE_CATEGORY_DEFINITIONS.forEach((definition) => {
+      upgradesByKey[definition.key] = 0;
+    });
+  }
+  const storageCategories = STORAGE_CATEGORY_DEFINITIONS.map((definition) => {
+    const upgrades = upgradesByKey[definition.key] != null ? upgradesByKey[definition.key] : sharedUpgrades;
+    const capacity = sharedBaseCapacity + sharedPerUpgrade * upgrades;
+    const storedCategory = storedCategoryMap.get(definition.key) || {};
+    const rawItems = Array.isArray(storedCategory.items) ? storedCategory.items : [];
+    let items;
+    if (definition.key === 'equipment') {
+      items = list;
+    } else {
+      items = rawItems.map((item) => (item && typeof item === 'object' ? { ...item } : item)).filter((item) => !!item);
+    }
+    const used = Array.isArray(items) ? items.length : 0;
+    const remaining = Math.max(capacity - used, 0);
+    return {
+      key: definition.key,
+      label: definition.label,
+      baseCapacity: sharedBaseCapacity,
+      perUpgrade: sharedPerUpgrade,
+      upgrades,
+      capacity,
+      used,
+      remaining,
+      items
     };
   });
+  const totalItems = storageCategories.reduce(
+    (acc, category) => acc + (Array.isArray(category.items) ? category.items.length : 0),
+    0
+  );
+  const sharedCapacity = sharedBaseCapacity + sharedPerUpgrade * sharedUpgrades;
+  const storageRemaining = Math.max(sharedCapacity - totalItems, 0);
+  const nextCapacity = sharedCapacity + sharedPerUpgrade;
+  const storageOverview = {
+    baseCapacity: sharedBaseCapacity,
+    perUpgrade: sharedPerUpgrade,
+    upgrades: sharedUpgrades,
+    capacity: sharedCapacity,
+    used: totalItems,
+    remaining: storageRemaining,
+    nextCapacity
+  };
+  if (typeof storage.upgradeAvailable === 'number' && Number.isFinite(storage.upgradeAvailable)) {
+    storageOverview.upgradeAvailable = Math.max(0, Math.floor(storage.upgradeAvailable));
+  } else if (storage.upgradeAvailable === null) {
+    storageOverview.upgradeAvailable = null;
+  }
   return {
     slots: slotDetails,
     inventory: list,
+    storage: {
+      categories: storageCategories,
+      overview: storageOverview,
+      upgrades: typeof rawUpgrades === 'number' ? Math.max(0, Math.floor(rawUpgrades)) : rawUpgrades,
+      upgradeAvailable: storageOverview.upgradeAvailable
+    },
     bonus: {
       sets: Array.isArray(bonusSummary && bonusSummary.sets) ? bonusSummary.sets : [],
       notes: Array.isArray(bonusSummary && bonusSummary.notes) ? bonusSummary.notes : []
@@ -3865,12 +4209,16 @@ function decorateEquipment(profile, summary = null) {
   };
 }
 
-function decorateEquipmentInventoryEntry(entry, slots = {}) {
-  const definition = EQUIPMENT_MAP[entry.itemId];
+function decorateEquipmentInventoryEntry(entry, options = {}) {
+  if (!entry) {
+    return null;
+  }
+  const payload = typeof entry === 'object' ? entry : { itemId: entry };
+  const definition = EQUIPMENT_MAP[payload.itemId];
   if (!definition) {
     return null;
   }
-  const detail = calculateEquipmentStats(definition, entry.refine || 0);
+  const detail = calculateEquipmentStats(definition, payload.refine || 0);
   const stats = detail.stats || {};
   const statTexts = formatStatsText({ ...stats });
   const breakdownTexts = [];
@@ -3897,10 +4245,10 @@ function decorateEquipmentInventoryEntry(entry, slots = {}) {
   }
   const combinedTexts = [...statTexts, ...breakdownTexts];
   const displayTexts = combinedTexts.filter((text, index, list) => text && list.indexOf(text) === index);
-  const equipped = Object.values(slots || {}).includes(entry.itemId);
+  const equipped = !!(options && options.equipped);
   return {
-    inventoryId: entry.inventoryId,
-    itemId: entry.itemId,
+    inventoryId: payload.inventoryId,
+    itemId: payload.itemId,
     name: definition.name,
     quality: definition.quality,
     qualityLabel: resolveEquipmentQualityLabel(definition.quality),
@@ -3913,17 +4261,18 @@ function decorateEquipmentInventoryEntry(entry, slots = {}) {
     mainAttribute: detail.mainAttribute,
     subAttributes: detail.subAttributes,
     uniqueEffects: detail.uniqueEffects,
-    level: entry.level || 1,
-    refine: entry.refine || 0,
-    refineLabel: entry.refine ? `精炼 +${entry.refine}` : '未精炼',
+    level: payload.level || 1,
+    refine: payload.refine || 0,
+    refineLabel: payload.refine ? `精炼 +${payload.refine}` : '未精炼',
     levelRequirement: definition.levelRequirement || 1,
     tags: definition.tags || [],
-    obtainedAt: entry.obtainedAt,
-    obtainedAtText: formatDateTime(entry.obtainedAt),
+    obtainedAt: payload.obtainedAt,
+    obtainedAtText: formatDateTime(payload.obtainedAt),
     setId: definition.setId || null,
     setName: setDefinition ? setDefinition.name : '',
     equipped,
-    favorite: !!entry.favorite,
+    equippedSlot: options && options.slotKey ? options.slotKey : '',
+    favorite: !!payload.favorite,
     notes: notes.filter((note, index, list) => note && list.indexOf(note) === index)
   };
 }

--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -36,8 +36,8 @@ const app = getApp();
 const BASE_NAV_ITEMS = [
   { icon: '🧝', label: '角色', url: '/pages/role/index?tab=character' },
   { icon: '🛡️', label: '装备', url: '/pages/role/index?tab=equipment' },
+  { icon: '💍', label: '纳戒', url: '/pages/role/index?tab=storage' },
   { icon: '📜', label: '技能', url: '/pages/role/index?tab=skill' },
-  { icon: '🎁', label: '权益', url: '/pages/rights/rights' },
   { icon: '📅', label: '预订', url: '/pages/reservation/reservation' },
   { icon: '💰', label: '钱包', url: '/pages/wallet/wallet' },
   { icon: '🧙‍♀️', label: '造型', url: '/pages/avatar/avatar' }

--- a/miniprogram/pages/role/index.wxml
+++ b/miniprogram/pages/role/index.wxml
@@ -14,6 +14,12 @@
       bindtap="handleTabChange"
     >装备</view>
     <view
+      class="tab-item {{activeTab === 'storage' ? 'tab-item--active' : ''}}"
+      data-tab="storage"
+      hover-class="tab-item--hover"
+      bindtap="handleTabChange"
+    >纳戒</view>
+    <view
       class="tab-item {{activeTab === 'skill' ? 'tab-item--active' : ''}}"
       data-tab="skill"
       hover-class="tab-item--hover"
@@ -112,6 +118,108 @@
       </view>
     </block>
 
+    <block wx:elif="{{activeTab === 'storage'}}">
+      <view class="section-card storage-section">
+        <view class="section-header">
+          <view class="section-title">纳戒储物</view>
+        </view>
+        <view wx:if="{{storageCategories.length}}" class="storage-tabs">
+          <view
+            wx:for="{{storageCategories}}"
+            wx:key="key"
+            class="storage-tab {{activeStorageCategory === item.key ? 'storage-tab--active' : ''}}"
+            data-key="{{item.key}}"
+            bindtap="handleStorageCategoryChange"
+          >
+            <text class="storage-tab__label">{{item.label}}</text>
+          </view>
+        </view>
+        <block wx:if="{{activeStorageCategoryData}}">
+          <view class="storage-summary" wx:if="{{storageOverview}}">
+            <view class="storage-summary__line">
+              <text>已用 {{storageOverview.used}} / {{storageOverview.capacity}}</text>
+              <text>剩余 {{storageOverview.remaining}}</text>
+            </view>
+            <progress
+              class="storage-summary__progress"
+              percent="{{storageOverview.usagePercent}}"
+              stroke-width="6"
+              backgroundColor="#1b2036"
+              activeColor="#566ed2"
+              show-info="{{false}}"
+            ></progress>
+            <view class="storage-summary__actions">
+              <button
+                class="pill-btn pill-btn--primary storage-summary__upgrade-btn"
+                hover-class="pill-btn--primary-hover"
+                size="mini"
+                loading="{{storageUpgrading}}"
+                disabled="{{storageUpgrading || (storageOverview.upgradeAvailable !== undefined && storageOverview.upgradeAvailable !== null && storageOverview.upgradeAvailable <= 0)}}"
+                bindtap="handleUpgradeStorage"
+              >升级储物空间</button>
+              <text class="storage-summary__hint">下次升级容量 {{storageOverview.nextCapacity}}</text>
+              <text
+                wx:if="{{storageOverview.upgradeAvailable !== undefined && storageOverview.upgradeAvailable !== null}}"
+                class="storage-summary__hint"
+              >剩余次数 {{storageOverview.upgradeAvailable}}</text>
+            </view>
+          </view>
+          <view class="storage-summary" wx:elif="{{!storageOverview}}">
+            <view class="storage-summary__line">
+              <text>已用 {{activeStorageCategoryData.items.length}} / {{activeStorageCategoryData.capacity}}</text>
+              <text>剩余 {{activeStorageCategoryData.remaining}}</text>
+            </view>
+            <progress
+              class="storage-summary__progress"
+              percent="{{activeStorageCategoryData.usagePercent}}"
+              stroke-width="6"
+              backgroundColor="#1b2036"
+              activeColor="#566ed2"
+              show-info="{{false}}"
+            ></progress>
+            <view class="storage-summary__actions">
+              <button
+                class="pill-btn pill-btn--primary storage-summary__upgrade-btn"
+                hover-class="pill-btn--primary-hover"
+                size="mini"
+                loading="{{storageUpgrading}}"
+                disabled="{{storageUpgrading}}"
+                bindtap="handleUpgradeStorage"
+              >升级储物空间</button>
+              <text class="storage-summary__hint">下次升级容量 {{activeStorageCategoryData.nextCapacity}}</text>
+            </view>
+          </view>
+          <view class="storage-grid">
+            <block wx:for="{{activeStorageCategoryData.slots}}" wx:key="storageKey">
+              <view wx:if="{{!item.placeholder}}" class="storage-slot">
+                <view class="storage-slot__badge">{{item.slotLabel}}</view>
+                <view
+                  class="storage-slot__frame"
+                  hover-class="storage-slot__frame--hover"
+                  bindtap="handleEquipmentTap"
+                  data-source="storage"
+                  data-slot="{{item.slot}}"
+                  data-slot-label="{{item.slotLabel}}"
+                  data-item="{{item}}"
+                  data-inventory-id="{{item.inventoryId || ''}}"
+                >
+                  <view class="storage-slot__icon" style="border-color: {{item.qualityColor}};">
+                    <view class="storage-slot__name">{{item.shortName || item.name}}</view>
+                  </view>
+                </view>
+              </view>
+              <view wx:else class="storage-slot storage-slot--empty">
+                <view class="storage-slot__frame storage-slot__frame--empty">
+                  <view class="storage-slot__placeholder">空</view>
+                </view>
+              </view>
+            </block>
+          </view>
+        </block>
+        <view wx:else class="empty-tip storage-empty">暂无储物数据</view>
+      </view>
+    </block>
+
     <block wx:elif="{{activeTab === 'equipment'}}">
       <view class="section-card">
         <view class="section-header">
@@ -170,7 +278,7 @@
           <view
             class="inventory-card {{item.equipped ? 'inventory-card--equipped' : ''}}"
             wx:for="{{(profile.equipment && profile.equipment.inventory) || []}}"
-            wx:key="itemId"
+            wx:key="inventoryId"
           >
             <view class="inventory-card__badge">{{item.slotLabel}}</view>
             <view class="inventory-card__frame">
@@ -181,6 +289,7 @@
                 data-source="inventory"
                 data-slot="{{item.slot}}"
                 data-item="{{item}}"
+                data-inventory-id="{{item.inventoryId || ''}}"
               >
                 <view class="inventory-card__icon-name">{{item.shortName || item.name}}</view>
                 <view wx:if="{{item.equipped}}" class="inventory-card__status">已装备</view>

--- a/miniprogram/pages/role/index.wxss
+++ b/miniprogram/pages/role/index.wxss
@@ -486,6 +486,179 @@ button.pill-btn[disabled] {
   box-shadow: 0 0 0 4rpx rgba(120, 176, 255, 0.32);
 }
 
+.storage-section {
+  position: relative;
+}
+
+.storage-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16rpx;
+  margin-bottom: 24rpx;
+}
+
+.storage-tab {
+  padding: 14rpx 24rpx;
+  border-radius: 999rpx;
+  border: 1rpx solid rgba(86, 112, 220, 0.32);
+  background: rgba(20, 34, 84, 0.62);
+  color: rgba(198, 210, 255, 0.82);
+  font-size: 24rpx;
+  display: inline-flex;
+  align-items: center;
+  gap: 10rpx;
+  line-height: 1;
+  transition: all 0.2s ease;
+}
+
+.storage-tab__label {
+  font-weight: 600;
+}
+
+.storage-tab--active {
+  border-color: rgba(130, 156, 255, 0.6);
+  background: linear-gradient(120deg, rgba(94, 124, 248, 0.92), rgba(144, 94, 255, 0.92));
+  color: #f8faff;
+  box-shadow: 0 10rpx 22rpx rgba(86, 108, 228, 0.28);
+}
+
+.storage-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 16rpx;
+  padding: 20rpx 24rpx;
+  border-radius: 24rpx;
+  background: rgba(24, 38, 88, 0.72);
+  border: 1rpx solid rgba(94, 122, 230, 0.28);
+  margin-bottom: 28rpx;
+}
+
+.storage-summary__line {
+  display: flex;
+  justify-content: space-between;
+  font-size: 24rpx;
+  color: rgba(205, 214, 255, 0.82);
+}
+
+.storage-summary__progress {
+  width: 100%;
+}
+
+.storage-summary__actions {
+  display: flex;
+  align-items: center;
+  gap: 16rpx;
+  flex-wrap: wrap;
+}
+
+.storage-summary__upgrade-btn {
+  min-width: auto;
+  padding: 4rpx 16rpx;
+  line-height: 1.2;
+  font-size: 22rpx;
+}
+
+.storage-summary__hint {
+  font-size: 22rpx;
+  color: rgba(186, 198, 255, 0.76);
+}
+
+.storage-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16rpx;
+}
+
+.storage-slot {
+  position: relative;
+  background: rgba(16, 28, 70, 0.85);
+  border-radius: 20rpx;
+  border: 1rpx solid rgba(86, 116, 210, 0.34);
+  box-sizing: border-box;
+  min-height: 0;
+}
+
+.storage-slot::before {
+  content: '';
+  display: block;
+  padding-top: 100%;
+}
+
+.storage-slot__badge {
+  position: absolute;
+  top: 12rpx;
+  left: 12rpx;
+  padding: 4rpx 12rpx;
+  font-size: 20rpx;
+  border-radius: 999rpx;
+  background: rgba(72, 94, 200, 0.42);
+  color: rgba(214, 224, 255, 0.88);
+  line-height: 1;
+  z-index: 2;
+}
+
+.storage-slot__frame {
+  position: absolute;
+  inset: 12rpx;
+  border-radius: 16rpx;
+  border: 4rpx solid rgba(118, 146, 250, 0.58);
+  background: rgba(10, 18, 48, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12rpx;
+  box-sizing: border-box;
+  transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.storage-slot__frame--hover {
+  border-color: rgba(150, 176, 255, 0.68);
+  box-shadow: 0 10rpx 24rpx rgba(90, 118, 240, 0.32);
+  transform: translateY(-2rpx);
+}
+
+.storage-slot__frame--empty {
+  border: 2rpx dashed rgba(102, 128, 210, 0.32);
+  background: rgba(12, 18, 40, 0.65);
+}
+
+.storage-slot__icon {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #f4f6ff;
+}
+
+.storage-slot__name {
+  font-size: 20rpx;
+  font-weight: 600;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+
+.storage-slot__placeholder {
+  font-size: 22rpx;
+  color: rgba(168, 186, 255, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.storage-slot--empty {
+  border: 1rpx dashed rgba(94, 122, 210, 0.32);
+  background: rgba(14, 22, 48, 0.6);
+}
+
+.storage-empty {
+  margin-top: 24rpx;
+}
+
 .equipment-summary {
   margin-top: 28rpx;
   padding: 24rpx;

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -279,17 +279,26 @@ export const PveService = {
     }
     return callCloud(CLOUD_FUNCTIONS.PVE, payload);
   },
-  async equipItem({ itemId = '', slot = '' } = {}) {
+  async equipItem({ itemId = '', slot = '', inventoryId = '' } = {}) {
     const payload = { action: 'equipItem' };
     const normalizedItemId = typeof itemId === 'string' ? itemId : '';
     const normalizedSlot = typeof slot === 'string' ? slot.trim() : '';
+    const normalizedInventoryId = typeof inventoryId === 'string' ? inventoryId.trim() : '';
     if (normalizedItemId) {
       payload.itemId = normalizedItemId;
     }
     if (normalizedSlot) {
       payload.slot = normalizedSlot;
     }
+    if (normalizedInventoryId) {
+      payload.inventoryId = normalizedInventoryId;
+    }
     return callCloud(CLOUD_FUNCTIONS.PVE, payload);
+  },
+  async upgradeStorage() {
+    return callCloud(CLOUD_FUNCTIONS.PVE, {
+      action: 'upgradeStorage'
+    });
   },
   async allocatePoints(allocations = {}) {
     return callCloud(CLOUD_FUNCTIONS.PVE, { action: 'allocatePoints', allocations });

--- a/miniprogram/utils/equipment.js
+++ b/miniprogram/utils/equipment.js
@@ -15,6 +15,8 @@ const DEFAULT_EQUIPMENT_IDS = [
 
 const DEFAULT_EQUIPMENT_ID_SET = new Set(DEFAULT_EQUIPMENT_IDS);
 
+const EXCLUDED_SLOT_KEYS = new Set(['accessory', 'armor']);
+
 function cloneItem(item) {
   return item && typeof item === 'object' ? { ...item } : null;
 }
@@ -46,15 +48,23 @@ export function sanitizeEquipmentProfile(profile) {
   const equipment = profile.equipment && typeof profile.equipment === 'object' ? profile.equipment : {};
   const rawSlots = Array.isArray(equipment.slots) ? equipment.slots : [];
   const rawInventory = Array.isArray(equipment.inventory) ? equipment.inventory : [];
+  const rawStorage = equipment.storage && typeof equipment.storage === 'object' ? equipment.storage : {};
 
-  const sanitizedSlots = rawSlots.map((slot) => {
-    if (!slot || typeof slot !== 'object') {
-      return { slot: '', slotLabel: '', item: null };
-    }
-    const rawItem = slot.item && typeof slot.item === 'object' ? slot.item : null;
-    const item = rawItem && rawItem.itemId && !isDefaultEquipmentId(rawItem.itemId) ? cloneItem(rawItem) : null;
-    return { ...slot, item };
-  });
+  const sanitizedSlots = rawSlots
+    .map((slot) => {
+      if (!slot || typeof slot !== 'object') {
+        return { slot: '', slotLabel: '', item: null };
+      }
+      const rawItem = slot.item && typeof slot.item === 'object' ? slot.item : null;
+      const item = rawItem && rawItem.itemId && !isDefaultEquipmentId(rawItem.itemId) ? cloneItem(rawItem) : null;
+      return { ...slot, item };
+    })
+    .filter((slot) => {
+      if (!slot || !slot.slot) {
+        return true;
+      }
+      return !EXCLUDED_SLOT_KEYS.has(slot.slot);
+    });
 
   const sanitizedInventory = rawInventory
     .filter((item) => item && typeof item === 'object' && item.itemId && !isDefaultEquipmentId(item.itemId))
@@ -87,10 +97,106 @@ export function sanitizeEquipmentProfile(profile) {
 
   const notes = extractNotesFromSlots(sanitizedSlots);
 
+  const storageCategories = Array.isArray(rawStorage.categories) ? rawStorage.categories : [];
+  const sanitizedCategories = storageCategories
+    .map((category) => {
+      if (!category || typeof category !== 'object') {
+        return null;
+      }
+      const key = typeof category.key === 'string' ? category.key : '';
+      const label = typeof category.label === 'string' ? category.label : '';
+      const baseCapacity = Math.max(0, Math.floor(Number(category.baseCapacity != null ? category.baseCapacity : 0)));
+      const perUpgrade = Math.max(0, Math.floor(Number(category.perUpgrade != null ? category.perUpgrade : 0)));
+      const upgrades = Math.max(0, Math.floor(Number(category.upgrades != null ? category.upgrades : 0)));
+      const rawCapacity = Number(category.capacity);
+      const capacity = Math.max(0, Math.floor(Number.isFinite(rawCapacity) ? rawCapacity : baseCapacity + perUpgrade * upgrades));
+      const items = Array.isArray(category.items)
+        ? category.items
+            .map((item) => {
+              if (!item || typeof item !== 'object') {
+                return null;
+              }
+              if (item.itemId && isDefaultEquipmentId(item.itemId)) {
+                return null;
+              }
+              return cloneItem(item);
+            })
+            .filter((item) => !!item)
+        : [];
+      const rawUsed = Number(category.used);
+      const used = Math.max(0, Math.floor(Number.isFinite(rawUsed) ? rawUsed : items.length));
+      const rawRemaining = Number(category.remaining);
+      const remaining = Math.max(0, Math.floor(Number.isFinite(rawRemaining) ? rawRemaining : capacity - used));
+      return {
+        key,
+        label,
+        baseCapacity,
+        perUpgrade,
+        upgrades,
+        capacity,
+        used,
+        remaining,
+        items
+      };
+    })
+    .filter((category) => !!category);
+
+  const sanitizedStorage = {};
+  if (typeof rawStorage.upgrades === 'number' && Number.isFinite(rawStorage.upgrades)) {
+    sanitizedStorage.upgrades = Math.max(0, Math.floor(rawStorage.upgrades));
+  } else if (rawStorage.upgrades && typeof rawStorage.upgrades === 'object') {
+    const normalizedUpgrades = {};
+    Object.keys(rawStorage.upgrades).forEach((key) => {
+      const value = Number(rawStorage.upgrades[key]);
+      if (Number.isFinite(value)) {
+        normalizedUpgrades[key] = Math.max(0, Math.floor(value));
+      }
+    });
+    sanitizedStorage.upgrades = normalizedUpgrades;
+  }
+  if (typeof rawStorage.upgradeAvailable === 'number' && Number.isFinite(rawStorage.upgradeAvailable)) {
+    sanitizedStorage.upgradeAvailable = Math.max(0, Math.floor(rawStorage.upgradeAvailable));
+  } else if (rawStorage.upgradeAvailable === null) {
+    sanitizedStorage.upgradeAvailable = null;
+  }
+  if (typeof rawStorage.baseCapacity === 'number' && Number.isFinite(rawStorage.baseCapacity)) {
+    sanitizedStorage.baseCapacity = Math.max(0, Math.floor(rawStorage.baseCapacity));
+  }
+  if (typeof rawStorage.perUpgrade === 'number' && Number.isFinite(rawStorage.perUpgrade)) {
+    sanitizedStorage.perUpgrade = Math.max(0, Math.floor(rawStorage.perUpgrade));
+  }
+  const overview = rawStorage.overview && typeof rawStorage.overview === 'object' ? rawStorage.overview : null;
+  if (overview) {
+    const baseCapacity = Math.max(0, Math.floor(Number(overview.baseCapacity != null ? overview.baseCapacity : 0)));
+    const perUpgrade = Math.max(0, Math.floor(Number(overview.perUpgrade != null ? overview.perUpgrade : 0)));
+    const upgrades = Math.max(0, Math.floor(Number(overview.upgrades != null ? overview.upgrades : 0)));
+    const capacity = Math.max(0, Math.floor(Number(overview.capacity != null ? overview.capacity : baseCapacity + perUpgrade * upgrades)));
+    const used = Math.max(0, Math.floor(Number(overview.used != null ? overview.used : 0)));
+    const remaining = Math.max(0, Math.floor(Number(overview.remaining != null ? overview.remaining : capacity - used)));
+    const nextCapacity = Math.max(0, Math.floor(Number(overview.nextCapacity != null ? overview.nextCapacity : capacity + perUpgrade)));
+    const sanitizedOverview = {
+      baseCapacity,
+      perUpgrade,
+      upgrades,
+      capacity,
+      used,
+      remaining,
+      nextCapacity
+    };
+    if (typeof overview.upgradeAvailable === 'number' && Number.isFinite(overview.upgradeAvailable)) {
+      sanitizedOverview.upgradeAvailable = Math.max(0, Math.floor(overview.upgradeAvailable));
+    } else if (overview.upgradeAvailable === null) {
+      sanitizedOverview.upgradeAvailable = null;
+    }
+    sanitizedStorage.overview = sanitizedOverview;
+  }
+  sanitizedStorage.categories = sanitizedCategories;
+
   const sanitizedEquipment = {
     ...equipment,
     slots: sanitizedSlots,
     inventory: sanitizedInventory,
+    storage: sanitizedStorage,
     bonus: {
       sets: sanitizedSets,
       notes


### PR DESCRIPTION
## Summary
- add the quest storage category on the backend and expose unified storage upgrade metadata
- sanitize and decorate storage data so the client can render a shared capacity overview with remaining upgrade counts
- update the role page storage tab to drop per-tab counts, show the aggregated summary, gate upgrades by remaining attempts, and shrink the upgrade button

## Testing
- Not run (WeChat mini program tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dcfa00b1588330ac94590205147e86