### PR TITLE
Add admin control for storage upgrade availability

### DIFF
--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -1320,6 +1320,13 @@ function buildUpdatePayload(updates, existing = {}, extras = {}) {
   if (Object.prototype.hasOwnProperty.call(updates, 'roomUsageCount')) {
     memberUpdates.roomUsageCount = normalizeUsageCount(updates.roomUsageCount);
   }
+  if (Object.prototype.hasOwnProperty.call(updates, 'storageUpgradeAvailable')) {
+    const available = normalizeUsageCount(updates.storageUpgradeAvailable);
+    memberUpdates['pveProfile.equipment.storage.upgradeAvailable'] = available;
+    memberUpdates['pveProfile.equipment.storage.upgradeRemaining'] = available;
+    memberUpdates['pveProfile.equipment.storage.meta.upgradeAvailable'] = available;
+    memberUpdates['pveProfile.equipment.storage.meta.upgradesRemaining'] = available;
+  }
   if (Object.prototype.hasOwnProperty.call(updates, 'roles')) {
     const roles = Array.isArray(updates.roles) ? updates.roles : [];
     const filtered = roles.filter((role) => ['member', 'admin', 'developer'].includes(role));

--- a/miniprogram/pages/admin/member-detail/index.js
+++ b/miniprogram/pages/admin/member-detail/index.js
@@ -232,7 +232,7 @@ Page({
       renameCredits: '',
       respecAvailable: '',
       roomUsageCount: '',
-      storageUpgradeAvailable: '',
+      storageUpgradeAvailable: '0',
       avatarUnlocks: []
     },
     rechargeVisible: false,
@@ -351,8 +351,13 @@ Page({
       typeof sanitizedProfile.equipment.storage === 'object'
         ? sanitizedProfile.equipment.storage
         : null;
-    const storageUpgradeAvailable =
-      storage && typeof storage.upgradeAvailable === 'number' ? String(storage.upgradeAvailable) : '';
+    const storageUpgradeAvailable = String(
+      this.parseStorageUpgradeAvailable(
+        storage && Object.prototype.hasOwnProperty.call(storage, 'upgradeAvailable')
+          ? storage.upgradeAvailable
+          : 0
+      )
+    );
     const levelIndex = Math.max(
       levels.findIndex((level) => level._id === member.levelId),
       0

--- a/miniprogram/pages/admin/member-detail/index.wxml
+++ b/miniprogram/pages/admin/member-detail/index.wxml
@@ -57,6 +57,17 @@
       />
     </view>
     <view class="form-item">
+      <view class="form-label">纳戒升级次数</view>
+      <input
+        class="form-input"
+        type="number"
+        value="{{form.storageUpgradeAvailable}}"
+        placeholder="请输入剩余纳戒升级次数"
+        data-field="storageUpgradeAvailable"
+        bindinput="handleInputChange"
+      />
+    </view>
+    <view class="form-item">
       <view class="form-label">包房使用次数</view>
       <input
         class="form-input"


### PR DESCRIPTION
## Summary
- surface and edit the storage upgrade count in the admin member detail view
- persist the updated count into the member profile so role storage upgrades honor it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd18e667f48330b0485f59b7998284