### PR TITLE
Fix skill equip logic to fill empty slots

### DIFF
--- a/cloudfunctions/pve/index.js
+++ b/cloudfunctions/pve/index.js
@@ -2922,7 +2922,7 @@ async function equipSkill(actorId, event) {
           (id) => typeof id === 'string' && id && SKILL_MAP[id] && ownedSkillIds.has(id)
         ).length;
         if (equippedCount >= MAX_SKILL_SLOTS) {
-          throw createError('SKILL_SLOT_FULL', `最多装备 ${MAX_SKILL_SLOTS} 个技能`);
+          throw createError('SKILL_SLOT_FULL', '技能槽位已满，请选择要替换的技能');
         }
         throw createError('SKILL_SLOT_INVALID', '技能槽位数据异常，请重试');
       }

--- a/cloudfunctions/pve/index.js
+++ b/cloudfunctions/pve/index.js
@@ -2862,6 +2862,13 @@ async function equipSkill(actorId, event) {
   const inventory = Array.isArray(profile.skills.inventory) ? profile.skills.inventory : [];
   const equipped = Array.isArray(profile.skills.equipped) ? [...profile.skills.equipped] : [];
 
+  for (let i = 0; i < equipped.length; i += 1) {
+    const id = equipped[i];
+    if (!(typeof id === 'string' && id && SKILL_MAP[id])) {
+      equipped[i] = '';
+    }
+  }
+
   if (skillId) {
     const hasSkill = inventory.some((entry) => entry.skillId === skillId);
     if (!hasSkill) {
@@ -2877,10 +2884,16 @@ async function equipSkill(actorId, event) {
     }
   } else if (skillId) {
     if (!equipped.includes(skillId)) {
-      if (equipped.length >= MAX_SKILL_SLOTS) {
-        throw createError('SKILL_SLOT_FULL', `最多装备 ${MAX_SKILL_SLOTS} 个技能`);
+      const emptySlotIndex = equipped.findIndex((id) => !id);
+      if (emptySlotIndex >= 0) {
+        equipped[emptySlotIndex] = skillId;
+      } else {
+        const equippedCount = equipped.filter((id) => typeof id === 'string' && id && SKILL_MAP[id]).length;
+        if (equippedCount >= MAX_SKILL_SLOTS) {
+          throw createError('SKILL_SLOT_FULL', `最多装备 ${MAX_SKILL_SLOTS} 个技能`);
+        }
+        equipped.push(skillId);
       }
-      equipped.push(skillId);
     }
   }
 


### PR DESCRIPTION
## Summary
- sanitize the equipped skills list before processing equip requests
- fill the first empty slot when equipping without an explicit index to avoid false slot full errors

## Testing
- Not run (serverless function change only)


------
https://chatgpt.com/codex/tasks/task_e_68dddd397188833095795b1ff1e599c3