### PR TITLE
feat: add expandable home toolbar

### DIFF
--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -88,9 +88,16 @@
       </view>
     </view>
 
-    <view class="bottom-nav">
-      <view class="nav-item" wx:for="{{navItems}}" wx:key="label" data-url="{{item.url}}" bindtap="handleNavTap">
-        <view class="nav-icon-wrapper">
+    <view class="bottom-nav {{navExpanded ? 'bottom-nav--expanded' : 'bottom-nav--collapsed'}}">
+      <view
+        class="nav-item {{item.more ? 'nav-item--more' : ''}}"
+        wx:for="{{navItems}}"
+        wx:key="label"
+        data-url="{{item.url}}"
+        data-more="{{item.more}}"
+        bindtap="handleNavTap"
+      >
+        <view class="nav-icon-wrapper {{item.more ? 'nav-icon-wrapper--more' : ''}}">
           <text class="nav-icon">{{item.icon}}</text>
           <view wx:if="{{item.showDot}}" class="nav-item__dot"></view>
         </view>

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -327,6 +327,7 @@ page {
   }
 }
 
+
 .bottom-nav {
   margin-top: auto;
   margin-bottom: 32rpx;
@@ -336,7 +337,28 @@ page {
   border: 1rpx solid rgba(119, 138, 230, 0.35);
   display: flex;
   justify-content: space-between;
+  align-items: stretch;
   box-shadow: 0 18rpx 36rpx rgba(16, 13, 55, 0.45);
+  overflow: hidden;
+  transition: max-height 280ms ease, padding 280ms ease;
+  max-height: 360rpx;
+}
+
+.bottom-nav--collapsed {
+  max-height: 150rpx;
+  flex-wrap: nowrap;
+}
+
+.bottom-nav--expanded {
+  padding: 24rpx 32rpx 32rpx;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  gap: 20rpx 12rpx;
+}
+
+.bottom-nav--expanded .nav-item {
+  flex: 0 0 25%;
+  max-width: 25%;
 }
 
 .nav-item {
@@ -345,6 +367,11 @@ page {
   align-items: center;
   gap: 8rpx;
   color: rgba(227, 233, 255, 0.95);
+  flex: 1;
+}
+
+.nav-item--more {
+  color: rgba(227, 233, 255, 0.85);
 }
 
 .nav-icon-wrapper {
@@ -352,6 +379,13 @@ page {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.nav-icon-wrapper--more {
+  padding: 8rpx 28rpx;
+  border-radius: 999rpx;
+  border: 2rpx dashed rgba(167, 187, 255, 0.65);
+  background: rgba(82, 101, 196, 0.24);
 }
 
 .nav-icon {


### PR DESCRIPTION
## Summary
- collapse the home toolbar to wallet, ordering, and reservations by default with a persisted "more" expansion state
- add nav expansion storage helpers and update event handling to reveal all entries after expanding
- refresh the bottom navigation markup and styles to support the animated expansion layout

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68df3ebc9ea48330bdd1851c58f278a7