### PR TITLE
feat: add expandable bottom nav on home page

### DIFF
--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -89,19 +89,48 @@
     </view>
 
     <view class="bottom-nav {{navExpanded ? 'bottom-nav--expanded' : 'bottom-nav--collapsed'}}">
-      <view
-        class="nav-item"
-        wx:for="{{navDisplayItems}}"
-        wx:key="label"
-        data-url="{{item.url}}"
-        data-action="{{item.action}}"
-        bindtap="handleNavTap"
-      >
-        <view class="nav-icon-wrapper">
-          <text class="nav-icon">{{item.icon}}</text>
-          <view wx:if="{{item.showDot}}" class="nav-item__dot"></view>
+      <view class="bottom-nav__primary">
+        <view
+          class="nav-item"
+          wx:for="{{navPrimaryItems}}"
+          wx:key="label"
+          data-url="{{item.url}}"
+          bindtap="handleNavTap"
+        >
+          <view class="nav-icon-wrapper">
+            <text class="nav-icon">{{item.icon}}</text>
+            <view wx:if="{{item.showDot}}" class="nav-item__dot"></view>
+          </view>
+          <view class="nav-label">{{item.label}}</view>
         </view>
-        <view class="nav-label">{{item.label}}</view>
+        <view wx:if="{{navHasMore}}" class="bottom-nav__more">
+          <view
+            wx:if="{{!navExpanded}}"
+            class="nav-item nav-item--more"
+            bindtap="handleNavMoreTap"
+          >
+            <view class="nav-icon-wrapper">
+              <text class="nav-icon">⋯</text>
+            </view>
+            <view class="nav-label">更多</view>
+          </view>
+          <view wx:else class="nav-item nav-item--placeholder"></view>
+          <view class="bottom-nav__drawer {{navExpanded ? 'bottom-nav__drawer--open' : ''}}">
+            <view
+              class="nav-item"
+              wx:for="{{navSecondaryItems}}"
+              wx:key="label"
+              data-url="{{item.url}}"
+              bindtap="handleNavTap"
+            >
+              <view class="nav-icon-wrapper">
+                <text class="nav-icon">{{item.icon}}</text>
+                <view wx:if="{{item.showDot}}" class="nav-item__dot"></view>
+              </view>
+              <view class="nav-label">{{item.label}}</view>
+            </view>
+          </view>
+        </view>
       </view>
     </view>
   </view>

--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -88,8 +88,15 @@
       </view>
     </view>
 
-    <view class="bottom-nav">
-      <view class="nav-item" wx:for="{{navItems}}" wx:key="label" data-url="{{item.url}}" bindtap="handleNavTap">
+    <view class="bottom-nav {{navExpanded ? 'bottom-nav--expanded' : 'bottom-nav--collapsed'}}">
+      <view
+        class="nav-item"
+        wx:for="{{navDisplayItems}}"
+        wx:key="label"
+        data-url="{{item.url}}"
+        data-action="{{item.action}}"
+        bindtap="handleNavTap"
+      >
         <view class="nav-icon-wrapper">
           <text class="nav-icon">{{item.icon}}</text>
           <view wx:if="{{item.showDot}}" class="nav-item__dot"></view>

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -336,13 +336,88 @@ page {
   border: 1rpx solid rgba(119, 138, 230, 0.35);
   display: flex;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 18rpx 24rpx;
   box-shadow: 0 18rpx 36rpx rgba(16, 13, 55, 0.45);
+  overflow: hidden;
+  transition: max-height 0.35s ease, padding 0.35s ease, background 0.35s ease;
+}
+
+.bottom-nav--collapsed {
+  max-height: 168rpx;
+}
+
+.bottom-nav--expanded {
+  max-height: 520rpx;
+  padding-bottom: 32rpx;
+  animation: bottom-nav-expand 0.35s ease;
+}
+
+.bottom-nav--expanded .nav-item {
+  animation: bottom-nav-item 0.3s ease both;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(1) {
+  animation-delay: 0s;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(2) {
+  animation-delay: 0.04s;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(3) {
+  animation-delay: 0.08s;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(4) {
+  animation-delay: 0.12s;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(5) {
+  animation-delay: 0.16s;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(6) {
+  animation-delay: 0.2s;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(7) {
+  animation-delay: 0.24s;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(8) {
+  animation-delay: 0.28s;
+}
+
+@keyframes bottom-nav-expand {
+  0% {
+    transform: translateY(36rpx);
+    opacity: 0.45;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes bottom-nav-item {
+  0% {
+    transform: translateY(24rpx) scale(0.92);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
 }
 
 .nav-item {
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
+  flex: 1 1 25%;
+  min-width: 22%;
   gap: 8rpx;
   color: rgba(227, 233, 255, 0.95);
 }

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -327,6 +327,7 @@ page {
   }
 }
 
+
 .bottom-nav {
   margin-top: auto;
   margin-bottom: 32rpx;
@@ -335,78 +336,100 @@ page {
   background: rgba(21, 32, 84, 0.85);
   border: 1rpx solid rgba(119, 138, 230, 0.35);
   display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 18rpx 24rpx;
+  align-items: center;
+  gap: 18rpx;
+  position: relative;
   box-shadow: 0 18rpx 36rpx rgba(16, 13, 55, 0.45);
-  overflow: hidden;
-  transition: max-height 0.35s ease, padding 0.35s ease, background 0.35s ease;
-}
-
-.bottom-nav--collapsed {
-  max-height: 168rpx;
+  overflow: visible;
+  transition: background 0.35s ease;
 }
 
 .bottom-nav--expanded {
-  max-height: 520rpx;
-  padding-bottom: 32rpx;
-  animation: bottom-nav-expand 0.35s ease;
+  background: rgba(21, 32, 84, 0.94);
 }
 
-.bottom-nav--expanded .nav-item {
-  animation: bottom-nav-item 0.3s ease both;
+.bottom-nav__primary {
+  display: flex;
+  align-items: center;
+  gap: 18rpx;
 }
 
-.bottom-nav--expanded .nav-item:nth-child(1) {
+.bottom-nav__more {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.bottom-nav__drawer {
+  position: absolute;
+  top: 50%;
+  left: calc(100% + 12rpx);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16rpx;
+  padding: 18rpx 22rpx;
+  border-radius: 32rpx;
+  background: rgba(15, 24, 66, 0.95);
+  border: 1rpx solid rgba(119, 138, 230, 0.35);
+  box-shadow: 0 18rpx 36rpx rgba(10, 12, 40, 0.55);
+  transform: translateY(-50%) translateX(36rpx) scale(0.96);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  min-width: 280rpx;
+  max-width: 520rpx;
+  z-index: 1;
+}
+
+.bottom-nav__drawer--open {
+  transform: translateY(-50%) translateX(0) scale(1);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.bottom-nav__drawer--open .nav-item {
+  animation: nav-drawer-item 0.28s ease both;
+}
+
+.bottom-nav__drawer--open .nav-item:nth-child(1) {
   animation-delay: 0s;
 }
 
-.bottom-nav--expanded .nav-item:nth-child(2) {
+.bottom-nav__drawer--open .nav-item:nth-child(2) {
   animation-delay: 0.04s;
 }
 
-.bottom-nav--expanded .nav-item:nth-child(3) {
+.bottom-nav__drawer--open .nav-item:nth-child(3) {
   animation-delay: 0.08s;
 }
 
-.bottom-nav--expanded .nav-item:nth-child(4) {
+.bottom-nav__drawer--open .nav-item:nth-child(4) {
   animation-delay: 0.12s;
 }
 
-.bottom-nav--expanded .nav-item:nth-child(5) {
+.bottom-nav__drawer--open .nav-item:nth-child(5) {
   animation-delay: 0.16s;
 }
 
-.bottom-nav--expanded .nav-item:nth-child(6) {
+.bottom-nav__drawer--open .nav-item:nth-child(6) {
   animation-delay: 0.2s;
 }
 
-.bottom-nav--expanded .nav-item:nth-child(7) {
+.bottom-nav__drawer--open .nav-item:nth-child(7) {
   animation-delay: 0.24s;
 }
 
-.bottom-nav--expanded .nav-item:nth-child(8) {
+.bottom-nav__drawer--open .nav-item:nth-child(8) {
   animation-delay: 0.28s;
 }
 
-@keyframes bottom-nav-expand {
+@keyframes nav-drawer-item {
   0% {
-    transform: translateY(36rpx);
-    opacity: 0.45;
-  }
-  100% {
-    transform: translateY(0);
-    opacity: 1;
-  }
-}
-
-@keyframes bottom-nav-item {
-  0% {
-    transform: translateY(24rpx) scale(0.92);
+    transform: translateX(42rpx) scale(0.9);
     opacity: 0;
   }
   100% {
-    transform: translateY(0) scale(1);
+    transform: translateX(0) scale(1);
     opacity: 1;
   }
 }
@@ -416,10 +439,37 @@ page {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  flex: 1 1 25%;
-  min-width: 22%;
+  width: 124rpx;
+  flex: 0 0 124rpx;
   gap: 8rpx;
   color: rgba(227, 233, 255, 0.95);
+  padding: 14rpx 0;
+  border-radius: 26rpx;
+  background: rgba(34, 48, 105, 0.6);
+  box-shadow: inset 0 0 0 1rpx rgba(138, 157, 255, 0.2);
+  transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.nav-item:active {
+  transform: translateY(2rpx) scale(0.96);
+  background: rgba(53, 73, 144, 0.7);
+  box-shadow: inset 0 0 0 1rpx rgba(181, 195, 255, 0.3);
+}
+
+.nav-item--more {
+  background: rgba(34, 48, 105, 0.45);
+  box-shadow: inset 0 0 0 1rpx rgba(138, 157, 255, 0.25);
+}
+
+.nav-item--placeholder {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.bottom-nav__drawer .nav-item {
+  width: 116rpx;
+  flex: 0 0 116rpx;
+  background: rgba(32, 46, 102, 0.55);
 }
 
 .nav-icon-wrapper {


### PR DESCRIPTION
## Summary
- collapse the home bottom toolbar to wallet, order, reservation, and a "more" entry by default
- remember the expanded state in local storage so the full set of shortcuts stays visible after opening
- refresh the bottom bar styling and animations to support the expanding layout

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df3ebc9ea48330bdd1851c58f278a7