### PR TITLE
Add admin member deletion support

### DIFF
--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -402,9 +402,7 @@ async function deleteMember(openid, memberId) {
   if (!targetId) {
     throw new Error('缺少会员编号');
   }
-  if (targetId === admin._id) {
-    throw new Error('无法删除当前管理员账号');
-  }
+  const deletingSelf = targetId === admin._id;
   const memberDoc = await db
     .collection(COLLECTIONS.MEMBERS)
     .doc(targetId)
@@ -417,7 +415,8 @@ async function deleteMember(openid, memberId) {
   return {
     success: true,
     memberId: targetId,
-    cleanup
+    cleanup,
+    selfDeleted: deletingSelf
   };
 }
 

--- a/miniprogram/pages/admin/member-detail/index.js
+++ b/miniprogram/pages/admin/member-detail/index.js
@@ -211,6 +211,7 @@ Page({
     memberId: '',
     loading: true,
     saving: false,
+    deleting: false,
     member: null,
     levels: [],
     levelIndex: 0,
@@ -652,6 +653,51 @@ Page({
       wx.showToast({ title: error.errMsg || error.message || '保存失败', icon: 'none' });
     } finally {
       this.setData({ saving: false });
+    }
+  },
+
+  handleDeleteMember() {
+    if (!this.data.memberId || this.data.deleting) {
+      return;
+    }
+    wx.showModal({
+      title: '删除会员',
+      content: '删除后将无法恢复该会员及其所有相关数据，确定继续吗？',
+      confirmText: '删除',
+      confirmColor: '#f43f5e',
+      cancelText: '取消',
+      success: (res) => {
+        if (res && res.confirm) {
+          this.confirmDeleteMember();
+        }
+      }
+    });
+  },
+
+  async confirmDeleteMember() {
+    if (!this.data.memberId || this.data.deleting) {
+      return;
+    }
+    this.setData({ deleting: true });
+    wx.showLoading({ title: '删除中', mask: true });
+    try {
+      await AdminService.deleteMember(this.data.memberId);
+      wx.hideLoading();
+      wx.showToast({ title: '删除成功', icon: 'success' });
+      setTimeout(() => {
+        wx.navigateBack({
+          delta: 1,
+          fail: () => {
+            wx.redirectTo({ url: '/pages/admin/members/index' });
+          }
+        });
+      }, 500);
+    } catch (error) {
+      wx.hideLoading();
+      console.error('[admin:member:delete]', error);
+      wx.showToast({ title: error.errMsg || error.message || '删除失败', icon: 'none' });
+    } finally {
+      this.setData({ deleting: false });
     }
   },
 

--- a/miniprogram/pages/admin/member-detail/index.js
+++ b/miniprogram/pages/admin/member-detail/index.js
@@ -206,9 +206,24 @@ function formatRenameHistory(history) {
     });
 }
 
+function getCurrentAdminId() {
+  try {
+    if (typeof getApp === 'function') {
+      const app = getApp();
+      if (app && app.globalData && app.globalData.memberInfo) {
+        return app.globalData.memberInfo._id || '';
+      }
+    }
+  } catch (error) {
+    console.error('[admin:member] resolve current admin id failed', error);
+  }
+  return '';
+}
+
 Page({
   data: {
     memberId: '',
+    currentAdminId: '',
     loading: true,
     saving: false,
     deleting: false,
@@ -268,7 +283,7 @@ Page({
       wx.showToast({ title: '缺少会员编号', icon: 'none' });
       return;
     }
-    this.setData({ memberId: id });
+    this.setData({ memberId: id, currentAdminId: getCurrentAdminId() });
   },
 
   onShow() {
@@ -660,9 +675,12 @@ Page({
     if (!this.data.memberId || this.data.deleting) {
       return;
     }
+    const deletingSelf = this.data.member && this.data.member._id === this.data.currentAdminId;
     wx.showModal({
       title: '删除会员',
-      content: '删除后将无法恢复该会员及其所有相关数据，确定继续吗？',
+      content: deletingSelf
+        ? '删除后您将失去管理员权限并需要重新登录，确定删除当前账号吗？'
+        : '删除后将无法恢复该会员及其所有相关数据，确定继续吗？',
       confirmText: '删除',
       confirmColor: '#f43f5e',
       cancelText: '取消',
@@ -681,8 +699,30 @@ Page({
     this.setData({ deleting: true });
     wx.showLoading({ title: '删除中', mask: true });
     try {
-      await AdminService.deleteMember(this.data.memberId);
+      const result = await AdminService.deleteMember(this.data.memberId);
+      const selfDeleted = result && result.selfDeleted;
       wx.hideLoading();
+      if (selfDeleted) {
+        try {
+          if (typeof getApp === 'function') {
+            const app = getApp();
+            if (app && app.globalData) {
+              app.globalData.memberInfo = null;
+            }
+          }
+        } catch (error) {
+          console.error('[admin:member:self-delete] clear member info failed', error);
+        }
+        wx.showModal({
+          title: '删除成功',
+          content: '当前管理员账号已删除，请重新登录。',
+          showCancel: false,
+          success: () => {
+            wx.reLaunch({ url: '/pages/index/index' });
+          }
+        });
+        return;
+      }
       wx.showToast({ title: '删除成功', icon: 'success' });
       setTimeout(() => {
         wx.navigateBack({

--- a/miniprogram/pages/admin/member-detail/index.wxml
+++ b/miniprogram/pages/admin/member-detail/index.wxml
@@ -20,6 +20,16 @@
     <view class="section-title">基础资料</view>
     <view class="toolbar">
       <button class="recharge" size="mini" bindtap="showRechargeDialog">为该会员充值</button>
+      <button
+        class="delete-member"
+        size="mini"
+        type="warn"
+        loading="{{deleting}}"
+        disabled="{{loading || deleting}}"
+        bindtap="handleDeleteMember"
+      >
+        删除会员
+      </button>
     </view>
     <view class="form-item">
       <view class="form-label">道号</view>

--- a/miniprogram/pages/admin/member-detail/index.wxss
+++ b/miniprogram/pages/admin/member-detail/index.wxss
@@ -36,7 +36,12 @@ page {
 .toolbar {
   display: flex;
   justify-content: flex-end;
+  align-items: center;
   margin-bottom: 16rpx;
+}
+
+.toolbar button + button {
+  margin-left: 16rpx;
 }
 
 .toolbar .recharge {
@@ -45,6 +50,22 @@ page {
   border-radius: 32rpx;
   padding: 12rpx 24rpx;
   border: none;
+}
+
+.toolbar .delete-member {
+  background: rgba(244, 63, 94, 0.14);
+  color: #fda4af;
+  border-radius: 32rpx;
+  padding: 12rpx 24rpx;
+  border: 1px solid rgba(248, 113, 113, 0.35);
+}
+
+.toolbar .delete-member::after {
+  border: none;
+}
+
+.toolbar .delete-member[disabled] {
+  opacity: 0.6;
 }
 
 .info-row {

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -350,6 +350,12 @@ export const AdminService = {
       updates
     });
   },
+  async deleteMember(memberId) {
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, {
+      action: 'deleteMember',
+      memberId
+    });
+  },
   async listEquipmentCatalog() {
     return callCloud(CLOUD_FUNCTIONS.ADMIN, {
       action: 'listEquipmentCatalog'


### PR DESCRIPTION
## Summary
- add a `deleteMember` admin action that purges the member document together with extras, transactions, reservations, and other related collections
- expose the new action through the mini program service layer and provide a guarded delete button on the admin member detail page
- style the toolbar to accommodate the destructive action button

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd21ac7768833083ebe094aaa4e052