### PR TITLE
feat: add meal ordering for members and kitchen workflow

### DIFF
--- a/cloudfunctions/member/menu-catalog.js
+++ b/cloudfunctions/member/menu-catalog.js
@@ -1,0 +1,201 @@
+const MENU_VERSION = '2024-03-01';
+
+const CATEGORIES = [
+  {
+    id: 'signature',
+    name: '招牌必点',
+    description: '老饕挚爱的镇店之作',
+    order: 1
+  },
+  {
+    id: 'hot-dishes',
+    name: '热菜',
+    description: '现点现做的热菜佳肴',
+    order: 2
+  },
+  {
+    id: 'snacks',
+    name: '小食',
+    description: '佐酒拍档或是间歇小点',
+    order: 3
+  },
+  {
+    id: 'drinks',
+    name: '酒水茶饮',
+    description: '醒神润喉的杯中物',
+    order: 4
+  }
+];
+
+const ITEMS = [
+  {
+    id: 'signature-snowflake-beef',
+    categoryId: 'signature',
+    name: '雪花牛小排',
+    description: '特选谷饲雪花牛排，铁板急火锁汁。',
+    price: 12800,
+    unit: '份',
+    spicy: 1,
+    tags: ['牛肉', '铁板']
+  },
+  {
+    id: 'signature-cherry-duck',
+    categoryId: 'signature',
+    name: '樱桃烟熏鸭胸',
+    description: '低温慢煮配以桂花蜜酱，入口即化。',
+    price: 9800,
+    unit: '份',
+    spicy: 0,
+    tags: ['禽类']
+  },
+  {
+    id: 'signature-matsutake-soup',
+    categoryId: 'signature',
+    name: '松茸灵芝汤',
+    description: '云南鲜松茸搭配灵芝文火煨制，清润暖胃。',
+    price: 16800,
+    unit: '盅',
+    spicy: 0,
+    tags: ['汤品']
+  },
+  {
+    id: 'hot-dishes-pepper-fish',
+    categoryId: 'hot-dishes',
+    name: '藤椒青麻鲜鱼',
+    description: '高原冷水鱼佐以藤椒秘制油，麻香爽口。',
+    price: 11800,
+    unit: '份',
+    spicy: 2,
+    tags: ['鱼类', '川味']
+  },
+  {
+    id: 'hot-dishes-black-garlic-ribs',
+    categoryId: 'hot-dishes',
+    name: '黑蒜慢炖排骨',
+    description: '黑蒜酱汁裹匀排骨，慢火入味骨肉脱离。',
+    price: 8800,
+    unit: '份',
+    spicy: 0,
+    tags: ['猪肉', '炖菜']
+  },
+  {
+    id: 'hot-dishes-seasonal-veg',
+    categoryId: 'hot-dishes',
+    name: '时蔬三味',
+    description: '精选当季蔬菜，蒜蓉/清炒/白灼三种做法。',
+    price: 5200,
+    unit: '份',
+    spicy: 0,
+    tags: ['素食']
+  },
+  {
+    id: 'snacks-truffle-fries',
+    categoryId: 'snacks',
+    name: '松露薯条',
+    description: '法芙娜松露酱拌匀手切薯条，酥香迷人。',
+    price: 3600,
+    unit: '篮',
+    spicy: 0,
+    tags: ['炸物', '素食']
+  },
+  {
+    id: 'snacks-crispy-shrimp',
+    categoryId: 'snacks',
+    name: '脆炸金钱虾饼',
+    description: '手拍虾泥夹入肥膘，外酥里弹。',
+    price: 4200,
+    unit: '份',
+    spicy: 1,
+    tags: ['海鲜', '炸物']
+  },
+  {
+    id: 'snacks-dragonbeard-candy',
+    categoryId: 'snacks',
+    name: '龙须酥拼盘',
+    description: '传统手工龙须酥搭配坚果、玫瑰与抹茶三味。',
+    price: 3200,
+    unit: '份',
+    spicy: 0,
+    tags: ['甜品']
+  },
+  {
+    id: 'drinks-aged-plum-wine',
+    categoryId: 'drinks',
+    name: '十年陈酿梅酒',
+    description: '低温窖藏十年的南高梅酒，酸甜平衡。',
+    price: 6800,
+    unit: '壶',
+    spicy: 0,
+    tags: ['酒类']
+  },
+  {
+    id: 'drinks-oolong-tea',
+    categoryId: 'drinks',
+    name: '武夷岩茶·大红袍',
+    description: '武夷山核心产区传统炭焙，岩韵饱满。',
+    price: 2600,
+    unit: '壶',
+    spicy: 0,
+    tags: ['茶饮']
+  },
+  {
+    id: 'drinks-cold-brew-coffee',
+    categoryId: 'drinks',
+    name: '冷萃耶加雪菲',
+    description: '18小时低温冷萃，柑橘花香清爽提神。',
+    price: 3200,
+    unit: '杯',
+    spicy: 0,
+    tags: ['咖啡']
+  }
+];
+
+function listMenuCatalog() {
+  const sortedCategories = [...CATEGORIES].sort((a, b) => (a.order || 0) - (b.order || 0));
+  return sortedCategories.map((category) => ({
+    ...category,
+    items: ITEMS.filter((item) => item.categoryId === category.id).map((item) => ({
+      ...item
+    }))
+  }));
+}
+
+function getMenuItem(itemId) {
+  if (!itemId) {
+    return null;
+  }
+  const targetId = String(itemId).trim();
+  if (!targetId) {
+    return null;
+  }
+  return ITEMS.find((item) => item.id === targetId) || null;
+}
+
+function normalizeSelection(selection = []) {
+  const aggregated = new Map();
+  selection.forEach((entry) => {
+    if (!entry) {
+      return;
+    }
+    const itemId = typeof entry.itemId === 'string' ? entry.itemId.trim() : '';
+    if (!itemId) {
+      return;
+    }
+    const quantity = Number(entry.quantity);
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      return;
+    }
+    const existing = aggregated.get(itemId) || 0;
+    aggregated.set(itemId, existing + Math.floor(quantity));
+  });
+  return Array.from(aggregated.entries())
+    .map(([itemId, quantity]) => ({ itemId, quantity }))
+    .filter((item) => item.quantity > 0);
+}
+
+module.exports = {
+  MENU_VERSION,
+  listMenuCatalog,
+  getMenuItem,
+  normalizeSelection
+};

--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -4,6 +4,7 @@
     "pages/membership/membership",
     "pages/rights/rights",
     "pages/tasks/tasks",
+    "pages/menu/menu",
     "pages/reservation/reservation",
     "pages/stones/stones",
     "pages/pve/pve",
@@ -16,6 +17,7 @@
     "pages/admin/member-detail/index",
     "pages/admin/charge/index",
     "pages/admin/orders/index",
+    "pages/admin/meal-prep/index",
     "pages/wallet/charge-confirm/index"
   ],
   "window": {

--- a/miniprogram/pages/admin/index.js
+++ b/miniprogram/pages/admin/index.js
@@ -24,6 +24,12 @@ const BASE_ACTIONS = [
     label: '预约审核',
     description: '查看并审核包房预约申请',
     url: '/pages/admin/reservations/index'
+  },
+  {
+    icon: '🍱',
+    label: '备餐列表',
+    description: '查看会员点餐并推送确认',
+    url: '/pages/admin/meal-prep/index'
   }
 ];
 

--- a/miniprogram/pages/admin/meal-prep/index.js
+++ b/miniprogram/pages/admin/meal-prep/index.js
@@ -1,0 +1,144 @@
+import { AdminService } from '../../../services/api';
+import { formatCurrency } from '../../../utils/format';
+
+const app = getApp();
+
+function formatOrderTime(value) {
+  const date = value ? new Date(value) : new Date();
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  const hour = `${date.getHours()}`.padStart(2, '0');
+  const minute = `${date.getMinutes()}`.padStart(2, '0');
+  return `${year}-${month}-${day} ${hour}:${minute}`;
+}
+
+function summarizeItems(items) {
+  return (items || [])
+    .map((item) => `${item.name || ''} ×${item.quantity || 0}`)
+    .join('、');
+}
+
+function transformAdminOrder(order) {
+  if (!order) {
+    return null;
+  }
+  const items = Array.isArray(order.items) ? order.items : [];
+  const id = order._id || order.orderId || '';
+  return {
+    id,
+    memberId: order.memberId || '',
+    memberName: order.memberName || '未登记',
+    memberMobile: order.memberMobile || '',
+    status: order.status || 'pendingAdmin',
+    statusLabel: order.statusLabel || '',
+    totalAmount: order.totalAmount || 0,
+    totalAmountLabel: formatCurrency(order.totalAmount || 0),
+    createdAtLabel: order.createdAtLabel || formatOrderTime(order.createdAt || Date.now()),
+    confirmedAtLabel: order.confirmedAtLabel || '',
+    memberConfirmedAtLabel: order.memberConfirmedAtLabel || '',
+    memberNotes: order.memberNotes || '',
+    adminNotes: order.adminNotes || '',
+    menuVersion: order.menuVersion || '',
+    items,
+    itemSummary: summarizeItems(items),
+    canConfirm: (order.status || 'pendingAdmin') === 'pendingAdmin'
+  };
+}
+
+Page({
+  data: {
+    navHeight: 88,
+    loading: true,
+    listLoading: false,
+    pendingOrders: [],
+    awaitingOrders: [],
+    confirmProcessing: ''
+  },
+
+  onLoad() {
+    this.ensureNavMetrics();
+    this.bootstrap();
+  },
+
+  onShow() {
+    this.loadAllOrders();
+  },
+
+  onPullDownRefresh() {
+    this.loadAllOrders()
+      .catch(() => {})
+      .finally(() => {
+        wx.stopPullDownRefresh();
+      });
+  },
+
+  ensureNavMetrics() {
+    try {
+      const { customNav = {} } = app.globalData || {};
+      if (customNav.navHeight && customNav.navHeight !== this.data.navHeight) {
+        this.setData({ navHeight: customNav.navHeight });
+      }
+    } catch (error) {
+      console.warn('[meal-prep] resolve nav metrics failed', error);
+    }
+  },
+
+  async bootstrap() {
+    this.setData({ loading: true });
+    await this.loadAllOrders();
+    this.setData({ loading: false });
+  },
+
+  async loadAllOrders() {
+    this.setData({ listLoading: true });
+    try {
+      const [pendingRes, awaitingRes] = await Promise.all([
+        AdminService.listMealOrders({ status: 'pendingAdmin', page: 1, pageSize: 50 }),
+        AdminService.listMealOrders({ status: 'awaitingMember', page: 1, pageSize: 50 })
+      ]);
+      const pendingOrders = (pendingRes && Array.isArray(pendingRes.orders) ? pendingRes.orders : [])
+        .map(transformAdminOrder)
+        .filter(Boolean);
+      const awaitingOrders = (awaitingRes && Array.isArray(awaitingRes.orders) ? awaitingRes.orders : [])
+        .map(transformAdminOrder)
+        .filter(Boolean);
+      this.setData({ pendingOrders, awaitingOrders, listLoading: false });
+    } catch (error) {
+      console.error('[meal-prep] load orders failed', error);
+      wx.showToast({ title: '订单加载失败', icon: 'none' });
+      this.setData({ listLoading: false });
+    }
+  },
+
+  async handleConfirmTap(event) {
+    const { orderId } = event.currentTarget.dataset;
+    if (!orderId || this.data.confirmProcessing === orderId) {
+      return;
+    }
+    const confirmResult = await wx.showModal({
+      title: '确认备餐完成',
+      content: '确认将订单推送给会员进行扣费？',
+      confirmText: '确认',
+      cancelText: '取消'
+    });
+    if (!confirmResult || !confirmResult.confirm) {
+      return;
+    }
+    this.setData({ confirmProcessing: orderId });
+    try {
+      await AdminService.confirmMealOrder(orderId, '');
+      wx.showToast({ title: '已推送会员确认', icon: 'success' });
+      await this.loadAllOrders();
+    } catch (error) {
+      console.error('[meal-prep] confirm meal order failed', error);
+      const message = (error && error.errMsg) || '确认失败';
+      wx.showToast({ title: message.replace('cloud.callFunction:fail ', ''), icon: 'none' });
+    } finally {
+      this.setData({ confirmProcessing: '' });
+    }
+  }
+});

--- a/miniprogram/pages/admin/meal-prep/index.json
+++ b/miniprogram/pages/admin/meal-prep/index.json
@@ -1,0 +1,6 @@
+{
+  "navigationBarTitleText": "备餐列表",
+  "usingComponents": {
+    "custom-nav": "/components/custom-nav/custom-nav"
+  }
+}

--- a/miniprogram/pages/admin/meal-prep/index.wxml
+++ b/miniprogram/pages/admin/meal-prep/index.wxml
@@ -1,0 +1,66 @@
+<custom-nav title="备餐列表" theme="dark"></custom-nav>
+<view class="prep-page" style="padding-top: {{navHeight}}px;">
+  <scroll-view class="prep-scroll" scroll-y>
+    <view class="section">
+      <view class="section-header">
+        <view class="section-title">待备餐</view>
+        <view class="section-meta">{{pendingOrders.length}} 单</view>
+      </view>
+      <view wx:if="{{listLoading && !pendingOrders.length}}" class="loading">加载中...</view>
+      <view wx:elif="{{!pendingOrders.length}}" class="empty">暂无待处理订单</view>
+      <view wx:else>
+        <view class="order-card" wx:for="{{pendingOrders}}" wx:key="id">
+          <view class="order-header">
+            <view class="order-member">
+              <view class="order-member-name">{{item.memberName}}</view>
+              <view wx:if="{{item.memberMobile}}" class="order-member-mobile">{{item.memberMobile}}</view>
+            </view>
+            <view class="order-time">{{item.createdAtLabel}}</view>
+          </view>
+          <view class="order-body">
+            <view class="order-amount">{{item.totalAmountLabel}}</view>
+            <view class="order-items" wx:if="{{item.itemSummary}}">{{item.itemSummary}}</view>
+            <view wx:if="{{item.memberNotes}}" class="order-note">会员备注：{{item.memberNotes}}</view>
+          </view>
+          <view class="order-footer">
+            <button
+              class="order-action"
+              type="primary"
+              size="mini"
+              loading="{{confirmProcessing === item.id}}"
+              data-order-id="{{item.id}}"
+              bindtap="handleConfirmTap"
+            >推送会员确认</button>
+          </view>
+        </view>
+      </view>
+    </view>
+
+    <view class="section">
+      <view class="section-header">
+        <view class="section-title">待会员确认</view>
+        <view class="section-meta">{{awaitingOrders.length}} 单</view>
+      </view>
+      <view wx:if="{{listLoading && !awaitingOrders.length}}" class="loading">加载中...</view>
+      <view wx:elif="{{!awaitingOrders.length}}" class="empty">暂无待会员确认订单</view>
+      <view wx:else>
+        <view class="order-card order-card--readonly" wx:for="{{awaitingOrders}}" wx:key="id">
+          <view class="order-header">
+            <view class="order-member">
+              <view class="order-member-name">{{item.memberName}}</view>
+              <view wx:if="{{item.memberMobile}}" class="order-member-mobile">{{item.memberMobile}}</view>
+            </view>
+            <view class="order-time">{{item.createdAtLabel}}</view>
+          </view>
+          <view class="order-body">
+            <view class="order-amount">{{item.totalAmountLabel}}</view>
+            <view class="order-items" wx:if="{{item.itemSummary}}">{{item.itemSummary}}</view>
+            <view wx:if="{{item.memberNotes}}" class="order-note">会员备注：{{item.memberNotes}}</view>
+            <view wx:if="{{item.adminNotes}}" class="order-note order-note--admin">后厨备注：{{item.adminNotes}}</view>
+            <view wx:if="{{item.memberConfirmedAtLabel}}" class="order-note">会员确认时间：{{item.memberConfirmedAtLabel}}</view>
+          </view>
+        </view>
+      </view>
+    </view>
+  </scroll-view>
+</view>

--- a/miniprogram/pages/admin/meal-prep/index.wxss
+++ b/miniprogram/pages/admin/meal-prep/index.wxss
@@ -1,0 +1,126 @@
+.prep-page {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #040714 0%, #0d1432 100%);
+  color: #f0f3ff;
+}
+
+.prep-scroll {
+  height: calc(100vh - 120rpx);
+  padding: 24rpx;
+  box-sizing: border-box;
+}
+
+.section {
+  margin-bottom: 32rpx;
+  padding: 24rpx;
+  border-radius: 20rpx;
+  background: rgba(9, 14, 34, 0.85);
+  border: 1rpx solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12rpx 30rpx rgba(0, 0, 0, 0.25);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20rpx;
+}
+
+.section-title {
+  font-size: 32rpx;
+  font-weight: 600;
+}
+
+.section-meta {
+  font-size: 24rpx;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.order-card {
+  padding: 20rpx;
+  border-radius: 16rpx;
+  background: rgba(5, 9, 24, 0.95);
+  border: 1rpx solid rgba(255, 255, 255, 0.05);
+  margin-bottom: 20rpx;
+}
+
+.order-card--readonly {
+  opacity: 0.85;
+}
+
+.order-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 12rpx;
+}
+
+.order-member {
+  display: flex;
+  flex-direction: column;
+}
+
+.order-member-name {
+  font-size: 28rpx;
+  font-weight: 600;
+}
+
+.order-member-mobile {
+  font-size: 22rpx;
+  color: rgba(255, 255, 255, 0.6);
+  margin-top: 4rpx;
+}
+
+.order-time {
+  font-size: 22rpx;
+  color: rgba(255, 255, 255, 0.6);
+  margin-top: 4rpx;
+}
+
+.order-amount {
+  font-size: 30rpx;
+  font-weight: 600;
+  color: #ffd166;
+  margin-bottom: 8rpx;
+}
+
+.order-items {
+  font-size: 24rpx;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.order-note {
+  font-size: 22rpx;
+  margin-top: 6rpx;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.order-note--admin {
+  color: #7ad3ff;
+}
+
+.order-footer {
+  margin-top: 16rpx;
+  text-align: right;
+}
+
+.order-action {
+  background: linear-gradient(135deg, #52b6ff 0%, #2f8de4 100%);
+  color: #fff;
+  border-radius: 999rpx;
+  padding: 10rpx 34rpx;
+}
+
+.loading {
+  text-align: center;
+  padding: 40rpx 0;
+  font-size: 26rpx;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.empty {
+  text-align: center;
+  padding: 48rpx 0;
+  font-size: 24rpx;
+  color: rgba(255, 255, 255, 0.5);
+}

--- a/miniprogram/pages/menu/menu.js
+++ b/miniprogram/pages/menu/menu.js
@@ -1,0 +1,321 @@
+import { MemberService } from '../../services/api';
+import { formatCurrency } from '../../utils/format';
+
+const app = getApp();
+
+function createEmptyCart() {
+  return {
+    items: {},
+    totalQuantity: 0,
+    totalAmount: 0,
+    totalAmountLabel: formatCurrency(0)
+  };
+}
+
+function computeCartState(items) {
+  const itemList = Object.values(items || {});
+  const totalQuantity = itemList.reduce((sum, item) => sum + (item.quantity || 0), 0);
+  const totalAmount = itemList.reduce((sum, item) => sum + (item.totalPrice || 0), 0);
+  return {
+    items,
+    totalQuantity,
+    totalAmount,
+    totalAmountLabel: formatCurrency(totalAmount)
+  };
+}
+
+function formatOrderTime(timestamp) {
+  const date = timestamp ? new Date(timestamp) : new Date();
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  const hour = `${date.getHours()}`.padStart(2, '0');
+  const minute = `${date.getMinutes()}`.padStart(2, '0');
+  return `${year}-${month}-${day} ${hour}:${minute}`;
+}
+
+function transformOrder(order) {
+  if (!order) {
+    return null;
+  }
+  const items = Array.isArray(order.items) ? order.items : [];
+  const summary = items.map((item) => `${item.name || ''} ×${item.quantity || 0}`).join('、');
+  const id = order.orderId || order._id || '';
+  return {
+    id,
+    status: order.status || 'pendingAdmin',
+    statusLabel: order.statusLabel || '',
+    totalAmount: order.totalAmount || 0,
+    totalAmountLabel: formatCurrency(order.totalAmount || 0),
+    displayTime: order.displayTime || formatOrderTime(order.createdAtTs || Date.now()),
+    memberNotes: order.memberNotes || '',
+    adminNotes: order.adminNotes || '',
+    items,
+    itemSummary: summary,
+    canConfirm: !!order.canConfirm,
+    menuVersion: order.menuVersion || ''
+  };
+}
+
+Page({
+  data: {
+    navHeight: 88,
+    loading: true,
+    menuLoading: false,
+    ordersLoading: false,
+    categories: [],
+    activeCategoryId: '',
+    visibleItems: [],
+    menuVersion: '',
+    cart: createEmptyCart(),
+    notes: '',
+    submitting: false,
+    confirmProcessing: '',
+    orders: [],
+    refreshing: false
+  },
+
+  onLoad() {
+    this.ensureNavMetrics();
+    this.bootstrap();
+  },
+
+  onShow() {
+    this.loadOrders({ markSeen: true });
+  },
+
+  onPullDownRefresh() {
+    this.refreshAll().finally(() => {
+      wx.stopPullDownRefresh();
+    });
+  },
+
+  ensureNavMetrics() {
+    try {
+      const { customNav = {} } = app.globalData || {};
+      if (customNav.navHeight && customNav.navHeight !== this.data.navHeight) {
+        this.setData({ navHeight: customNav.navHeight });
+      }
+    } catch (error) {
+      console.warn('[menu] resolve nav metrics failed', error);
+    }
+  },
+
+  async bootstrap() {
+    this.setData({ loading: true });
+    await Promise.all([this.loadMenu(), this.loadOrders({ markSeen: true })]);
+    this.setData({ loading: false });
+  },
+
+  async refreshAll() {
+    this.setData({ refreshing: true });
+    try {
+      await Promise.all([this.loadMenu(), this.loadOrders({ markSeen: true })]);
+    } finally {
+      this.setData({ refreshing: false });
+    }
+  },
+
+  async loadMenu() {
+    this.setData({ menuLoading: true });
+    try {
+      const response = await MemberService.listMealMenu();
+      const categories = (response && Array.isArray(response.categories) ? response.categories : []).map((category) => ({
+        id: category.id,
+        name: category.name,
+        description: category.description || '',
+        order: category.order || 0,
+        items: (Array.isArray(category.items) ? category.items : []).map((item) => ({
+          id: item.id,
+          categoryId: category.id,
+          name: item.name,
+          description: item.description || '',
+          price: item.price || 0,
+          priceLabel: formatCurrency(item.price || 0),
+          unit: item.unit || '',
+          spicy: item.spicy || 0,
+          tags: Array.isArray(item.tags) ? item.tags : []
+        }))
+      }));
+      const sorted = categories.sort((a, b) => (a.order || 0) - (b.order || 0));
+      const nextActiveId = this.data.activeCategoryId || (sorted.length ? sorted[0].id : '');
+      const visibleItems = this.resolveVisibleItems(sorted, nextActiveId);
+      this.setData({
+        categories: sorted,
+        activeCategoryId: nextActiveId,
+        visibleItems,
+        menuVersion: response && response.version ? response.version : '',
+        menuLoading: false
+      });
+    } catch (error) {
+      console.error('[menu] load menu failed', error);
+      wx.showToast({ title: '菜单加载失败', icon: 'none' });
+      this.setData({ menuLoading: false });
+    }
+  },
+
+  async loadOrders({ markSeen = false } = {}) {
+    this.setData({ ordersLoading: true });
+    try {
+      const response = await MemberService.listMealOrders({ page: 1, pageSize: 20, markSeen });
+      const orders = (response && Array.isArray(response.orders) ? response.orders : [])
+        .map(transformOrder)
+        .filter(Boolean);
+      this.setData({ orders, ordersLoading: false });
+      if (response && response.badges) {
+        this.updateGlobalMealBadges(response.badges);
+      }
+    } catch (error) {
+      console.error('[menu] load orders failed', error);
+      wx.showToast({ title: '订单加载失败', icon: 'none' });
+      this.setData({ ordersLoading: false });
+    }
+  },
+
+  updateGlobalMealBadges(badges) {
+    try {
+      if (app && app.globalData && app.globalData.memberInfo) {
+        app.globalData.memberInfo.mealOrderBadges = badges;
+      }
+    } catch (error) {
+      console.warn('[menu] update global badges failed', error);
+    }
+  },
+
+  handleCategoryTap(event) {
+    const { id } = event.currentTarget.dataset;
+    if (!id || id === this.data.activeCategoryId) {
+      return;
+    }
+    const visibleItems = this.resolveVisibleItems(this.data.categories, id);
+    this.setData({ activeCategoryId: id, visibleItems });
+  },
+
+  resolveVisibleItems(categories, categoryId) {
+    const target = (categories || []).find((item) => item.id === categoryId);
+    return target && Array.isArray(target.items) ? target.items : [];
+  },
+
+  handleAddItem(event) {
+    const { itemId } = event.currentTarget.dataset;
+    if (!itemId) {
+      return;
+    }
+    const menuItem = this.findMenuItem(itemId);
+    if (!menuItem) {
+      wx.showToast({ title: '菜品不存在', icon: 'none' });
+      return;
+    }
+    const cartItems = { ...this.data.cart.items };
+    const existing = cartItems[itemId] || {
+      itemId,
+      name: menuItem.name,
+      price: menuItem.price,
+      unit: menuItem.unit,
+      quantity: 0,
+      priceLabel: formatCurrency(menuItem.price || 0),
+      totalPrice: 0,
+      totalPriceLabel: formatCurrency(0)
+    };
+    existing.quantity += 1;
+    existing.totalPrice = existing.quantity * (menuItem.price || 0);
+    existing.totalPriceLabel = formatCurrency(existing.totalPrice);
+    cartItems[itemId] = existing;
+    this.setData({ cart: computeCartState(cartItems) });
+  },
+
+  handleDecreaseItem(event) {
+    const { itemId } = event.currentTarget.dataset;
+    if (!itemId) {
+      return;
+    }
+    const cartItems = { ...this.data.cart.items };
+    const existing = cartItems[itemId];
+    if (!existing) {
+      return;
+    }
+    existing.quantity -= 1;
+    if (existing.quantity <= 0) {
+      delete cartItems[itemId];
+    } else {
+      existing.totalPrice = existing.quantity * existing.price;
+      existing.totalPriceLabel = formatCurrency(existing.totalPrice);
+      cartItems[itemId] = existing;
+    }
+    this.setData({ cart: computeCartState(cartItems) });
+  },
+
+  handleNotesInput(event) {
+    const value = event.detail && typeof event.detail.value === 'string' ? event.detail.value : '';
+    this.setData({ notes: value });
+  },
+
+  async handleSubmitOrder() {
+    if (this.data.submitting) {
+      return;
+    }
+    if (!this.data.cart.totalQuantity) {
+      wx.showToast({ title: '请选择菜品', icon: 'none' });
+      return;
+    }
+    const items = Object.values(this.data.cart.items).map((item) => ({
+      itemId: item.itemId,
+      quantity: item.quantity
+    }));
+    this.setData({ submitting: true });
+    try {
+      const response = await MemberService.createMealOrder({ items, notes: this.data.notes });
+      if (response && response.badges) {
+        this.updateGlobalMealBadges(response.badges);
+      }
+      wx.showToast({ title: '下单成功', icon: 'success' });
+      this.setData({ cart: createEmptyCart(), notes: '' });
+      await this.loadOrders({ markSeen: true });
+    } catch (error) {
+      console.error('[menu] submit order failed', error);
+      const message = (error && error.errMsg) || '下单失败';
+      wx.showToast({ title: message.replace('cloud.callFunction:fail ', ''), icon: 'none' });
+    } finally {
+      this.setData({ submitting: false });
+    }
+  },
+
+  async handleConfirmOrder(event) {
+    const { orderId } = event.currentTarget.dataset;
+    if (!orderId || this.data.confirmProcessing === orderId) {
+      return;
+    }
+    this.setData({ confirmProcessing: orderId });
+    try {
+      const response = await MemberService.confirmMealOrder(orderId);
+      if (response && response.badges) {
+        this.updateGlobalMealBadges(response.badges);
+      }
+      wx.showToast({ title: '扣费成功', icon: 'success' });
+      await this.loadOrders({ markSeen: true });
+    } catch (error) {
+      console.error('[menu] confirm order failed', error);
+      const message = (error && error.errMsg) || '确认失败';
+      wx.showToast({ title: message.replace('cloud.callFunction:fail ', ''), icon: 'none' });
+    } finally {
+      this.setData({ confirmProcessing: '' });
+    }
+  },
+
+  handleRefreshOrders() {
+    this.loadOrders({ markSeen: true });
+  },
+
+  findMenuItem(itemId) {
+    for (const category of this.data.categories || []) {
+      const found = (category.items || []).find((item) => item.id === itemId);
+      if (found) {
+        return found;
+      }
+    }
+    return null;
+  }
+});

--- a/miniprogram/pages/menu/menu.json
+++ b/miniprogram/pages/menu/menu.json
@@ -1,0 +1,7 @@
+{
+  "navigationBarTitleText": "仙膳点餐",
+  "enablePullDownRefresh": true,
+  "usingComponents": {
+    "custom-nav": "/components/custom-nav/custom-nav"
+  }
+}

--- a/miniprogram/pages/menu/menu.wxml
+++ b/miniprogram/pages/menu/menu.wxml
@@ -1,0 +1,108 @@
+<custom-nav title="仙膳点餐" theme="dark"></custom-nav>
+<view class="meal-page" style="padding-top: {{navHeight}}px;">
+  <view class="menu-body">
+    <scroll-view class="category-panel" scroll-y>
+      <view
+        wx:for="{{categories}}"
+        wx:key="id"
+        class="category-item {{activeCategoryId === item.id ? 'category-item--active' : ''}}"
+        data-id="{{item.id}}"
+        bindtap="handleCategoryTap"
+      >
+        <view class="category-name">{{item.name}}</view>
+        <view wx:if="{{item.description}}" class="category-desc">{{item.description}}</view>
+      </view>
+    </scroll-view>
+
+    <scroll-view class="menu-panel" scroll-y>
+      <view wx:if="{{menuLoading}}" class="loading">灵力汇聚中...</view>
+      <view wx:elif="{{!visibleItems.length}}" class="empty">该分类暂无菜品</view>
+      <view wx:else class="dish-list">
+        <view class="dish-card" wx:for="{{visibleItems}}" wx:key="id">
+          <view class="dish-info">
+            <view class="dish-name">{{item.name}}</view>
+            <view wx:if="{{item.description}}" class="dish-desc">{{item.description}}</view>
+            <view class="dish-meta">
+              <text class="dish-price">{{item.priceLabel}}</text>
+              <text wx:if="{{item.unit}}" class="dish-unit">/{{item.unit}}</text>
+              <text wx:if="{{item.spicy}}" class="dish-tag dish-tag--spicy">辣度 {{item.spicy}}</text>
+              <text wx:for="{{item.tags}}" wx:key="*this" class="dish-tag">{{item}}</text>
+            </view>
+          </view>
+          <view class="dish-actions">
+            <view class="quantity-control">
+              <button
+                class="quantity-btn quantity-btn--minus"
+                data-item-id="{{item.id}}"
+                disabled="{{!(cart.items[item.id] && cart.items[item.id].quantity)}}"
+                bindtap="handleDecreaseItem"
+              >-</button>
+              <text class="quantity-value">{{cart.items[item.id] ? cart.items[item.id].quantity : 0}}</text>
+              <button class="quantity-btn quantity-btn--plus" data-item-id="{{item.id}}" bindtap="handleAddItem">+</button>
+            </view>
+          </view>
+        </view>
+      </view>
+    </scroll-view>
+  </view>
+
+  <view class="notes-section">
+    <view class="notes-title">口味备注</view>
+    <textarea
+      class="notes-input"
+      placeholder="如有口味偏好或过敏，请告知后厨"
+      maxlength="120"
+      value="{{notes}}"
+      bindinput="handleNotesInput"
+    ></textarea>
+  </view>
+
+  <view class="cart-bar">
+    <view class="cart-summary">
+      <view class="cart-count">已选 {{cart.totalQuantity}} 道菜</view>
+      <view class="cart-total">{{cart.totalAmountLabel}}</view>
+    </view>
+    <button
+      class="cart-submit"
+      type="primary"
+      size="mini"
+      loading="{{submitting}}"
+      disabled="{{submitting || cart.totalQuantity === 0}}"
+      bindtap="handleSubmitOrder"
+    >提交下单</button>
+  </view>
+
+  <view class="orders-section">
+    <view class="section-header">
+      <view class="section-title">近期订单</view>
+      <button class="refresh-btn" size="mini" loading="{{ordersLoading}}" bindtap="handleRefreshOrders">刷新</button>
+    </view>
+    <view wx:if="{{ordersLoading && !orders.length}}" class="loading">订单加载中...</view>
+    <view wx:elif="{{!orders.length}}" class="empty">暂无订单记录</view>
+    <view wx:else>
+      <view class="order-card" wx:for="{{orders}}" wx:key="id">
+        <view class="order-header">
+          <view class="order-status">{{item.statusLabel}}</view>
+          <view class="order-time">{{item.displayTime}}</view>
+        </view>
+        <view class="order-body">
+          <view class="order-amount">{{item.totalAmountLabel}}</view>
+          <view class="order-items">{{item.itemSummary}}</view>
+          <view wx:if="{{item.memberNotes}}" class="order-note">备注：{{item.memberNotes}}</view>
+          <view wx:if="{{item.adminNotes}}" class="order-note order-note--admin">后厨留言：{{item.adminNotes}}</view>
+        </view>
+        <view class="order-actions">
+          <button
+            wx:if="{{item.canConfirm}}"
+            class="order-confirm"
+            type="primary"
+            size="mini"
+            loading="{{confirmProcessing === item.id}}"
+            data-order-id="{{item.id}}"
+            bindtap="handleConfirmOrder"
+          >确认扣费</button>
+        </view>
+      </view>
+    </view>
+  </view>
+</view>

--- a/miniprogram/pages/menu/menu.wxss
+++ b/miniprogram/pages/menu/menu.wxss
@@ -1,0 +1,306 @@
+.meal-page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #080c24 0%, #12163a 100%);
+  color: #f7f9ff;
+}
+
+.menu-body {
+  display: flex;
+  flex: 1;
+  padding: 24rpx 24rpx 0;
+  box-sizing: border-box;
+}
+
+.category-panel {
+  width: 200rpx;
+  margin-right: 24rpx;
+  max-height: 660rpx;
+}
+
+.category-item {
+  padding: 20rpx;
+  margin-bottom: 16rpx;
+  border-radius: 16rpx;
+  background: rgba(255, 255, 255, 0.06);
+  transition: background 0.3s ease;
+}
+
+.category-item--active {
+  background: rgba(86, 120, 255, 0.35);
+  box-shadow: 0 8rpx 20rpx rgba(86, 120, 255, 0.25);
+}
+
+.category-name {
+  font-size: 28rpx;
+  font-weight: 600;
+  margin-bottom: 6rpx;
+}
+
+.category-desc {
+  font-size: 22rpx;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.menu-panel {
+  flex: 1;
+  max-height: 660rpx;
+  padding-right: 12rpx;
+}
+
+.dish-list {
+  display: flex;
+  flex-direction: column;
+  gap: 20rpx;
+}
+
+.dish-card {
+  display: flex;
+  justify-content: space-between;
+  padding: 24rpx;
+  border-radius: 20rpx;
+  background: rgba(12, 18, 48, 0.8);
+  border: 1rpx solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 10rpx 24rpx rgba(0, 0, 0, 0.18);
+}
+
+.dish-info {
+  flex: 1;
+  padding-right: 20rpx;
+}
+
+.dish-name {
+  font-size: 30rpx;
+  font-weight: 600;
+  margin-bottom: 8rpx;
+}
+
+.dish-desc {
+  font-size: 24rpx;
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom: 12rpx;
+}
+
+.dish-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12rpx;
+  align-items: center;
+}
+
+.dish-price {
+  font-size: 32rpx;
+  color: #ffd166;
+  font-weight: 700;
+}
+
+.dish-unit {
+  font-size: 22rpx;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.dish-tag {
+  padding: 4rpx 12rpx;
+  border-radius: 999rpx;
+  background: rgba(255, 255, 255, 0.12);
+  font-size: 22rpx;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dish-tag--spicy {
+  background: rgba(255, 107, 107, 0.18);
+  color: #ff6b6b;
+}
+
+.dish-actions {
+  display: flex;
+  align-items: center;
+}
+
+.quantity-control {
+  display: flex;
+  align-items: center;
+  gap: 12rpx;
+}
+
+.quantity-btn {
+  width: 56rpx;
+  height: 56rpx;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.12);
+  color: #f7f9ff;
+  border: none;
+  font-size: 34rpx;
+  line-height: 56rpx;
+}
+
+.quantity-btn[disabled] {
+  opacity: 0.4;
+}
+
+.quantity-value {
+  min-width: 48rpx;
+  text-align: center;
+  font-size: 28rpx;
+}
+
+.notes-section {
+  margin: 24rpx;
+  padding: 20rpx;
+  background: rgba(12, 18, 48, 0.8);
+  border-radius: 20rpx;
+  border: 1rpx solid rgba(255, 255, 255, 0.08);
+}
+
+.notes-title {
+  font-size: 26rpx;
+  font-weight: 600;
+  margin-bottom: 12rpx;
+}
+
+.notes-input {
+  width: 100%;
+  min-height: 120rpx;
+  padding: 16rpx;
+  border-radius: 16rpx;
+  background: rgba(255, 255, 255, 0.08);
+  color: #f7f9ff;
+  font-size: 24rpx;
+  box-sizing: border-box;
+}
+
+.cart-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0 24rpx;
+  padding: 20rpx 24rpx;
+  background: rgba(12, 18, 48, 0.9);
+  border-radius: 20rpx;
+  border: 1rpx solid rgba(255, 255, 255, 0.08);
+}
+
+.cart-summary {
+  display: flex;
+  flex-direction: column;
+}
+
+.cart-count {
+  font-size: 24rpx;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.cart-total {
+  font-size: 32rpx;
+  font-weight: 700;
+  color: #ffd166;
+}
+
+.cart-submit {
+  background: linear-gradient(135deg, #566eff 0%, #7a8bff 100%);
+  color: #fff;
+  border-radius: 999rpx;
+  padding: 12rpx 36rpx;
+}
+
+.orders-section {
+  margin: 32rpx 24rpx 48rpx;
+  padding: 20rpx;
+  border-radius: 20rpx;
+  background: rgba(12, 18, 48, 0.8);
+  border: 1rpx solid rgba(255, 255, 255, 0.08);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16rpx;
+}
+
+.section-title {
+  font-size: 28rpx;
+  font-weight: 600;
+}
+
+.refresh-btn {
+  background: rgba(255, 255, 255, 0.12);
+  color: #f7f9ff;
+  border-radius: 999rpx;
+}
+
+.order-card {
+  padding: 20rpx;
+  border-radius: 16rpx;
+  background: rgba(5, 10, 30, 0.85);
+  margin-bottom: 20rpx;
+  border: 1rpx solid rgba(255, 255, 255, 0.05);
+}
+
+.order-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 12rpx;
+}
+
+.order-status {
+  font-size: 26rpx;
+  font-weight: 600;
+  color: #ffd166;
+}
+
+.order-time {
+  font-size: 22rpx;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.order-amount {
+  font-size: 28rpx;
+  font-weight: 600;
+  margin-bottom: 8rpx;
+}
+
+.order-items {
+  font-size: 24rpx;
+  color: rgba(255, 255, 255, 0.75);
+  margin-bottom: 6rpx;
+}
+
+.order-note {
+  font-size: 22rpx;
+  color: rgba(255, 255, 255, 0.6);
+  margin-top: 4rpx;
+}
+
+.order-note--admin {
+  color: #7ad3ff;
+}
+
+.order-actions {
+  margin-top: 16rpx;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.order-confirm {
+  background: linear-gradient(135deg, #4cafef 0%, #2f8de4 100%);
+  color: #fff;
+  border-radius: 999rpx;
+  padding: 8rpx 32rpx;
+}
+
+.loading {
+  text-align: center;
+  padding: 40rpx 0;
+  font-size: 26rpx;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.empty {
+  text-align: center;
+  padding: 60rpx 0;
+  font-size: 24rpx;
+  color: rgba(255, 255, 255, 0.5);
+}

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -181,6 +181,30 @@ export const MemberService = {
       action: 'redeemRenameCard',
       count
     });
+  },
+  async listMealMenu() {
+    return callCloud(CLOUD_FUNCTIONS.MEMBER, { action: 'listMealMenu' });
+  },
+  async createMealOrder({ items = [], notes = '' } = {}) {
+    return callCloud(CLOUD_FUNCTIONS.MEMBER, {
+      action: 'createMealOrder',
+      items,
+      notes
+    });
+  },
+  async listMealOrders({ page = 1, pageSize = 20, markSeen = false } = {}) {
+    return callCloud(CLOUD_FUNCTIONS.MEMBER, {
+      action: 'listMealOrders',
+      page,
+      pageSize,
+      markSeen
+    });
+  },
+  async confirmMealOrder(orderId) {
+    return callCloud(CLOUD_FUNCTIONS.MEMBER, {
+      action: 'confirmMealOrder',
+      orderId
+    });
   }
 };
 
@@ -468,6 +492,21 @@ export const AdminService = {
   async markReservationRead() {
     return callCloud(CLOUD_FUNCTIONS.ADMIN, {
       action: 'markReservationRead'
+    });
+  },
+  async listMealOrders({ status = 'pendingAdmin', page = 1, pageSize = 20 } = {}) {
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, {
+      action: 'listMealOrders',
+      status,
+      page,
+      pageSize
+    });
+  },
+  async confirmMealOrder(orderId, adminNotes = '') {
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, {
+      action: 'confirmMealOrder',
+      orderId,
+      adminNotes
     });
   }
 };


### PR DESCRIPTION
## Summary
- add member-facing meal ordering page backed by a curated menu catalog
- surface pending and awaiting meal orders in a new admin prep console
- extend cloud functions so admins can confirm orders and notify members for wallet deduction

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de8d182a988330970c83a526600f83