### PR TITLE
Add admin controls for storage upgrade limits

### DIFF
--- a/miniprogram/pages/admin/member-detail/index.wxml
+++ b/miniprogram/pages/admin/member-detail/index.wxml
@@ -78,6 +78,17 @@
       />
     </view>
     <view class="form-item">
+      <view class="form-label">纳戒升级上限</view>
+      <input
+        class="form-input"
+        type="number"
+        value="{{form.storageUpgradeLimit}}"
+        placeholder="请输入纳戒升级上限"
+        data-field="storageUpgradeLimit"
+        bindinput="handleInputChange"
+      />
+    </view>
+    <view class="form-item">
       <view class="form-label">包房使用次数</view>
       <input
         class="form-input"


### PR DESCRIPTION
## Summary
- ensure the admin cloud function records a storage upgrade limit whenever upgrade credits are adjusted and respect optional overrides
- expose a storage upgrade limit field in the member detail page so admins can review or customize the cap

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd478b661c8330885b891b66f699a9