### PR TITLE
Set new member storage upgrades to zero by default

### DIFF
--- a/cloudfunctions/pve/index.js
+++ b/cloudfunctions/pve/index.js
@@ -17,7 +17,7 @@ const MAX_SKILL_HISTORY = 30;
 
 const STORAGE_BASE_CAPACITY = 100;
 const STORAGE_PER_UPGRADE = 20;
-const DEFAULT_STORAGE_UPGRADE_LIMIT = 10;
+const DEFAULT_STORAGE_UPGRADE_LIMIT = 20;
 const STORAGE_CATEGORY_DEFINITIONS = [
   { key: 'equipment', label: '装备' },
   { key: 'quest', label: '任务' },

--- a/cloudfunctions/pve/index.js
+++ b/cloudfunctions/pve/index.js
@@ -121,7 +121,8 @@ function extractStorageUpgradeLimit(storage) {
 }
 
 function resolveStorageUpgradeAvailable(storage) {
-  return extractStorageUpgradeAvailable(storage).value;
+  const descriptor = extractStorageUpgradeAvailable(storage);
+  return descriptor.value !== null ? descriptor.value : 0;
 }
 
 function resolveStorageUpgradeLimit(storage) {
@@ -2621,17 +2622,18 @@ async function upgradeStorage(actorId, event = {}) {
   const perUpgrade = resolveStoragePerUpgrade(storage);
   const upgradeAvailableDescriptor = extractStorageUpgradeAvailable(storage);
   const upgradeLimitDescriptor = extractStorageUpgradeLimit(storage);
-  const upgradeAvailable = upgradeAvailableDescriptor.value;
+  const upgradeAvailableRaw = upgradeAvailableDescriptor.value;
+  const upgradeAvailable = upgradeAvailableRaw !== null ? upgradeAvailableRaw : 0;
   const upgradeLimit = upgradeLimitDescriptor.value;
   let normalizedLimit = upgradeLimit !== null && upgradeLimit > 0 ? upgradeLimit : null;
   if (normalizedLimit === null) {
-    const fallbackLimitBase = currentLevel + (upgradeAvailable !== null ? upgradeAvailable : 0);
+    const fallbackLimitBase = currentLevel + upgradeAvailable;
     normalizedLimit = Math.max(DEFAULT_STORAGE_UPGRADE_LIMIT, fallbackLimitBase);
   }
   if (normalizedLimit !== null && currentLevel >= normalizedLimit) {
     throw createError('STORAGE_MAX_UPGRADES', '储物空间已达到上限');
   }
-  if (upgradeAvailable !== null && upgradeAvailable <= 0) {
+  if (upgradeAvailable <= 0) {
     throw createError('STORAGE_NO_UPGRADES', '升级次数不足');
   }
   const nextLevel = currentLevel + 1;
@@ -2639,13 +2641,11 @@ async function upgradeStorage(actorId, event = {}) {
     throw createError('STORAGE_MAX_UPGRADES', '储物空间已达到上限');
   }
   let nextAvailable = null;
-  if (upgradeAvailable !== null) {
+  if (upgradeAvailableRaw !== null) {
     nextAvailable = Math.max(upgradeAvailable - 1, 0);
     if (normalizedLimit !== null) {
       nextAvailable = Math.min(nextAvailable, Math.max(normalizedLimit - nextLevel, 0));
     }
-  } else if (normalizedLimit !== null) {
-    nextAvailable = Math.max(normalizedLimit - nextLevel, 0);
   }
   const updatedUpgrades = {};
   STORAGE_CATEGORY_KEYS.forEach((key) => {
@@ -3525,31 +3525,25 @@ function normalizeEquipment(equipment, now = new Date(), options = {}) {
   const { level: storageLevel, upgrades: storageUpgrades } = resolveStorageUpgradeState(rawStorage);
   const baseCapacity = resolveStorageBaseCapacity(rawStorage);
   const perUpgrade = resolveStoragePerUpgrade(rawStorage);
-  const { value: storageUpgradeAvailable, key: storageUpgradeAvailableKey } =
-    extractStorageUpgradeAvailable(rawStorage);
+  const {
+    value: storageUpgradeAvailable,
+    key: storageUpgradeAvailableKey
+  } = extractStorageUpgradeAvailable(rawStorage);
   const { value: storageUpgradeLimit, key: storageUpgradeLimitKey } = extractStorageUpgradeLimit(rawStorage);
   const hasAvailableField = storageUpgradeAvailableKey !== null;
   const hasLimitField = storageUpgradeLimitKey !== null;
-  let resolvedUpgradeAvailable = storageUpgradeAvailable;
-  let resolvedUpgradeLimit = storageUpgradeLimit;
-  if (!hasLimitField && !hasAvailableField) {
-    const defaultLimit = Math.max(DEFAULT_STORAGE_UPGRADE_LIMIT, storageLevel);
-    resolvedUpgradeLimit = defaultLimit;
-    resolvedUpgradeAvailable = Math.max(defaultLimit - Math.min(defaultLimit, storageLevel), 0);
-  } else {
-    if (!hasLimitField && resolvedUpgradeAvailable !== null) {
-      const inferredLimit = Math.max(
-        DEFAULT_STORAGE_UPGRADE_LIMIT,
-        storageLevel + Math.max(0, resolvedUpgradeAvailable)
-      );
-      resolvedUpgradeLimit = inferredLimit;
-    }
-    if (!hasAvailableField && resolvedUpgradeLimit !== null) {
-      resolvedUpgradeAvailable = Math.max(
-        resolvedUpgradeLimit - Math.min(resolvedUpgradeLimit, storageLevel),
-        0
-      );
-    }
+  let resolvedUpgradeAvailable =
+    typeof storageUpgradeAvailable === 'number' ? Math.max(0, storageUpgradeAvailable) : null;
+  let resolvedUpgradeLimit = storageUpgradeLimit !== null && storageUpgradeLimit > 0 ? storageUpgradeLimit : null;
+  if (resolvedUpgradeLimit === null) {
+    const inferredLimit = Math.max(
+      DEFAULT_STORAGE_UPGRADE_LIMIT,
+      storageLevel + Math.max(0, resolvedUpgradeAvailable !== null ? resolvedUpgradeAvailable : 0)
+    );
+    resolvedUpgradeLimit = inferredLimit;
+  }
+  if (resolvedUpgradeAvailable === null || !hasAvailableField) {
+    resolvedUpgradeAvailable = 0;
   }
   const normalizedStorage = {
     upgrades: storageUpgrades,
@@ -3557,10 +3551,8 @@ function normalizeEquipment(equipment, now = new Date(), options = {}) {
     baseCapacity,
     perUpgrade
   };
-  if (resolvedUpgradeAvailable !== null) {
-    const key = storageUpgradeAvailableKey || 'upgradeAvailable';
-    normalizedStorage[key] = resolvedUpgradeAvailable;
-  }
+  const availableKey = storageUpgradeAvailableKey || 'upgradeAvailable';
+  normalizedStorage[availableKey] = resolvedUpgradeAvailable;
   if (resolvedUpgradeLimit !== null) {
     const key = storageUpgradeLimitKey || 'upgradeLimit';
     normalizedStorage[key] = resolvedUpgradeLimit;

--- a/cloudfunctions/pve/index.js
+++ b/cloudfunctions/pve/index.js
@@ -3186,13 +3186,15 @@ function buildDefaultStorage(level = 0) {
   STORAGE_CATEGORY_KEYS.forEach((key) => {
     upgrades[key] = safeLevel;
   });
+  const upgradeAvailable =
+    safeLevel > 0 ? Math.max(limit - Math.min(limit, safeLevel), 0) : 0;
   return {
     upgrades,
     globalUpgrades: safeLevel,
     baseCapacity: STORAGE_BASE_CAPACITY,
     perUpgrade: STORAGE_PER_UPGRADE,
     upgradeLimit: limit,
-    upgradeAvailable: Math.max(limit - Math.min(limit, safeLevel), 0)
+    upgradeAvailable
   };
 }
 

--- a/docs/pve.md
+++ b/docs/pve.md
@@ -37,7 +37,8 @@
 
 #### 储物空间与升级限制
 
-- 储物空间以统一的品类数组定义，初始容量为 100 格，单次升级增加 20 格，并设定默认最多 10 次升级的上限。【F:cloudfunctions/pve/index.js†L18-L31】
+- 储物空间以统一的品类数组定义，初始容量为 100 格，单次升级增加 20 格，并设定默认最多 10 次升级的上限。【F:cloudfunctions/pve/index.js†L18-L34】
+- 新会员建档时可用的纳戒升级次数默认为 0，需要通过后台或运营投放提升次数后才能升级存储空间。【F:cloudfunctions/pve/index.js†L3179-L3195】【F:cloudfunctions/admin/index.js†L1574-L1580】
 - 新会员建档时会调用 `buildDefaultStorage` 写入基础配置，记录当前升级层级、容量成长参数、可用升级次数与固定上限，避免出现“未初始化导致无限升级”的状态。【F:cloudfunctions/pve/index.js†L3182-L3196】
 - 旧档案在 `normalizeEquipment` 中会回填缺失字段：如果历史数据缺乏上限或剩余次数，会用默认上限推导，并在存在任何一项时把两者校正到“上限 − 已升级次数”的安全区间。【F:cloudfunctions/pve/index.js†L3520-L3565】
 - 升级接口会综合当前层数、剩余次数与上限判定：一旦当前层数达到或超过上限立即拒绝；否则扣减一次可用次数并把所有品类的升级层级同步加一，同时把上限写回档案，防止客户端伪造字段绕过校验。【F:cloudfunctions/pve/index.js†L2610-L2666】

--- a/docs/pve.md
+++ b/docs/pve.md
@@ -40,7 +40,7 @@
 - 储物空间以统一的品类数组定义，初始容量为 100 格，单次升级增加 20 格，并设定默认最多 10 次升级的上限。【F:cloudfunctions/pve/index.js†L18-L34】
 - 新会员建档时可用的纳戒升级次数默认为 0，需要通过后台或运营投放提升次数后才能升级存储空间。【F:cloudfunctions/pve/index.js†L3179-L3195】【F:cloudfunctions/admin/index.js†L1574-L1580】
 - 新会员建档时会调用 `buildDefaultStorage` 写入基础配置，记录当前升级层级、容量成长参数、可用升级次数与固定上限，避免出现“未初始化导致无限升级”的状态。【F:cloudfunctions/pve/index.js†L3182-L3196】
-- 旧档案在 `normalizeEquipment` 中会回填缺失字段：如果历史数据缺乏上限或剩余次数，会用默认上限推导，并在存在任何一项时把两者校正到“上限 − 已升级次数”的安全区间。【F:cloudfunctions/pve/index.js†L3520-L3565】
+- 旧档案在 `normalizeEquipment` 中会回填缺失字段：如果历史数据缺乏上限会用默认值推导；若缺少 `upgradeAvailable` 字段则按 0 次处理，避免在未授权的情况下继续升级。【F:cloudfunctions/pve/index.js†L3518-L3560】
 - 升级接口会综合当前层数、剩余次数与上限判定：一旦当前层数达到或超过上限立即拒绝；否则扣减一次可用次数并把所有品类的升级层级同步加一，同时把上限写回档案，防止客户端伪造字段绕过校验。【F:cloudfunctions/pve/index.js†L2610-L2666】
 - 返回给前端的档案中，服务端会重新计算容量、剩余额度与 `upgradeLimit`/`upgradesRemaining` 元数据，确保可视化状态与服务端判定始终一致，供前端进行提示与二次校验。【F:cloudfunctions/pve/index.js†L4496-L4554】
 

--- a/docs/pve.md
+++ b/docs/pve.md
@@ -37,7 +37,7 @@
 
 #### 储物空间与升级限制
 
-- 储物空间以统一的品类数组定义，初始容量为 100 格，单次升级增加 20 格，并设定默认最多 10 次升级的上限。【F:cloudfunctions/pve/index.js†L18-L34】
+- 储物空间以统一的品类数组定义，初始容量为 100 格，单次升级增加 20 格，并设定默认最多 20 次升级的上限。【F:cloudfunctions/pve/index.js†L18-L34】
 - 新会员建档时可用的纳戒升级次数默认为 0，需要通过后台或运营投放提升次数后才能升级存储空间。【F:cloudfunctions/pve/index.js†L3179-L3195】【F:cloudfunctions/admin/index.js†L1574-L1580】
 - 新会员建档时会调用 `buildDefaultStorage` 写入基础配置，记录当前升级层级、容量成长参数、可用升级次数与固定上限，避免出现“未初始化导致无限升级”的状态。【F:cloudfunctions/pve/index.js†L3182-L3196】
 - 旧档案在 `normalizeEquipment` 中会回填缺失字段：如果历史数据缺乏上限会用默认值推导；若缺少 `upgradeAvailable` 字段则按 0 次处理，避免在未授权的情况下继续升级。【F:cloudfunctions/pve/index.js†L3518-L3560】


### PR DESCRIPTION
## Summary
- make the default storage profile start with zero available upgrades so new members cannot upgrade immediately
- document the storage upgrade cap and default availability for reference

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd51d3655083308389697ccfa8c54e