### PR TITLE
feat: show stone reward on membership order total

### DIFF
--- a/miniprogram/pages/membership/order/index.js
+++ b/miniprogram/pages/membership/order/index.js
@@ -142,12 +142,18 @@ function decorateOrder(order) {
       })
     : [];
   const totalAmount = Number(order.totalAmount || 0);
+  const stoneRewardRaw = Number(
+    Object.prototype.hasOwnProperty.call(order, 'stoneReward') ? order.stoneReward : order.totalAmount
+  );
+  const stoneReward = Math.max(0, Math.floor(stoneRewardRaw));
   return {
     ...order,
     _id: id,
     items,
     totalAmount,
     totalAmountLabel: formatCurrency(totalAmount),
+    stoneReward,
+    stoneRewardLabel: formatStones(stoneReward),
     statusLabel: STATUS_LABELS[order.status] || '处理中',
     createdAtLabel: formatDateTime(order.createdAt),
     adminConfirmedAtLabel: formatDateTime(order.adminConfirmedAt),

--- a/miniprogram/pages/membership/order/index.js
+++ b/miniprogram/pages/membership/order/index.js
@@ -1,5 +1,5 @@
 import { MenuOrderService } from '../../../services/api';
-import { formatCurrency } from '../../../utils/format';
+import { formatCurrency, formatStones } from '../../../utils/format';
 import { categories as rawCategories, items as rawItems, softDrinks } from '../../../shared/menu-data';
 
 function normalizeVariant(variant) {
@@ -194,6 +194,8 @@ Page({
     cart: [],
     cartTotal: 0,
     cartTotalLabel: formatCurrency(0),
+    cartStoneReward: 0,
+    cartStoneRewardLabel: formatStones(0),
     remark: '',
     submitting: false,
     loadingOrders: false,
@@ -254,10 +256,13 @@ Page({
     }
     const decorated = decorateCart(cart);
     const total = computeCartTotal(decorated);
+    const stoneReward = Math.max(0, Math.floor(total));
     this.setData({
       cart: decorated,
       cartTotal: total,
-      cartTotalLabel: formatCurrency(total)
+      cartTotalLabel: formatCurrency(total),
+      cartStoneReward: stoneReward,
+      cartStoneRewardLabel: formatStones(stoneReward)
     });
   },
 
@@ -280,10 +285,13 @@ Page({
     }
     const decorated = decorateCart(cart);
     const total = computeCartTotal(decorated);
+    const stoneReward = Math.max(0, Math.floor(total));
     this.setData({
       cart: decorated,
       cartTotal: total,
-      cartTotalLabel: formatCurrency(total)
+      cartTotalLabel: formatCurrency(total),
+      cartStoneReward: stoneReward,
+      cartStoneRewardLabel: formatStones(stoneReward)
     });
   },
 
@@ -291,7 +299,9 @@ Page({
     this.setData({
       cart: [],
       cartTotal: 0,
-      cartTotalLabel: formatCurrency(0)
+      cartTotalLabel: formatCurrency(0),
+      cartStoneReward: 0,
+      cartStoneRewardLabel: formatStones(0)
     });
   },
 
@@ -323,6 +333,8 @@ Page({
         cart: [],
         cartTotal: 0,
         cartTotalLabel: formatCurrency(0),
+        cartStoneReward: 0,
+        cartStoneRewardLabel: formatStones(0),
         remark: ''
       });
       await this.loadOrders();

--- a/miniprogram/pages/membership/order/index.wxml
+++ b/miniprogram/pages/membership/order/index.wxml
@@ -117,7 +117,10 @@
         </view>
       </view>
       <view class="order-remark" wx:if="{{order.remark}}">备注：{{order.remark}}</view>
-      <view class="order-total">合计 {{order.totalAmountLabel}}</view>
+      <view class="order-summary">
+        <view class="order-total">合计 {{order.totalAmountLabel}}</view>
+        <view class="order-stones">送 {{order.stoneRewardLabel}} 灵石</view>
+      </view>
       <button
         wx:if="{{order.status === 'pendingMember'}}"
         class="confirm-btn"

--- a/miniprogram/pages/membership/order/index.wxml
+++ b/miniprogram/pages/membership/order/index.wxml
@@ -87,7 +87,10 @@
       bindinput="handleRemarkInput"
     ></textarea>
     <view class="cart-summary">
-      <view class="summary-amount">合计 {{cartTotalLabel}}</view>
+      <view class="summary-info">
+        <view class="summary-amount">合计 {{cartTotalLabel}}</view>
+        <view class="summary-stones">送 {{cartStoneRewardLabel}} 灵石</view>
+      </view>
       <button class="submit-btn" type="primary" loading="{{submitting}}" bindtap="handleSubmitOrder">提交订单</button>
     </view>
   </view>

--- a/miniprogram/pages/membership/order/index.wxss
+++ b/miniprogram/pages/membership/order/index.wxss
@@ -225,9 +225,20 @@
   align-items: center;
 }
 
+.summary-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6rpx;
+}
+
 .summary-amount {
   font-size: 30rpx;
   font-weight: 600;
+}
+
+.summary-stones {
+  font-size: 24rpx;
+  color: rgba(255, 255, 255, 0.7);
 }
 
 .submit-btn {

--- a/miniprogram/pages/membership/order/index.wxss
+++ b/miniprogram/pages/membership/order/index.wxss
@@ -342,10 +342,21 @@
   color: rgba(255, 255, 255, 0.75);
 }
 
+.order-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 4rpx;
+  margin-bottom: 8px;
+}
+
 .order-total {
   font-size: 28rpx;
   font-weight: 600;
-  margin-bottom: 8px;
+}
+
+.order-stones {
+  font-size: 24rpx;
+  color: rgba(255, 255, 255, 0.7);
 }
 
 .confirm-btn {

--- a/miniprogram/utils/format.js
+++ b/miniprogram/utils/format.js
@@ -66,7 +66,7 @@ export const formatStones = (value = 0) => {
     return '0';
   }
   const normalized = Math.max(0, Math.floor(numeric));
-  return normalized.toLocaleString('zh-CN');
+  return normalized.toString();
 };
 
 export const formatStoneChange = (value = 0) => {


### PR DESCRIPTION
## Summary
- display the corresponding stone reward beneath the cart total on the membership ordering page
- keep the stone reward value in sync with cart updates and resets using shared formatting helpers

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df3613e02c8330b7c822dc79f49491