### PR TITLE
feat: support expanding home quick actions toolbar

### DIFF
--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -88,13 +88,23 @@
       </view>
     </view>
 
-    <view class="bottom-nav">
-      <view class="nav-item" wx:for="{{navItems}}" wx:key="label" data-url="{{item.url}}" bindtap="handleNavTap">
-        <view class="nav-icon-wrapper">
-          <text class="nav-icon">{{item.icon}}</text>
-          <view wx:if="{{item.showDot}}" class="nav-item__dot"></view>
+    <view class="bottom-nav {{navExpanded ? 'bottom-nav--expanded' : 'bottom-nav--collapsed'}}">
+      <view class="bottom-nav__items">
+        <view class="nav-item" wx:for="{{navVisibleItems}}" wx:key="label" data-url="{{item.url}}" bindtap="handleNavTap">
+          <view class="nav-icon-wrapper">
+            <text class="nav-icon">{{item.icon}}</text>
+            <view wx:if="{{item.showDot}}" class="nav-item__dot"></view>
+          </view>
+          <view class="nav-label">{{item.label}}</view>
         </view>
-        <view class="nav-label">{{item.label}}</view>
+      </view>
+      <view
+        wx:if="{{showNavMore}}"
+        class="bottom-nav__more"
+        bindtap="handleNavExpandTap"
+      >
+        <text class="bottom-nav__more-label">更多</text>
+        <text class="bottom-nav__more-icon">›</text>
       </view>
     </view>
   </view>

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -335,16 +335,114 @@ page {
   background: rgba(21, 32, 84, 0.85);
   border: 1rpx solid rgba(119, 138, 230, 0.35);
   display: flex;
-  justify-content: space-between;
+  align-items: center;
+  gap: 24rpx;
   box-shadow: 0 18rpx 36rpx rgba(16, 13, 55, 0.45);
+}
+
+.bottom-nav__items {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 24rpx;
+  transition: all 0.35s ease;
+  flex-wrap: nowrap;
+  overflow: hidden;
+}
+
+.bottom-nav--collapsed .bottom-nav__items {
+  gap: 18rpx;
+}
+
+.bottom-nav--expanded .bottom-nav__items {
+  gap: 28rpx;
+  flex-wrap: wrap;
+}
+
+.bottom-nav__more {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 120rpx;
+  height: 108rpx;
+  border-radius: 24rpx;
+  background: rgba(32, 45, 104, 0.88);
+  border: 1rpx solid rgba(132, 152, 255, 0.45);
+  color: rgba(227, 233, 255, 0.95);
+  font-size: 26rpx;
+  letter-spacing: 4rpx;
+  gap: 6rpx;
+  box-shadow: 0 12rpx 24rpx rgba(10, 16, 48, 0.45);
+}
+
+.bottom-nav__more:active {
+  transform: scale(0.96);
+  transition: transform 0.15s ease;
+}
+
+.bottom-nav__more-icon {
+  font-size: 36rpx;
+  line-height: 1;
 }
 
 .nav-item {
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: 8rpx;
   color: rgba(227, 233, 255, 0.95);
+  min-width: 112rpx;
+  padding: 6rpx 0;
+}
+
+.bottom-nav--expanded .nav-item {
+  animation: nav-expand-slide 0.38s ease forwards;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(1) {
+  animation-delay: 0s;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(2) {
+  animation-delay: 0.03s;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(3) {
+  animation-delay: 0.06s;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(4) {
+  animation-delay: 0.09s;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(5) {
+  animation-delay: 0.12s;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(6) {
+  animation-delay: 0.15s;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(7) {
+  animation-delay: 0.18s;
+}
+
+.bottom-nav--expanded .nav-item:nth-child(8) {
+  animation-delay: 0.21s;
+}
+
+@keyframes nav-expand-slide {
+  0% {
+    opacity: 0;
+    transform: translateX(48rpx);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 
 .nav-icon-wrapper {

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -327,16 +327,17 @@ page {
   }
 }
 
+
 .bottom-nav {
   margin-top: auto;
   margin-bottom: 32rpx;
-  padding: 18rpx 24rpx;
+  padding: 12rpx 18rpx;
   border-radius: 36rpx;
-  background: rgba(21, 32, 84, 0.85);
+  background: rgba(21, 32, 84, 0.88);
   border: 1rpx solid rgba(119, 138, 230, 0.35);
   display: flex;
   align-items: center;
-  gap: 24rpx;
+  gap: 14rpx;
   box-shadow: 0 18rpx 36rpx rgba(16, 13, 55, 0.45);
 }
 
@@ -345,35 +346,29 @@ page {
   flex: 1;
   align-items: center;
   justify-content: flex-start;
-  gap: 24rpx;
+  gap: 10rpx;
   transition: all 0.35s ease;
   flex-wrap: nowrap;
   overflow: hidden;
 }
 
-.bottom-nav--collapsed .bottom-nav__items {
-  gap: 18rpx;
-}
-
 .bottom-nav--expanded .bottom-nav__items {
-  gap: 28rpx;
-  flex-wrap: wrap;
+  gap: 10rpx;
 }
 
 .bottom-nav__more {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 120rpx;
-  height: 108rpx;
-  border-radius: 24rpx;
-  background: rgba(32, 45, 104, 0.88);
-  border: 1rpx solid rgba(132, 152, 255, 0.45);
+  min-width: 72rpx;
+  height: 72rpx;
+  border-radius: 36rpx;
+  background: rgba(32, 45, 104, 0.92);
   color: rgba(227, 233, 255, 0.95);
-  font-size: 26rpx;
-  letter-spacing: 4rpx;
-  gap: 6rpx;
-  box-shadow: 0 12rpx 24rpx rgba(10, 16, 48, 0.45);
+  font-size: 22rpx;
+  letter-spacing: 0rpx;
+  gap: 2rpx;
+  box-shadow: 0 6rpx 16rpx rgba(10, 16, 48, 0.35);
 }
 
 .bottom-nav__more:active {
@@ -382,7 +377,7 @@ page {
 }
 
 .bottom-nav__more-icon {
-  font-size: 36rpx;
+  font-size: 30rpx;
   line-height: 1;
 }
 
@@ -391,10 +386,10 @@ page {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8rpx;
+  gap: 6rpx;
   color: rgba(227, 233, 255, 0.95);
-  min-width: 112rpx;
-  padding: 6rpx 0;
+  min-width: 80rpx;
+  padding: 4rpx 0;
 }
 
 .bottom-nav--expanded .nav-item {


### PR DESCRIPTION
## Summary
- show only wallet, ordering, and reservation by default with a “more” affordance on the home toolbar
- persist the expanded toolbar preference in local storage and update the displayed actions when member data refreshes
- restyle the toolbar layout with an expansion animation for the additional quick actions

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68df484b9cb48330a073117d4cebc05b