### PR TITLE
fix: center phone authorization text

### DIFF
--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -1053,10 +1053,9 @@ page {
 
 .authorization-phone__value {
   font-size: 28rpx;
+  line-height: 28rpx;
   color: #ffffff;
   letter-spacing: 2rpx;
-  display: flex;
-  align-items: center;
   height: 100%;
 }
 

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -1055,8 +1055,9 @@ page {
   font-size: 28rpx;
   color: #ffffff;
   letter-spacing: 2rpx;
-  display: block;
-  line-height: 88rpx;
+  display: flex;
+  align-items: center;
+  height: 100%;
 }
 
 .authorization-phone__value--placeholder {


### PR DESCRIPTION
## Summary
- adjust the onboarding authorization phone text container to use flex alignment
- ensure the authorized phone placeholder text is vertically centered within its wrapper

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd4dfde9e0833097d5cdc3ea4ab6f5