### PR TITLE
feat: add equipment icons and fallbacks

### DIFF
--- a/cloudfunctions/pve/index.js
+++ b/cloudfunctions/pve/index.js
@@ -507,6 +507,23 @@ function isIgnoredEquipmentSlot(slot) {
   return typeof slot === 'string' && IGNORED_EQUIPMENT_SLOTS.has(slot);
 }
 
+const EQUIPMENT_QUALITY_ORDER = [
+  'mortal',
+  'inferior',
+  'standard',
+  'superior',
+  'excellent',
+  'immortal',
+  'perfect',
+  'primordial',
+  'relic'
+];
+
+const EQUIPMENT_QUALITY_RANK_MAP = EQUIPMENT_QUALITY_ORDER.reduce((map, key, index) => {
+  map[key] = index + 1;
+  return map;
+}, {});
+
 const EQUIPMENT_QUALITY_CONFIG = {
   mortal: { key: 'mortal', label: '凡品', color: '#8d9099', mainCoefficient: 0.8, subCount: 0, subTierRange: ['common'], dropWeight: 42 },
   inferior: { key: 'inferior', label: '下品', color: '#63a86c', mainCoefficient: 1, subCount: 0, subTierRange: ['common'], dropWeight: 34 },
@@ -1669,6 +1686,16 @@ const EQUIPMENT_LIBRARY = [
   }
 ];
 
+const EQUIPMENT_QUALITY_ICON_COUNTER = {};
+EQUIPMENT_LIBRARY.forEach((item) => {
+  const qualityKey = typeof item.quality === 'string' ? item.quality : '';
+  const rank = EQUIPMENT_QUALITY_RANK_MAP[qualityKey] || 1;
+  const iconId = (EQUIPMENT_QUALITY_ICON_COUNTER[qualityKey] || 0) + 1;
+  EQUIPMENT_QUALITY_ICON_COUNTER[qualityKey] = iconId;
+  item.qualityRank = rank;
+  item.iconId = iconId;
+});
+
 function resolveEquipmentQualityConfig(quality) {
   return EQUIPMENT_QUALITY_CONFIG[quality] || EQUIPMENT_QUALITY_CONFIG.inferior;
 }
@@ -1679,6 +1706,11 @@ function resolveEquipmentQualityLabel(quality) {
 
 function resolveEquipmentQualityColor(quality) {
   return resolveEquipmentQualityConfig(quality).color;
+}
+
+function resolveEquipmentQualityRank(quality) {
+  const key = typeof quality === 'string' ? quality : '';
+  return EQUIPMENT_QUALITY_RANK_MAP[key] || 1;
 }
 
 function resolveEquipmentSlotConfig(slot) {
@@ -3338,6 +3370,8 @@ async function listEquipmentCatalog(actorId) {
     quality: item.quality,
     qualityLabel: resolveEquipmentQualityLabel(item.quality),
     qualityColor: resolveEquipmentQualityColor(item.quality),
+    qualityRank: item.qualityRank || resolveEquipmentQualityRank(item.quality),
+    iconId: item.iconId || 0,
     levelRequirement: item.levelRequirement || 1,
     tags: item.tags || []
   }));
@@ -5164,6 +5198,8 @@ function decorateEquipmentInventoryEntry(entry, options = {}) {
     quality: definition.quality,
     qualityLabel: resolveEquipmentQualityLabel(definition.quality),
     qualityColor: resolveEquipmentQualityColor(definition.quality),
+    qualityRank: definition.qualityRank || resolveEquipmentQualityRank(definition.quality),
+    iconId: definition.iconId || 0,
     description: definition.description,
     slot: definition.slot,
     slotLabel: EQUIPMENT_SLOT_LABELS[definition.slot] || '装备',

--- a/miniprogram/pages/admin/member-detail/index.wxml
+++ b/miniprogram/pages/admin/member-detail/index.wxml
@@ -223,13 +223,33 @@
           <view
             class="equipment-admin__slot"
             wx:for="{{equipmentSlots}}"
+            wx:for-index="slotIndex"
             wx:key="slot"
             data-item-id="{{item.itemId}}"
             data-inventory-id="{{item.inventoryId || item.itemId}}"
             bindlongpress="handleEquipmentItemLongPress"
           >
-            <text class="equipment-admin__slot-label">{{item.slotLabel}}</text>
-            <text class="equipment-admin__slot-value" style="color: {{item.qualityColor}};">{{item.name || '未装备'}}</text>
+            <view class="equipment-admin__slot-content">
+              <view
+                wx:if="{{item.iconUrl}}"
+                class="equipment-admin__slot-icon"
+                style="border-color: {{item.qualityColor}};"
+              >
+                <image
+                  class="equipment-admin__slot-icon-image"
+                  src="{{item.iconUrl}}"
+                  mode="aspectFill"
+                  data-context="slot"
+                  data-index="{{slotIndex}}"
+                  data-fallback="{{item.iconFallbackUrl}}"
+                  binderror="handleEquipmentIconError"
+                />
+              </view>
+              <view class="equipment-admin__slot-text">
+                <text class="equipment-admin__slot-label">{{item.slotLabel}}</text>
+                <text class="equipment-admin__slot-value" style="color: {{item.qualityColor}};">{{item.name || '未装备'}}</text>
+              </view>
+            </view>
           </view>
         </view>
         <view wx:else class="equipment-admin__empty">暂无装备数据</view>
@@ -240,11 +260,27 @@
           <view
             class="equipment-admin__inventory-item"
             wx:for="{{equipmentInventory}}"
+            wx:for-index="inventoryIndex"
             wx:key="inventoryId"
             data-item-id="{{item.itemId}}"
             data-inventory-id="{{item.inventoryId || item.itemId}}"
             bindlongpress="handleEquipmentItemLongPress"
           >
+            <view
+              wx:if="{{item.iconUrl}}"
+              class="equipment-admin__inventory-icon"
+              style="border-color: {{item.qualityColor}};"
+            >
+              <image
+                class="equipment-admin__inventory-icon-image"
+                src="{{item.iconUrl}}"
+                mode="aspectFill"
+                data-context="inventory"
+                data-index="{{inventoryIndex}}"
+                data-fallback="{{item.iconFallbackUrl}}"
+                binderror="handleEquipmentIconError"
+              />
+            </view>
             <view class="equipment-admin__inventory-info">
               <view class="equipment-admin__inventory-name" style="color: {{item.qualityColor}};">{{item.name}}</view>
               <view class="equipment-admin__inventory-meta">
@@ -387,7 +423,24 @@
           class="equipment-dialog__option {{equipmentSelectionId === item.id ? 'equipment-dialog__option--active' : ''}}"
         >
           <radio value="{{item.id}}" checked="{{equipmentSelectionId === item.id}}" />
-          <text class="equipment-dialog__option-text">{{item.name}}</text>
+          <view class="equipment-dialog__option-content">
+            <view
+              wx:if="{{item.iconUrl}}"
+              class="equipment-dialog__option-icon"
+              style="border-color: {{item.qualityColor}};"
+            >
+              <image
+                class="equipment-dialog__option-icon-image"
+                src="{{item.iconUrl}}"
+                mode="aspectFill"
+                data-context="catalog"
+                data-id="{{item.id}}"
+                data-fallback="{{item.iconFallbackUrl}}"
+                binderror="handleEquipmentIconError"
+              />
+            </view>
+            <text class="equipment-dialog__option-text">{{item.name}}</text>
+          </view>
         </label>
       </radio-group>
     </scroll-view>

--- a/miniprogram/pages/admin/member-detail/index.wxss
+++ b/miniprogram/pages/admin/member-detail/index.wxss
@@ -430,6 +430,31 @@ page {
   min-height: 88rpx;
 }
 
+.equipment-dialog__option-content {
+  display: flex;
+  align-items: center;
+  gap: 16rpx;
+  width: 100%;
+  justify-content: center;
+}
+
+.equipment-dialog__option-icon {
+  width: 72rpx;
+  height: 72rpx;
+  border: 4rpx solid rgba(148, 163, 184, 0.3);
+  border-radius: 16rpx;
+  overflow: hidden;
+  background: rgba(28, 38, 68, 0.75);
+  flex-shrink: 0;
+  display: flex;
+}
+
+.equipment-dialog__option-icon-image {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
 .equipment-dialog__option radio {
   display: none;
 }
@@ -587,6 +612,37 @@ page {
   background: rgba(15, 23, 42, 0.8);
 }
 
+.equipment-admin__slot-content {
+  display: flex;
+  align-items: center;
+  gap: 16rpx;
+}
+
+.equipment-admin__slot-icon {
+  width: 96rpx;
+  height: 96rpx;
+  border: 4rpx solid rgba(148, 163, 184, 0.35);
+  border-radius: 16rpx;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.75);
+  flex-shrink: 0;
+  display: flex;
+}
+
+.equipment-admin__slot-icon-image {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.equipment-admin__slot-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6rpx;
+}
+
 .equipment-admin__slot-label {
   font-size: 24rpx;
   color: #94a3b8;
@@ -618,6 +674,23 @@ page {
   border-radius: 14rpx;
   padding: 16rpx;
   background: rgba(15, 23, 42, 0.75);
+}
+
+.equipment-admin__inventory-icon {
+  width: 96rpx;
+  height: 96rpx;
+  border: 4rpx solid rgba(148, 163, 184, 0.32);
+  border-radius: 16rpx;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.7);
+  flex-shrink: 0;
+  display: flex;
+}
+
+.equipment-admin__inventory-icon-image {
+  width: 100%;
+  height: 100%;
+  display: block;
 }
 
 .equipment-admin__inventory-info {

--- a/miniprogram/pages/role/index.wxml
+++ b/miniprogram/pages/role/index.wxml
@@ -191,7 +191,7 @@
             </view>
           </view>
           <view class="storage-grid">
-            <block wx:for="{{activeStorageCategoryData.slots}}" wx:key="storageKey">
+            <block wx:for="{{activeStorageCategoryData.slots}}" wx:for-index="slotIndex" wx:key="storageKey">
               <view wx:if="{{!item.placeholder}}" class="storage-slot">
                 <view class="storage-slot__badge">{{item.slotLabel}}</view>
                 <view
@@ -207,7 +207,24 @@
                   data-category="{{item.storageCategory || activeStorageCategory}}"
                 >
                   <view class="storage-slot__icon" style="border-color: {{item.qualityColor}};">
-                    <view class="storage-slot__name">{{item.shortName || item.name}}</view>
+                    <block wx:if="{{item.iconUrl}}">
+                      <image
+                        class="storage-slot__icon-image"
+                        src="{{item.iconUrl}}"
+                        mode="aspectFill"
+                        data-context="storage"
+                        data-index="{{slotIndex}}"
+                        data-category-index="{{activeStorageCategoryIndex}}"
+                        data-fallback="{{item.iconFallbackUrl}}"
+                        binderror="handleEquipmentIconError"
+                      />
+                      <view class="storage-slot__name storage-slot__name--overlay">
+                        {{item.shortName || item.name}}
+                      </view>
+                    </block>
+                    <view wx:else class="storage-slot__name storage-slot__name--placeholder">
+                      {{item.shortName || item.name}}
+                    </view>
                   </view>
                 </view>
               </view>
@@ -232,6 +249,7 @@
           <view
             class="slot-card {{item.item ? 'slot-card--filled' : 'slot-card--empty'}}"
             wx:for="{{(profile.equipment && profile.equipment.slots) || []}}"
+            wx:for-index="slotIndex"
             wx:key="slot"
           >
             <view class="slot-card__header">
@@ -246,9 +264,19 @@
               data-slot-label="{{item.slotLabel}}"
               data-item="{{item.item}}"
             >
-              <view class="slot-card__icon-name">
-                {{item.item ? (item.item.shortName || item.item.name) : '未装备'}}
-              </view>
+              <block wx:if="{{item.item}}">
+                <image
+                  class="slot-card__icon-image"
+                  src="{{item.item.iconUrl}}"
+                  mode="aspectFill"
+                  data-context="slot"
+                  data-index="{{slotIndex}}"
+                  data-fallback="{{item.item.iconFallbackUrl}}"
+                  binderror="handleEquipmentIconError"
+                />
+                <view class="slot-card__icon-label">{{item.item.shortName || item.item.name}}</view>
+              </block>
+              <view wx:else class="slot-card__icon-placeholder">未装备</view>
             </view>
           </view>
         </view>
@@ -281,6 +309,7 @@
           <view
             class="inventory-card {{item.equipped ? 'inventory-card--equipped' : ''}}"
             wx:for="{{(profile.equipment && profile.equipment.inventory) || []}}"
+            wx:for-index="inventoryIndex"
             wx:key="inventoryId"
           >
             <view class="inventory-card__badge">{{item.slotLabel}}</view>
@@ -297,7 +326,16 @@
                 data-slot-label="{{item.slotLabel || ''}}"
                 data-category="{{item.storageCategory || 'equipment'}}"
               >
-                <view class="inventory-card__icon-name">{{item.shortName || item.name}}</view>
+                <image
+                  class="inventory-card__icon-image"
+                  src="{{item.iconUrl}}"
+                  mode="aspectFill"
+                  data-context="inventory"
+                  data-index="{{inventoryIndex}}"
+                  data-fallback="{{item.iconFallbackUrl}}"
+                  binderror="handleEquipmentIconError"
+                />
+                <view class="inventory-card__icon-label">{{item.shortName || item.name}}</view>
                 <view wx:if="{{item.equipped}}" class="inventory-card__status">已装备</view>
               </view>
             </view>

--- a/miniprogram/pages/role/index.wxss
+++ b/miniprogram/pages/role/index.wxss
@@ -362,29 +362,43 @@ button.pill-btn[disabled] {
   height: 128rpx;
   border: 4rpx solid rgba(113, 140, 255, 0.6);
   border-radius: 20rpx;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   background: rgba(12, 20, 52, 0.9);
   color: #f5f8ff;
-  padding: 0 10rpx;
+  position: relative;
+  overflow: hidden;
   box-sizing: border-box;
 }
 
-.slot-card__icon-name {
-  max-width: 100%;
+.slot-card__icon-image {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.slot-card__icon-label {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 10rpx;
   font-size: 18rpx;
   font-weight: 600;
   text-align: center;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  line-height: 1.3;
+  color: #f5f8ff;
+  background: linear-gradient(180deg, rgba(10, 16, 40, 0) 0%, rgba(10, 16, 40, 0.88) 100%);
+  box-sizing: border-box;
+  z-index: 1;
+}
+
+.slot-card__icon-placeholder {
+  width: 100%;
+  height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 100%;
-  height: 100%;
-  line-height: 1.2;
+  font-size: 18rpx;
+  font-weight: 600;
 }
 
 .inventory-title {
@@ -448,30 +462,33 @@ button.pill-btn[disabled] {
   height: 100%;
   border: 4rpx solid rgba(120, 146, 255, 0.62);
   border-radius: 16rpx;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   background: rgba(8, 14, 40, 0.9);
   color: #f5f8ff;
-  padding: 0 10rpx;
   box-sizing: border-box;
   position: relative;
+  overflow: hidden;
 }
 
-.inventory-card__icon-name {
-  max-width: 100%;
+.inventory-card__icon-image {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.inventory-card__icon-label {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 10rpx;
   font-size: 18rpx;
   font-weight: 600;
   text-align: center;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  line-height: 1.2;
+  line-height: 1.3;
+  color: #f5f8ff;
+  background: linear-gradient(180deg, rgba(6, 12, 32, 0) 0%, rgba(6, 12, 32, 0.92) 100%);
+  box-sizing: border-box;
+  z-index: 1;
 }
 
 .inventory-card__status {
@@ -488,6 +505,7 @@ button.pill-btn[disabled] {
   justify-content: center;
   line-height: 1;
   font-weight: 600;
+  z-index: 2;
 }
 
 .inventory-card--equipped {
@@ -620,7 +638,6 @@ button.pill-btn[disabled] {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0 12rpx;
   box-sizing: border-box;
   transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
 }
@@ -638,10 +655,20 @@ button.pill-btn[disabled] {
 
 .storage-slot__icon {
   width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  height: 100%;
+  border: 4rpx solid rgba(118, 146, 250, 0.58);
+  border-radius: 16rpx;
+  background: rgba(12, 18, 40, 0.9);
   color: #f4f6ff;
+  position: relative;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.storage-slot__icon-image {
+  width: 100%;
+  height: 100%;
+  display: block;
 }
 
 .storage-slot__name {
@@ -651,7 +678,26 @@ button.pill-btn[disabled] {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.storage-slot__name--overlay {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 10rpx;
+  color: #f4f6ff;
+  background: linear-gradient(180deg, rgba(8, 14, 34, 0) 0%, rgba(8, 14, 34, 0.92) 100%);
+  box-sizing: border-box;
+  z-index: 1;
+}
+
+.storage-slot__name--placeholder {
   width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .storage-slot__placeholder {


### PR DESCRIPTION
## Summary
- assign per-quality icon sequences for equipment and expose them via the API
- compute cloud storage icon URLs with quality fallbacks when sanitizing equipment data
- render equipment icons with graceful degradation on the role and admin management pages

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dd7ad984708330afdae0a739f4fc94