### PR TITLE
Add expandable bottom navigation on home page

### DIFF
--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -88,8 +88,15 @@
       </view>
     </view>
 
-    <view class="bottom-nav">
-      <view class="nav-item" wx:for="{{navItems}}" wx:key="label" data-url="{{item.url}}" bindtap="handleNavTap">
+    <view class="bottom-nav {{navExpanded ? 'bottom-nav--expanded' : ''}}">
+      <view
+        class="nav-item {{item.action ? 'nav-item--action' : ''}}"
+        wx:for="{{navItems}}"
+        wx:key="label"
+        data-url="{{item.url}}"
+        data-action="{{item.action}}"
+        bindtap="handleNavTap"
+      >
         <view class="nav-icon-wrapper">
           <text class="nav-icon">{{item.icon}}</text>
           <view wx:if="{{item.showDot}}" class="nav-item__dot"></view>

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -336,7 +336,10 @@ page {
   border: 1rpx solid rgba(119, 138, 230, 0.35);
   display: flex;
   justify-content: space-between;
+  align-items: stretch;
   box-shadow: 0 18rpx 36rpx rgba(16, 13, 55, 0.45);
+  transition: transform 0.28s ease, box-shadow 0.28s ease, padding 0.28s ease;
+  overflow: hidden;
 }
 
 .nav-item {
@@ -345,6 +348,90 @@ page {
   align-items: center;
   gap: 8rpx;
   color: rgba(227, 233, 255, 0.95);
+}
+
+.nav-item--action .nav-icon-wrapper {
+  width: 96rpx;
+  height: 96rpx;
+  border-radius: 50%;
+  border: 2rpx dashed rgba(166, 184, 255, 0.6);
+  background: rgba(45, 68, 158, 0.4);
+  box-shadow: inset 0 0 12rpx rgba(120, 154, 255, 0.45);
+}
+
+.nav-item--action .nav-icon {
+  font-size: 36rpx;
+}
+
+.nav-item--action .nav-label {
+  font-weight: 600;
+  letter-spacing: 4rpx;
+}
+
+.bottom-nav--expanded {
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  padding: 24rpx 28rpx;
+  box-shadow: 0 24rpx 48rpx rgba(16, 13, 55, 0.55);
+  transform: translateY(-8rpx);
+}
+
+.bottom-nav--expanded .nav-item {
+  flex: 0 0 25%;
+  margin-bottom: 20rpx;
+  opacity: 0;
+  animation: navItemPop 0.32s ease forwards;
+}
+
+.bottom-nav--expanded .nav-item .nav-icon {
+  font-size: 44rpx;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(1) {
+  animation-delay: 0ms;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(2) {
+  animation-delay: 40ms;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(3) {
+  animation-delay: 80ms;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(4) {
+  animation-delay: 120ms;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(5) {
+  animation-delay: 160ms;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(6) {
+  animation-delay: 200ms;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(7) {
+  animation-delay: 240ms;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(8) {
+  animation-delay: 280ms;
+}
+
+@keyframes navItemPop {
+  0% {
+    transform: translateY(28rpx) scale(0.96);
+    opacity: 0;
+  }
+  60% {
+    transform: translateY(-6rpx) scale(1.04);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
 }
 
 .nav-icon-wrapper {


### PR DESCRIPTION
## Summary
- add helpers to collapse or expand the home bottom navigation and persist the expanded state
- update the index page logic to show a "更多" entry, expand on tap, and remember the choice
- style the expanded toolbar with a pop animation and multi-row layout

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68df3ebc9ea48330bdd1851c58f278a7