### PR TITLE
feat: add meal ordering workflow for members and admins

### DIFF
--- a/cloudfunctions/shared/menu-data.js
+++ b/cloudfunctions/shared/menu-data.js
@@ -1,0 +1,137 @@
+const MENU_CATALOG = [
+  {
+    id: 'signature',
+    name: '招牌菜',
+    description: 'La Casa 经典人气菜肴',
+    items: [
+      {
+        id: 'signature-asado',
+        name: '阿根廷烤肉拼盘',
+        description: '精选牛腹肉、香肠与香草腌制蔬菜的拼盘，搭配自制青酱。',
+        price: 16800,
+        unit: '份',
+        tags: ['肉类', '分享'],
+        spicy: '微辣'
+      },
+      {
+        id: 'signature-risotto',
+        name: '松露牛肝菌烩饭',
+        description: '慢火熬制的牛肝菌汤底，加入意大利米与黑松露，口感丝滑浓郁。',
+        price: 12800,
+        unit: '份',
+        tags: ['主食'],
+        spicy: '不辣'
+      },
+      {
+        id: 'signature-seafood',
+        name: '西班牙海鲜饭',
+        description: '以藏红花调味的经典海鲜饭，搭配大虾、青口与鱿鱼圈。',
+        price: 15800,
+        unit: '份',
+        tags: ['主食', '海鲜'],
+        spicy: '微辣'
+      }
+    ]
+  },
+  {
+    id: 'tapas',
+    name: '小食与塔帕斯',
+    description: '佐酒分享的轻食与开胃小点',
+    items: [
+      {
+        id: 'tapas-croquetas',
+        name: '火腿芝士丸',
+        description: '西班牙塞拉诺火腿与曼切戈芝士炸球，酥脆绵密。',
+        price: 5200,
+        unit: '份',
+        tags: ['炸物'],
+        spicy: '不辣'
+      },
+      {
+        id: 'tapas-shrimp',
+        name: '蒜香橄榄油虾',
+        description: '新鲜大虾以蒜蓉、橄榄油与辣椒爆香，配上手工面包。',
+        price: 6800,
+        unit: '份',
+        tags: ['海鲜'],
+        spicy: '微辣'
+      },
+      {
+        id: 'tapas-salad',
+        name: '地中海沙拉',
+        description: '混合生菜、羊乳酪与风干番茄，佐以柠檬橄榄油酱。',
+        price: 4600,
+        unit: '份',
+        tags: ['素食'],
+        spicy: '不辣'
+      }
+    ]
+  },
+  {
+    id: 'beverage',
+    name: '饮品与甜品',
+    description: '特色调制鸡尾酒、咖啡与甜点',
+    items: [
+      {
+        id: 'beverage-sangria',
+        name: '自家秘制桑格利亚',
+        description: '红酒搭配时令水果与香料，清爽易饮。',
+        price: 3800,
+        unit: '杯',
+        tags: ['酒精'],
+        spicy: '不辣'
+      },
+      {
+        id: 'beverage-oldfashioned',
+        name: '烟熏老式',
+        description: '波本威士忌与自制糖浆调制，入口带有烟熏木香。',
+        price: 4200,
+        unit: '杯',
+        tags: ['酒精'],
+        spicy: '不辣'
+      },
+      {
+        id: 'dessert-basque',
+        name: '巴斯克芝士蛋糕',
+        description: '焦香外皮与柔滑内层，使用进口奶油慢烤而成。',
+        price: 4800,
+        unit: '份',
+        tags: ['甜点'],
+        spicy: '不辣'
+      }
+    ]
+  }
+];
+
+function cloneCatalog() {
+  return MENU_CATALOG.map((category) => ({
+    ...category,
+    items: category.items.map((item) => ({ ...item }))
+  }));
+}
+
+function buildItemIndex() {
+  const index = new Map();
+  MENU_CATALOG.forEach((category) => {
+    category.items.forEach((item) => {
+      index.set(item.id, { ...item, categoryId: category.id, categoryName: category.name });
+    });
+  });
+  return index;
+}
+
+const ITEM_INDEX = buildItemIndex();
+
+function getMenuCatalog() {
+  return cloneCatalog();
+}
+
+function getMenuItemById(id) {
+  if (!id) return null;
+  return ITEM_INDEX.get(id) ? { ...ITEM_INDEX.get(id) } : null;
+}
+
+module.exports = {
+  getMenuCatalog,
+  getMenuItemById
+};

--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -5,7 +5,7 @@
     "pages/rights/rights",
     "pages/tasks/tasks",
     "pages/reservation/reservation",
-    "pages/menu/order",
+    "pages/menu/order/order",
     "pages/stones/stones",
     "pages/pve/pve",
     "pages/role/index",

--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -5,6 +5,7 @@
     "pages/rights/rights",
     "pages/tasks/tasks",
     "pages/reservation/reservation",
+    "pages/menu/order",
     "pages/stones/stones",
     "pages/pve/pve",
     "pages/role/index",
@@ -15,6 +16,7 @@
     "pages/admin/members/index",
     "pages/admin/member-detail/index",
     "pages/admin/charge/index",
+    "pages/admin/meal-prep/index",
     "pages/admin/orders/index",
     "pages/wallet/charge-confirm/index"
   ],

--- a/miniprogram/pages/admin/index.js
+++ b/miniprogram/pages/admin/index.js
@@ -14,6 +14,12 @@ const BASE_ACTIONS = [
     url: '/pages/admin/charge/index'
   },
   {
+    icon: '🍱',
+    label: '备餐列表',
+    description: '查看会员点餐并通知扣款',
+    url: '/pages/admin/meal-prep/index'
+  },
+  {
     icon: '📊',
     label: '订单查询',
     description: '按会员查看扣费订单记录',

--- a/miniprogram/pages/admin/meal-prep/index.js
+++ b/miniprogram/pages/admin/meal-prep/index.js
@@ -1,0 +1,175 @@
+import { AdminService } from '../../../services/api';
+import { formatCurrency } from '../../../utils/format';
+
+const STATUS_TABS = [
+  { id: 'pending', label: '待备餐' },
+  { id: 'preparing', label: '备餐中' },
+  { id: 'awaitingMember', label: '待确认' },
+  { id: 'paid', label: '已结算' },
+  { id: 'all', label: '全部' }
+];
+
+const STATUS_LABELS = {
+  pending: '待备餐',
+  preparing: '备餐中',
+  awaitingMember: '待会员确认',
+  paid: '已结算',
+  cancelled: '已取消'
+};
+
+function formatDateTime(value) {
+  if (!value) return '';
+  let date = null;
+  if (value instanceof Date) {
+    date = value;
+  } else if (value && typeof value.toDate === 'function') {
+    try {
+      date = value.toDate();
+    } catch (error) {
+      date = null;
+    }
+  } else {
+    const parsed = new Date(value);
+    date = Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  if (!date) return '';
+  const y = date.getFullYear();
+  const m = `${date.getMonth() + 1}`.padStart(2, '0');
+  const d = `${date.getDate()}`.padStart(2, '0');
+  const h = `${date.getHours()}`.padStart(2, '0');
+  const mm = `${date.getMinutes()}`.padStart(2, '0');
+  return `${y}-${m}-${d} ${h}:${mm}`;
+}
+
+function decorateOrder(order) {
+  if (!order) return null;
+  const items = Array.isArray(order.items)
+    ? order.items.map((item) => {
+        const quantity = Math.max(1, Math.floor(Number(item.quantity || 0)) || 1);
+        const price = Number(item.price || 0);
+        const amount = Number(item.amount || price * quantity || 0);
+        return {
+          ...item,
+          quantity,
+          amount,
+          amountLabel: formatCurrency(amount)
+        };
+      })
+    : [];
+  const totalAmount = Number(order.totalAmount || 0);
+  const status = order.status || 'pending';
+  const memberName = order.memberName || (order.member && order.member.nickName) || '';
+  return {
+    ...order,
+    items,
+    memberName,
+    totalAmount,
+    totalAmountLabel: formatCurrency(totalAmount),
+    statusLabel: STATUS_LABELS[status] || '未知状态',
+    createdAtLabel: formatDateTime(order.createdAt || order.createdAtLabel),
+    updatedAtLabel: formatDateTime(order.updatedAt || order.updatedAtLabel)
+  };
+}
+
+Page({
+  data: {
+    statusTabs: STATUS_TABS,
+    activeStatus: 'pending',
+    orders: [],
+    loading: false,
+    statusCounts: {},
+    actionLoading: ''
+  },
+
+  onShow() {
+    this.loadOrders();
+  },
+
+  onPullDownRefresh() {
+    this.loadOrders().finally(() => {
+      wx.stopPullDownRefresh();
+    });
+  },
+
+  async loadOrders() {
+    if (this.data.loading) {
+      return Promise.resolve();
+    }
+    this.setData({ loading: true });
+    try {
+      const response = await AdminService.listMealOrders({
+        status: this.data.activeStatus,
+        page: 1,
+        pageSize: 50
+      });
+      const orders = Array.isArray(response.orders) ? response.orders.map(decorateOrder) : [];
+      const counts = response.statusCounts || {};
+      const statusTabs = STATUS_TABS.map((tab) => ({
+        ...tab,
+        count: typeof counts[tab.id] === 'number' ? counts[tab.id] : undefined
+      }));
+      this.setData({
+        orders,
+        statusCounts: counts,
+        statusTabs,
+        loading: false
+      });
+    } catch (error) {
+      this.setData({ loading: false });
+    }
+  },
+
+  handleStatusTap(event) {
+    const { id } = event.currentTarget.dataset || {};
+    if (!id || id === this.data.activeStatus) {
+      return;
+    }
+    this.setData({ activeStatus: id });
+    this.loadOrders();
+  },
+
+  async handleStartPrep(event) {
+    const { id } = event.currentTarget.dataset || {};
+    if (!id || this.data.actionLoading) {
+      return;
+    }
+    this.setData({ actionLoading: id });
+    try {
+      await AdminService.markMealOrderPreparing(id);
+      wx.showToast({ title: '已标记备餐', icon: 'success' });
+      this.loadOrders();
+    } catch (error) {
+      // handled by cloud
+    } finally {
+      this.setData({ actionLoading: '' });
+    }
+  },
+
+  async handleRequestPayment(event) {
+    const { id } = event.currentTarget.dataset || {};
+    if (!id || this.data.actionLoading) {
+      return;
+    }
+    wx.showModal({
+      title: '通知会员确认',
+      content: '确认已完成核对，通知会员确认扣款吗？',
+      confirmText: '通知',
+      cancelText: '再等等',
+      success: async (result) => {
+        if (!result.confirm) {
+          return;
+        }
+        this.setData({ actionLoading: id });
+        try {
+          await AdminService.requestMealOrderPayment(id);
+          wx.showToast({ title: '已通知会员', icon: 'success' });
+          this.loadOrders();
+        } catch (error) {
+          // handled globally
+        } finally {
+          this.setData({ actionLoading: '' });
+        }
+      }
+    });
+  }
+});

--- a/miniprogram/pages/admin/meal-prep/index.json
+++ b/miniprogram/pages/admin/meal-prep/index.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "备餐列表"
+}

--- a/miniprogram/pages/admin/meal-prep/index.wxml
+++ b/miniprogram/pages/admin/meal-prep/index.wxml
@@ -1,0 +1,61 @@
+<view class="prep-page">
+  <view class="status-tabs">
+    <view
+      wx:for="{{statusTabs}}"
+      wx:key="id"
+      class="status-tab {{activeStatus === item.id ? 'status-tab--active' : ''}}"
+      data-id="{{item.id}}"
+      bindtap="handleStatusTap"
+    >
+      <text>{{item.label}}</text>
+      <text wx:if="{{typeof item.count === 'number'}}" class="status-count">{{item.count}}</text>
+    </view>
+  </view>
+
+  <view class="content">
+    <view wx:if="{{loading}}" class="state">加载中...</view>
+    <view wx:elif="{{!orders.length}}" class="state">暂无相关订单</view>
+    <block wx:else wx:for="{{orders}}" wx:key="_id">
+      <view class="order-card">
+        <view class="order-card__header">
+          <view class="order-card__member">
+            <text class="order-card__name">{{item.memberName || '匿名会员'}}</text>
+            <text class="order-card__time">{{item.createdAtLabel}}</text>
+          </view>
+          <view class="order-card__status {{'status-' + (item.status || 'pending')}}">{{item.statusLabel}}</view>
+        </view>
+        <view class="order-card__amount">{{item.totalAmountLabel}}</view>
+        <view class="order-card__items">
+          <view class="order-item" wx:for="{{item.items}}" wx:key="itemId">
+            <view class="order-item__name">{{item.name}}</view>
+            <view class="order-item__qty">×{{item.quantity}}</view>
+            <view class="order-item__amount">{{item.amountLabel}}</view>
+          </view>
+        </view>
+        <view wx:if="{{item.memberNote}}" class="order-card__note">会员备注：{{item.memberNote}}</view>
+        <view wx:if="{{item.kitchenNote}}" class="order-card__note">备餐提示：{{item.kitchenNote}}</view>
+        <view wx:if="{{item.paymentNote}}" class="order-card__note">付款提示：{{item.paymentNote}}</view>
+        <view class="order-card__actions">
+          <button
+            wx:if="{{item.status === 'pending'}}"
+            class="action-btn action-btn--secondary"
+            size="mini"
+            loading="{{actionLoading === item._id}}"
+            data-id="{{item._id}}"
+            bindtap="handleStartPrep"
+          >标记备餐</button>
+          <button
+            wx:if="{{item.status === 'pending' || item.status === 'preparing'}}"
+            class="action-btn"
+            type="primary"
+            size="mini"
+            loading="{{actionLoading === item._id}}"
+            data-id="{{item._id}}"
+            bindtap="handleRequestPayment"
+          >通知会员确认</button>
+          <view wx:if="{{item.status === 'awaitingMember'}}" class="order-card__hint">等待会员确认扣款...</view>
+        </view>
+      </view>
+    </block>
+  </view>
+</view>

--- a/miniprogram/pages/admin/meal-prep/index.wxss
+++ b/miniprogram/pages/admin/meal-prep/index.wxss
@@ -1,0 +1,178 @@
+.prep-page {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #090d1e 0%, #141b3a 100%);
+  padding: 24rpx;
+  box-sizing: border-box;
+  color: #f3f6ff;
+}
+
+.status-tabs {
+  display: flex;
+  gap: 16rpx;
+  margin-bottom: 24rpx;
+}
+
+.status-tab {
+  flex: 1;
+  padding: 20rpx 0;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999rpx;
+  text-align: center;
+  font-size: 26rpx;
+  display: flex;
+  flex-direction: column;
+  gap: 6rpx;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.status-tab--active {
+  background: rgba(79, 115, 255, 0.28);
+  color: #ffffff;
+  font-weight: 600;
+  box-shadow: 0 10rpx 24rpx rgba(4, 8, 24, 0.35);
+}
+
+.status-count {
+  font-size: 22rpx;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 20rpx;
+}
+
+.state {
+  text-align: center;
+  color: rgba(255, 255, 255, 0.6);
+  padding: 80rpx 0;
+  font-size: 28rpx;
+}
+
+.order-card {
+  background: rgba(16, 25, 56, 0.92);
+  border-radius: 24rpx;
+  padding: 24rpx;
+  box-shadow: 0 12rpx 30rpx rgba(4, 8, 24, 0.4);
+}
+
+.order-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 12rpx;
+}
+
+.order-card__member {
+  display: flex;
+  flex-direction: column;
+  gap: 6rpx;
+}
+
+.order-card__name {
+  font-size: 30rpx;
+  font-weight: 600;
+}
+
+.order-card__time {
+  font-size: 24rpx;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.order-card__status {
+  padding: 6rpx 16rpx;
+  border-radius: 999rpx;
+  font-size: 24rpx;
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.status-awaitingMember {
+  background: rgba(255, 193, 7, 0.25);
+  color: #ffd166;
+}
+
+.status-preparing {
+  background: rgba(111, 207, 151, 0.24);
+  color: #6fcf97;
+}
+
+.status-paid {
+  background: rgba(100, 181, 246, 0.24);
+  color: #64b5f6;
+}
+
+.status-cancelled {
+  background: rgba(255, 99, 132, 0.24);
+  color: #ff6384;
+}
+
+.order-card__amount {
+  font-size: 34rpx;
+  font-weight: 600;
+  margin-bottom: 12rpx;
+  color: #ffd166;
+}
+
+.order-card__items {
+  border-top: 1rpx solid rgba(255, 255, 255, 0.1);
+  border-bottom: 1rpx solid rgba(255, 255, 255, 0.1);
+  padding: 12rpx 0;
+  margin-bottom: 12rpx;
+}
+
+.order-item {
+  display: flex;
+  justify-content: space-between;
+  font-size: 26rpx;
+  padding: 6rpx 0;
+}
+
+.order-item__name {
+  flex: 1;
+}
+
+.order-item__qty {
+  width: 80rpx;
+  text-align: right;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.order-item__amount {
+  width: 120rpx;
+  text-align: right;
+  color: rgba(255, 209, 102, 0.95);
+}
+
+.order-card__note {
+  font-size: 24rpx;
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom: 8rpx;
+}
+
+.order-card__actions {
+  display: flex;
+  gap: 16rpx;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 12rpx;
+}
+
+.action-btn {
+  border-radius: 999rpx;
+  padding: 12rpx 32rpx;
+  font-size: 24rpx;
+  background: linear-gradient(135deg, #4f73ff 0%, #7f8cff 100%);
+  color: #ffffff;
+}
+
+.action-btn--secondary {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.order-card__hint {
+  font-size: 24rpx;
+  color: rgba(255, 255, 255, 0.6);
+}

--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -38,7 +38,7 @@ const BASE_NAV_ITEMS = [
   { icon: '🛡️', label: '装备', url: '/pages/role/index?tab=equipment' },
   { icon: '💍', label: '纳戒', url: '/pages/role/index?tab=storage' },
   { icon: '📜', label: '技能', url: '/pages/role/index?tab=skill' },
-  { icon: '🍽️', label: '点餐', url: '/pages/menu/order' },
+  { icon: '🍽️', label: '点餐', url: '/pages/menu/order/order' },
   { icon: '📅', label: '预订', url: '/pages/reservation/reservation' },
   { icon: '💰', label: '钱包', url: '/pages/wallet/wallet' },
   { icon: '🧙‍♀️', label: '造型', url: '/pages/avatar/avatar' }

--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -38,6 +38,7 @@ const BASE_NAV_ITEMS = [
   { icon: '🛡️', label: '装备', url: '/pages/role/index?tab=equipment' },
   { icon: '💍', label: '纳戒', url: '/pages/role/index?tab=storage' },
   { icon: '📜', label: '技能', url: '/pages/role/index?tab=skill' },
+  { icon: '🍽️', label: '点餐', url: '/pages/menu/order' },
   { icon: '📅', label: '预订', url: '/pages/reservation/reservation' },
   { icon: '💰', label: '钱包', url: '/pages/wallet/wallet' },
   { icon: '🧙‍♀️', label: '造型', url: '/pages/avatar/avatar' }

--- a/miniprogram/pages/menu/order/order.js
+++ b/miniprogram/pages/menu/order/order.js
@@ -1,0 +1,303 @@
+import { MemberService, WalletService } from '../../../services/api';
+import { formatCurrency } from '../../../utils/format';
+
+const STATUS_LABELS = {
+  pending: '待备餐',
+  preparing: '备餐中',
+  awaitingMember: '待会员确认',
+  paid: '已结算',
+  cancelled: '已取消'
+};
+
+function formatDateTime(value) {
+  if (!value) {
+    return '';
+  }
+  let date = null;
+  if (value instanceof Date) {
+    date = value;
+  } else if (value && typeof value.toDate === 'function') {
+    try {
+      date = value.toDate();
+    } catch (error) {
+      date = null;
+    }
+  } else if (typeof value === 'string' || typeof value === 'number') {
+    const parsed = new Date(value);
+    date = Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  if (!date) {
+    return '';
+  }
+  const y = date.getFullYear();
+  const m = `${date.getMonth() + 1}`.padStart(2, '0');
+  const d = `${date.getDate()}`.padStart(2, '0');
+  const h = `${date.getHours()}`.padStart(2, '0');
+  const mm = `${date.getMinutes()}`.padStart(2, '0');
+  return `${y}-${m}-${d} ${h}:${mm}`;
+}
+
+function decorateOrder(order) {
+  if (!order) return null;
+  const items = Array.isArray(order.items)
+    ? order.items.map((item) => {
+        const price = Number(item.price || 0);
+        const quantity = Math.max(1, Math.floor(Number(item.quantity || 0)) || 1);
+        const amount = Number(item.amount || price * quantity || 0);
+        return {
+          ...item,
+          quantity,
+          price,
+          amount,
+          priceLabel: formatCurrency(price),
+          amountLabel: formatCurrency(amount)
+        };
+      })
+    : [];
+  const totalAmount = Number(order.totalAmount || 0);
+  const status = order.status || 'pending';
+  const createdAt = order.createdAt || order.createdAtLabel || null;
+  return {
+    ...order,
+    items,
+    totalAmount,
+    totalAmountLabel: formatCurrency(totalAmount),
+    statusLabel: STATUS_LABELS[status] || '未知状态',
+    createdAtLabel: formatDateTime(createdAt),
+    canConfirm: status === 'awaitingMember'
+  };
+}
+
+Page({
+  data: {
+    categories: [],
+    activeCategoryId: '',
+    cart: {},
+    cartList: [],
+    totalAmount: 0,
+    totalAmountLabel: formatCurrency(0),
+    totalQuantity: 0,
+    note: '',
+    menuLoading: false,
+    orderSubmitting: false,
+    ordersLoading: false,
+    orders: [],
+    payingOrderId: '',
+    currentTab: 'menu'
+  },
+
+  onLoad() {
+    this.loadMenu();
+    this.loadOrders();
+  },
+
+  onPullDownRefresh() {
+    Promise.all([this.loadMenu(), this.loadOrders()]).finally(() => {
+      wx.stopPullDownRefresh();
+    });
+  },
+
+  async loadMenu() {
+    if (this.data.menuLoading) {
+      return Promise.resolve();
+    }
+    this.setData({ menuLoading: true });
+    try {
+      const response = await MemberService.listMealMenu();
+      const categories = Array.isArray(response.categories)
+        ? response.categories.map((category) => ({
+            ...category,
+            items: Array.isArray(category.items)
+              ? category.items.map((item) => ({
+                  ...item,
+                  priceLabel: formatCurrency(item.price || 0),
+                  tags: Array.isArray(item.tags) ? item.tags : []
+                }))
+              : []
+          }))
+        : [];
+      const activeCategoryId = this.data.activeCategoryId || (categories[0] && categories[0].id) || '';
+      this.setData({ categories, activeCategoryId, menuLoading: false });
+    } catch (error) {
+      this.setData({ menuLoading: false });
+    }
+  },
+
+  async loadOrders() {
+    if (this.data.ordersLoading) {
+      return Promise.resolve();
+    }
+    this.setData({ ordersLoading: true });
+    try {
+      const response = await MemberService.listMealOrders({ page: 1, pageSize: 20 });
+      const orders = Array.isArray(response.orders) ? response.orders.map(decorateOrder) : [];
+      this.setData({ orders, ordersLoading: false });
+    } catch (error) {
+      this.setData({ ordersLoading: false });
+    }
+  },
+
+  handleTabChange(event) {
+    const { tab } = event.currentTarget.dataset || {};
+    if (!tab || tab === this.data.currentTab) {
+      return;
+    }
+    this.setData({ currentTab: tab });
+  },
+
+  handleCategorySelect(event) {
+    const { id } = event.currentTarget.dataset || {};
+    if (!id || id === this.data.activeCategoryId) {
+      return;
+    }
+    this.setData({ activeCategoryId: id });
+  },
+
+  handleIncrease(event) {
+    const { id } = event.currentTarget.dataset || {};
+    if (!id) return;
+    this.adjustCartQuantity(id, 1);
+  },
+
+  handleDecrease(event) {
+    const { id } = event.currentTarget.dataset || {};
+    if (!id) return;
+    this.adjustCartQuantity(id, -1);
+  },
+
+  adjustCartQuantity(itemId, delta) {
+    if (!itemId || !delta) {
+      return;
+    }
+    const item = this.findMenuItem(itemId);
+    if (!item) {
+      wx.showToast({ title: '菜品已更新，请刷新菜单', icon: 'none' });
+      return;
+    }
+    const nextCart = { ...this.data.cart };
+    const existing = nextCart[itemId] || { item, quantity: 0 };
+    const nextQuantity = Math.max(0, (existing.quantity || 0) + delta);
+    if (nextQuantity <= 0) {
+      delete nextCart[itemId];
+    } else {
+      nextCart[itemId] = { item, quantity: nextQuantity };
+    }
+    this.recalculateCart(nextCart);
+  },
+
+  recalculateCart(cart) {
+    const entries = Object.keys(cart).map((key) => {
+      const entry = cart[key];
+      if (!entry || !entry.item) {
+        return null;
+      }
+      const quantity = Math.max(1, Math.floor(Number(entry.quantity || 0)) || 1);
+      const price = Number(entry.item.price || 0);
+      const amount = price * quantity;
+      return {
+        ...entry,
+        item: entry.item,
+        quantity,
+        amount,
+        amountLabel: formatCurrency(amount)
+      };
+    }).filter(Boolean);
+    let totalAmount = 0;
+    let totalQuantity = 0;
+    entries.forEach((entry) => {
+      totalAmount += entry.amount;
+      totalQuantity += entry.quantity;
+    });
+    this.setData({
+      cart,
+      cartList: entries,
+      totalAmount,
+      totalAmountLabel: formatCurrency(totalAmount),
+      totalQuantity
+    });
+  },
+
+  findMenuItem(itemId) {
+    if (!itemId) return null;
+    for (const category of this.data.categories) {
+      if (!category || !Array.isArray(category.items)) continue;
+      const found = category.items.find((item) => item.id === itemId);
+      if (found) {
+        return found;
+      }
+    }
+    return null;
+  },
+
+  handleNoteInput(event) {
+    this.setData({ note: event.detail.value || '' });
+  },
+
+  async handleSubmitOrder() {
+    if (this.data.orderSubmitting) {
+      return;
+    }
+    if (!this.data.cartList.length) {
+      wx.showToast({ title: '请先选择菜品', icon: 'none' });
+      return;
+    }
+    this.setData({ orderSubmitting: true });
+    try {
+      const items = this.data.cartList.map((entry) => ({
+        itemId: entry.item.id,
+        quantity: entry.quantity
+      }));
+      await MemberService.createMealOrder({
+        items,
+        note: this.data.note
+      });
+      wx.showToast({ title: '订单已提交', icon: 'success' });
+      this.clearCart();
+      this.loadOrders();
+    } catch (error) {
+      // handled globally by service
+    } finally {
+      this.setData({ orderSubmitting: false });
+    }
+  },
+
+  clearCart() {
+    this.setData({
+      cart: {},
+      cartList: [],
+      totalAmount: 0,
+      totalAmountLabel: formatCurrency(0),
+      totalQuantity: 0,
+      note: ''
+    });
+  },
+
+  async handleConfirmPayment(event) {
+    const { id } = event.currentTarget.dataset || {};
+    if (!id) return;
+    if (this.data.payingOrderId) return;
+    const target = this.data.orders.find((order) => order._id === id || order.id === id);
+    const amountLabel = target ? target.totalAmountLabel : '';
+    wx.showModal({
+      title: '确认扣款',
+      content: amountLabel ? `确认使用钱包余额支付 ${amountLabel} 吗？` : '确认使用钱包余额支付该订单吗？',
+      confirmText: '确认支付',
+      cancelText: '暂不',
+      success: async (result) => {
+        if (!result.confirm) {
+          return;
+        }
+        this.setData({ payingOrderId: id });
+        try {
+          await WalletService.payMealOrder(id);
+          wx.showToast({ title: '扣款成功', icon: 'success' });
+          this.loadOrders();
+        } catch (error) {
+          // error handled by cloud function toast
+        } finally {
+          this.setData({ payingOrderId: '' });
+        }
+      }
+    });
+  }
+});

--- a/miniprogram/pages/menu/order/order.json
+++ b/miniprogram/pages/menu/order/order.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "会员点餐"
+}

--- a/miniprogram/pages/menu/order/order.wxml
+++ b/miniprogram/pages/menu/order/order.wxml
@@ -1,0 +1,121 @@
+<view class="order-page">
+  <view class="tabs">
+    <view
+      class="tab {{currentTab === 'menu' ? 'tab--active' : ''}}"
+      data-tab="menu"
+      bindtap="handleTabChange"
+    >点餐</view>
+    <view
+      class="tab {{currentTab === 'orders' ? 'tab--active' : ''}}"
+      data-tab="orders"
+      bindtap="handleTabChange"
+    >我的订单</view>
+  </view>
+
+  <view wx:if="{{currentTab === 'menu'}}" class="menu-tab">
+    <view wx:if="{{menuLoading}}" class="loading">菜单载入中...</view>
+    <view wx:elif="{{!categories.length}}" class="empty">暂未配置菜单，请稍后再试</view>
+    <scroll-view
+      wx:else
+      scroll-y
+      class="category-scroll"
+    >
+      <block wx:for="{{categories}}" wx:key="id">
+        <view class="category-section">
+          <view class="category-header">
+            <view class="category-name">{{item.name}}</view>
+            <view wx:if="{{item.description}}" class="category-desc">{{item.description}}</view>
+          </view>
+          <view class="menu-item" wx:for="{{item.items}}" wx:key="id">
+            <view class="menu-item__body">
+              <view class="menu-item__header">
+                <view class="menu-item__name">{{item.name}}</view>
+                <view class="menu-item__price">{{item.priceLabel}}</view>
+              </view>
+              <view wx:if="{{item.description}}" class="menu-item__desc">{{item.description}}</view>
+              <view wx:if="{{item.tags.length}}" class="menu-item__tags">
+                <text class="menu-item__tag" wx:for="{{item.tags}}" wx:key="*this">{{item}}</text>
+              </view>
+            </view>
+            <view class="menu-item__actions">
+              <view class="quantity-control">
+                <button
+                  class="quantity-btn"
+                  data-id="{{item.id}}"
+                  bindtap="handleDecrease"
+                  size="mini"
+                >-</button>
+                <text class="quantity-value">{{cart[item.id] ? cart[item.id].quantity : 0}}</text>
+                <button
+                  class="quantity-btn"
+                  data-id="{{item.id}}"
+                  bindtap="handleIncrease"
+                  size="mini"
+                >+</button>
+              </view>
+            </view>
+          </view>
+        </view>
+      </block>
+    </scroll-view>
+
+    <view class="note-section">
+      <textarea
+        class="note-input"
+        placeholder="口味偏好、过敏原等备注"
+        maxlength="200"
+        value="{{note}}"
+        bindinput="handleNoteInput"
+      ></textarea>
+    </view>
+
+    <view class="cart-summary">
+      <view class="cart-info">
+        <text class="cart-count">共 {{totalQuantity}} 份</text>
+        <text class="cart-amount">{{totalAmountLabel}}</text>
+      </view>
+      <button
+        class="submit-btn"
+        type="primary"
+        loading="{{orderSubmitting}}"
+        disabled="{{orderSubmitting || totalQuantity === 0}}"
+        bindtap="handleSubmitOrder"
+      >提交订单</button>
+    </view>
+  </view>
+
+  <view wx:if="{{currentTab === 'orders'}}" class="orders-tab">
+    <view wx:if="{{ordersLoading}}" class="loading">订单加载中...</view>
+    <view wx:elif="{{!orders.length}}" class="empty">暂无历史订单</view>
+    <block wx:else wx:for="{{orders}}" wx:key="_id">
+      <view class="order-card">
+        <view class="order-card__header">
+          <view class="order-card__status {{'status--' + (item.status || 'pending')}}">{{item.statusLabel}}</view>
+          <view class="order-card__time">{{item.createdAtLabel}}</view>
+        </view>
+        <view class="order-card__body">
+          <view class="order-card__amount">总计 {{item.totalAmountLabel}}</view>
+          <view class="order-card__items">
+            <view class="order-line" wx:for="{{item.items}}" wx:key="itemId">
+              <view class="order-line__name">{{item.name}}</view>
+              <view class="order-line__qty">×{{item.quantity}}</view>
+              <view class="order-line__amount">{{item.amountLabel}}</view>
+            </view>
+          </view>
+          <view wx:if="{{item.memberNote}}" class="order-card__note">备注：{{item.memberNote}}</view>
+          <view wx:if="{{item.kitchenNote}}" class="order-card__note">备餐提示：{{item.kitchenNote}}</view>
+          <view wx:if="{{item.paymentNote}}" class="order-card__note">付款提示：{{item.paymentNote}}</view>
+        </view>
+        <button
+          wx:if="{{item.canConfirm}}"
+          class="confirm-btn"
+          type="primary"
+          size="mini"
+          loading="{{payingOrderId === item._id || payingOrderId === item.id}}"
+          data-id="{{item._id || item.id}}"
+          bindtap="handleConfirmPayment"
+        >确认扣款</button>
+      </view>
+    </block>
+  </view>
+</view>

--- a/miniprogram/pages/menu/order/order.wxss
+++ b/miniprogram/pages/menu/order/order.wxss
@@ -1,0 +1,308 @@
+.order-page {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #050921 0%, #101735 100%);
+  color: #f0f4ff;
+  display: flex;
+  flex-direction: column;
+}
+
+.tabs {
+  display: flex;
+  margin: 24rpx 24rpx 0;
+  border-radius: 24rpx;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.tab {
+  flex: 1;
+  text-align: center;
+  padding: 22rpx 0;
+  font-size: 30rpx;
+  color: rgba(255, 255, 255, 0.64);
+  transition: all 0.2s ease;
+}
+
+.tab--active {
+  background: rgba(65, 105, 255, 0.28);
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.menu-tab,
+.orders-tab {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 24rpx;
+  box-sizing: border-box;
+}
+
+.loading,
+.empty {
+  text-align: center;
+  color: rgba(255, 255, 255, 0.6);
+  padding: 60rpx 0;
+  font-size: 28rpx;
+}
+
+.category-scroll {
+  flex: 1;
+  padding-bottom: 220rpx;
+}
+
+.category-section {
+  margin-bottom: 32rpx;
+}
+
+.category-header {
+  margin-bottom: 12rpx;
+}
+
+.category-name {
+  font-size: 36rpx;
+  font-weight: 600;
+  margin-bottom: 8rpx;
+}
+
+.category-desc {
+  font-size: 26rpx;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.menu-item {
+  background: rgba(16, 25, 56, 0.9);
+  border-radius: 20rpx;
+  padding: 24rpx;
+  margin-bottom: 20rpx;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  box-shadow: 0 8rpx 24rpx rgba(4, 8, 24, 0.4);
+}
+
+.menu-item__body {
+  flex: 1;
+  padding-right: 24rpx;
+}
+
+.menu-item__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.menu-item__name {
+  font-size: 32rpx;
+  font-weight: 600;
+}
+
+.menu-item__price {
+  font-size: 30rpx;
+  color: #ffd166;
+}
+
+.menu-item__desc {
+  font-size: 26rpx;
+  color: rgba(255, 255, 255, 0.65);
+  margin-top: 8rpx;
+}
+
+.menu-item__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12rpx;
+  margin-top: 12rpx;
+}
+
+.menu-item__tag {
+  font-size: 22rpx;
+  padding: 6rpx 16rpx;
+  border-radius: 999rpx;
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.menu-item__actions {
+  display: flex;
+  align-items: center;
+}
+
+.quantity-control {
+  display: flex;
+  align-items: center;
+  gap: 16rpx;
+}
+
+.quantity-btn {
+  background: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+  border: none;
+  border-radius: 50%;
+  width: 64rpx;
+  height: 64rpx;
+  line-height: 64rpx;
+  font-size: 32rpx;
+}
+
+.quantity-value {
+  font-size: 30rpx;
+  min-width: 48rpx;
+  text-align: center;
+}
+
+.note-section {
+  margin-top: 12rpx;
+}
+
+.note-input {
+  width: 100%;
+  min-height: 120rpx;
+  padding: 20rpx;
+  border-radius: 20rpx;
+  background: rgba(16, 25, 56, 0.9);
+  color: #f0f4ff;
+  font-size: 26rpx;
+  box-sizing: border-box;
+}
+
+.cart-summary {
+  position: sticky;
+  bottom: 24rpx;
+  margin-top: 24rpx;
+  background: rgba(8, 12, 32, 0.9);
+  border-radius: 24rpx;
+  padding: 24rpx;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  box-shadow: 0 12rpx 30rpx rgba(4, 8, 24, 0.45);
+}
+
+.cart-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6rpx;
+}
+
+.cart-count {
+  font-size: 26rpx;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.cart-amount {
+  font-size: 36rpx;
+  font-weight: 600;
+  color: #ffd166;
+}
+
+.submit-btn {
+  min-width: 200rpx;
+  border-radius: 999rpx;
+  background: linear-gradient(135deg, #4f73ff 0%, #7f8cff 100%);
+}
+
+.orders-tab {
+  gap: 20rpx;
+}
+
+.order-card {
+  background: rgba(16, 25, 56, 0.9);
+  border-radius: 24rpx;
+  padding: 24rpx;
+  margin-bottom: 24rpx;
+  box-shadow: 0 12rpx 28rpx rgba(4, 8, 24, 0.4);
+}
+
+.order-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 12rpx;
+}
+
+.order-card__status {
+  font-size: 26rpx;
+  padding: 6rpx 16rpx;
+  border-radius: 999rpx;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.status--awaitingMember {
+  background: rgba(255, 193, 7, 0.24);
+  color: #ffd166;
+}
+
+.status--pending {
+  background: rgba(255, 255, 255, 0.18);
+  color: #f0f4ff;
+}
+
+.status--preparing {
+  background: rgba(111, 207, 151, 0.24);
+  color: #6fcf97;
+}
+
+.status--paid {
+  background: rgba(100, 181, 246, 0.24);
+  color: #64b5f6;
+}
+
+.status--cancelled {
+  background: rgba(255, 99, 132, 0.24);
+  color: #ff6384;
+}
+
+.order-card__time {
+  font-size: 24rpx;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.order-card__amount {
+  font-size: 30rpx;
+  font-weight: 600;
+  margin-bottom: 12rpx;
+}
+
+.order-card__items {
+  border-top: 1rpx solid rgba(255, 255, 255, 0.1);
+  border-bottom: 1rpx solid rgba(255, 255, 255, 0.1);
+  padding: 12rpx 0;
+}
+
+.order-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 26rpx;
+  padding: 6rpx 0;
+}
+
+.order-line__name {
+  flex: 1;
+}
+
+.order-line__qty {
+  width: 80rpx;
+  text-align: right;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.order-line__amount {
+  width: 120rpx;
+  text-align: right;
+  color: #ffd166;
+}
+
+.order-card__note {
+  margin-top: 8rpx;
+  font-size: 24rpx;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.confirm-btn {
+  margin-top: 16rpx;
+  border-radius: 999rpx;
+  background: linear-gradient(135deg, #ff9d6c 0%, #ff6f91 100%);
+  color: #fff;
+}

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -181,6 +181,21 @@ export const MemberService = {
       action: 'redeemRenameCard',
       count
     });
+  },
+  async listMealMenu() {
+    return callCloud(CLOUD_FUNCTIONS.MEMBER, { action: 'listMealMenu' });
+  },
+  async createMealOrder(order = {}) {
+    return callCloud(CLOUD_FUNCTIONS.MEMBER, {
+      action: 'createMealOrder',
+      order
+    });
+  },
+  async listMealOrders(options = {}) {
+    return callCloud(CLOUD_FUNCTIONS.MEMBER, {
+      action: 'listMealOrders',
+      options
+    });
   }
 };
 
@@ -257,6 +272,12 @@ export const WalletService = {
   async confirmChargeOrder(orderId) {
     return callCloud(CLOUD_FUNCTIONS.WALLET, {
       action: 'confirmChargeOrder',
+      orderId
+    });
+  },
+  async payMealOrder(orderId) {
+    return callCloud(CLOUD_FUNCTIONS.WALLET, {
+      action: 'payMealOrder',
       orderId
     });
   }
@@ -468,6 +489,28 @@ export const AdminService = {
   async markReservationRead() {
     return callCloud(CLOUD_FUNCTIONS.ADMIN, {
       action: 'markReservationRead'
+    });
+  },
+  async listMealOrders({ status = 'pending', page = 1, pageSize = 20 } = {}) {
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, {
+      action: 'listMealOrders',
+      status,
+      page,
+      pageSize
+    });
+  },
+  async markMealOrderPreparing(orderId, note = '') {
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, {
+      action: 'markMealOrderPreparing',
+      orderId,
+      note
+    });
+  },
+  async requestMealOrderPayment(orderId, note = '') {
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, {
+      action: 'requestMealOrderPayment',
+      orderId,
+      note
     });
   }
 };


### PR DESCRIPTION
## Summary
- add shared La Casa menu data and meal-order actions across member, admin, and wallet cloud functions
- create a member-facing ordering page with cart, order history, and balance confirmation flow
- add an admin meal-prep dashboard to track submissions, start prep, and notify members for payment
- expose new APIs and navigation entries so both roles can access the meal workflow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de8d182a988330970c83a526600f83