### PR TITLE
feat: 支持纳戒装备快速穿戴对比

### DIFF
--- a/miniprogram/pages/role/index.wxml
+++ b/miniprogram/pages/role/index.wxml
@@ -206,6 +206,9 @@
                   data-inventory-id="{{item.inventoryId || ''}}"
                   data-category="{{item.storageCategory || activeStorageCategory}}"
                 >
+                  <view wx:if="{{item.recommendedUpgrade}}" class="storage-slot__recommend">
+                    <text class="storage-slot__recommend-icon">↑</text>
+                  </view>
                   <view
                     class="storage-slot__icon {{item.iconUrl ? 'storage-slot__icon--image' : ''}}"
                     style="{{item.iconUrl ? '' : 'border-color: ' + item.qualityColor + ';'}}"

--- a/miniprogram/pages/role/index.wxml
+++ b/miniprogram/pages/role/index.wxml
@@ -498,11 +498,12 @@
 
   <view wx:if="{{equipmentTooltip && equipmentTooltip.visible}}" class="equipment-tooltip">
     <view class="equipment-tooltip__mask" catchtouchmove="noop" bindtap="closeEquipmentTooltip"></view>
-    <view class="equipment-tooltip__card">
-      <view class="equipment-tooltip__header">
-        <text
-          class="equipment-tooltip__name"
-          style="color: {{equipmentTooltip.item.qualityColor}};"
+    <view class="equipment-tooltip__container">
+      <view class="equipment-tooltip__card">
+        <view class="equipment-tooltip__header">
+          <text
+            class="equipment-tooltip__name"
+            style="color: {{equipmentTooltip.item.qualityColor}};"
         >{{equipmentTooltip.item.name}}</text>
         <text class="equipment-tooltip__quality">{{equipmentTooltip.item.qualityLabel}}</text>
       </view>
@@ -532,7 +533,7 @@
         bindtap="handleUnequipFromTooltip"
       >卸下</button>
       <button
-        wx:elif="{{equipmentTooltip.mode !== 'delete' && equipmentTooltip.source === 'inventory'}}"
+        wx:elif="{{equipmentTooltip.mode !== 'delete' && (equipmentTooltip.source === 'inventory' || equipmentTooltip.source === 'storage')}}"
         class="equipment-tooltip__equip pill-btn pill-btn--primary"
         hover-class="pill-btn--primary-hover"
         size="mini"
@@ -551,6 +552,37 @@
         wx:if="{{equipmentTooltip.mode === 'delete' && equipmentTooltip.deleteDisabledReason}}"
         class="equipment-tooltip__hint"
       >{{equipmentTooltip.deleteDisabledReason}}</view>
+      </view>
+      <view
+        wx:if="{{equipmentTooltip.equippedItem}}"
+        class="equipment-tooltip__card equipment-tooltip__card--secondary"
+      >
+        <view class="equipment-tooltip__compare-title">当前已穿戴</view>
+        <view class="equipment-tooltip__header">
+          <text
+            class="equipment-tooltip__name"
+            style="color: {{equipmentTooltip.equippedItem.qualityColor}};"
+          >{{equipmentTooltip.equippedItem.name}}</text>
+          <text class="equipment-tooltip__quality">{{equipmentTooltip.equippedItem.qualityLabel}}</text>
+        </view>
+        <view class="equipment-tooltip__meta">
+          <text wx:if="{{equipmentTooltip.equippedItem.slotLabel}}">槽位：{{equipmentTooltip.equippedItem.slotLabel}}</text>
+          <text wx:if="{{equipmentTooltip.equippedItem.refineLabel}}">{{equipmentTooltip.equippedItem.refineLabel}}</text>
+          <text wx:elif="{{equipmentTooltip.equippedItem.refine != null}}">精炼 {{equipmentTooltip.equippedItem.refine}}</text>
+        </view>
+        <view
+          class="equipment-tooltip__stats"
+          wx:if="{{equipmentTooltip.equippedItem.statsText && equipmentTooltip.equippedItem.statsText.length}}"
+        >
+          <text wx:for="{{equipmentTooltip.equippedItem.statsText}}" wx:key="index">{{item}}</text>
+        </view>
+        <view
+          class="equipment-tooltip__notes"
+          wx:if="{{equipmentTooltip.equippedItem.notes && equipmentTooltip.equippedItem.notes.length}}"
+        >
+          <text wx:for="{{equipmentTooltip.equippedItem.notes}}" wx:key="index">{{item}}</text>
+        </view>
+      </view>
     </view>
   </view>
   <view wx:if="{{skillModal && skillModal.visible}}" class="skill-modal">

--- a/miniprogram/pages/role/index.wxss
+++ b/miniprogram/pages/role/index.wxss
@@ -635,6 +635,29 @@ button.pill-btn[disabled] {
   z-index: 2;
 }
 
+.storage-slot__recommend {
+  position: absolute;
+  top: 8rpx;
+  right: 8rpx;
+  width: 44rpx;
+  height: 44rpx;
+  border-radius: 999rpx;
+  background: rgba(46, 184, 123, 0.92);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 6rpx 14rpx rgba(46, 184, 123, 0.38);
+  pointer-events: none;
+  z-index: 3;
+}
+
+.storage-slot__recommend-icon {
+  font-size: 28rpx;
+  color: #f5fff8;
+  font-weight: 700;
+  transform: translateY(-2rpx);
+}
+
 .storage-slot__frame {
   position: absolute;
   inset: 12rpx;

--- a/miniprogram/pages/role/index.wxss
+++ b/miniprogram/pages/role/index.wxss
@@ -849,10 +849,19 @@ button.pill-btn[disabled] {
   background: rgba(5, 9, 28, 0.72);
 }
 
-.equipment-tooltip__card {
+.equipment-tooltip__container {
   position: relative;
   max-width: 640rpx;
   width: calc(100% - 120rpx);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 24rpx;
+}
+
+.equipment-tooltip__card {
+  position: relative;
+  width: 100%;
   padding: 24rpx 36rpx 36rpx;
   border-radius: 28rpx;
   background: rgba(18, 30, 74, 0.92);
@@ -915,8 +924,14 @@ button.pill-btn[disabled] {
   color: rgba(195, 206, 255, 0.78);
 }
 
-.equipment-tooltip__equipped {
-  font-size: 22rpx;
+.equipment-tooltip__card--secondary {
+  background: rgba(18, 30, 74, 0.88);
+  border-color: rgba(102, 130, 238, 0.32);
+  box-shadow: 0 16rpx 36rpx rgba(6, 10, 32, 0.45);
+}
+
+.equipment-tooltip__compare-title {
+  font-size: 24rpx;
   color: rgba(195, 206, 255, 0.82);
 }
 


### PR DESCRIPTION
## Summary
- allow equipment stored in the 纳戒 tab to be equipped directly from the tooltip and keep the tooltip in sync with storage data
- show the currently equipped item for the same slot beneath the storage tooltip and adjust the layout styles accordingly

## Testing
- not run (mini program change)


------
https://chatgpt.com/codex/tasks/task_e_68de237c25148330815b0a6315efe714