### PR TITLE
feat: add expandable home nav bar

### DIFF
--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -89,7 +89,14 @@
     </view>
 
     <view class="bottom-nav">
-      <view class="nav-item" wx:for="{{navItems}}" wx:key="label" data-url="{{item.url}}" bindtap="handleNavTap">
+      <view
+        class="nav-item"
+        wx:for="{{visibleNavItems}}"
+        wx:key="label"
+        data-url="{{item.url}}"
+        data-action="{{item.action}}"
+        bindtap="handleNavTap"
+      >
         <view class="nav-icon-wrapper">
           <text class="nav-icon">{{item.icon}}</text>
           <view wx:if="{{item.showDot}}" class="nav-item__dot"></view>


### PR DESCRIPTION
## Summary
- collapse the home bottom navigation to the primary wallet, order, and reservation entries
- add a "更多" toggle that expands the full navigation list and persists the choice locally

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df3b2c6c448330a8fea8efe964c79a