### PR TITLE
feat: expand home bottom nav with persistent state

### DIFF
--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -88,13 +88,25 @@
       </view>
     </view>
 
-    <view class="bottom-nav">
-      <view class="nav-item" wx:for="{{navItems}}" wx:key="label" data-url="{{item.url}}" bindtap="handleNavTap">
-        <view class="nav-icon-wrapper">
-          <text class="nav-icon">{{item.icon}}</text>
-          <view wx:if="{{item.showDot}}" class="nav-item__dot"></view>
+    <view class="bottom-nav {{navExpanded ? 'bottom-nav--expanded' : 'bottom-nav--collapsed'}}">
+      <view class="bottom-nav__items">
+        <view
+          class="nav-item"
+          wx:for="{{navExpanded ? navItems : collapsedNavItems}}"
+          wx:key="label"
+          data-url="{{item.url}}"
+          bindtap="handleNavTap"
+        >
+          <view class="nav-icon-wrapper">
+            <text class="nav-icon">{{item.icon}}</text>
+            <view wx:if="{{item.showDot}}" class="nav-item__dot"></view>
+          </view>
+          <view class="nav-label">{{item.label}}</view>
         </view>
-        <view class="nav-label">{{item.label}}</view>
+      </view>
+      <view wx:if="{{!navExpanded}}" class="bottom-nav__more" bindtap="handleExpandNav">
+        <text class="bottom-nav__more-icon">⋯</text>
+        <text class="bottom-nav__more-label">更多</text>
       </view>
     </view>
   </view>

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -330,37 +330,43 @@ page {
 .bottom-nav {
   margin-top: auto;
   margin-bottom: 32rpx;
-  padding: 18rpx 20rpx;
+  padding: 18rpx 24rpx;
   border-radius: 36rpx;
   background: rgba(21, 32, 84, 0.85);
   border: 1rpx solid rgba(119, 138, 230, 0.35);
   display: flex;
   align-items: center;
-  gap: 20rpx;
+  gap: 16rpx;
   box-shadow: 0 18rpx 36rpx rgba(16, 13, 55, 0.45);
   overflow: hidden;
+  width: 100%;
+  max-width: 100%;
+  transition: max-width 280ms ease, padding-right 280ms ease, padding-left 280ms ease;
+  transform-origin: left center;
+}
+
+.bottom-nav--collapsed {
+  max-width: 520rpx;
+  padding-right: 20rpx;
 }
 
 .bottom-nav__items {
+  flex: 1;
   display: flex;
   align-items: center;
-  gap: 24rpx;
   flex-wrap: nowrap;
-  transition: width 260ms ease, max-width 260ms ease, padding 260ms ease, gap 260ms ease;
+  overflow: hidden;
+  transition: gap 260ms ease, justify-content 260ms ease;
 }
 
 .bottom-nav--collapsed .bottom-nav__items {
-  width: calc(3 * 112rpx);
-  max-width: calc(3 * 112rpx);
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 12rpx;
 }
 
 .bottom-nav--expanded .bottom-nav__items {
-  width: 100%;
-  max-width: 100%;
   justify-content: space-between;
-  gap: 20rpx;
+  gap: 0;
 }
 
 .bottom-nav__more {
@@ -368,18 +374,16 @@ page {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 2rpx 8rpx;
-  border-radius: 24rpx;
-  color: rgba(227, 233, 255, 0.95);
-  background: rgba(255, 255, 255, 0.06);
-  line-height: 1.2;
+  padding: 0 4rpx;
+  color: rgba(227, 233, 255, 0.9);
+  line-height: 1.1;
   font-size: 20rpx;
-  transition: transform 200ms ease, background 200ms ease, opacity 200ms ease;
+  transition: transform 200ms ease, opacity 200ms ease;
 }
 
 .bottom-nav__more:active {
-  transform: scale(0.92);
-  background: rgba(255, 255, 255, 0.14);
+  transform: scale(0.9);
+  opacity: 0.7;
 }
 
 .bottom-nav__more-icon {
@@ -388,16 +392,16 @@ page {
 }
 
 .bottom-nav__more-label {
-  margin-top: 2rpx;
+  margin-top: 0;
 }
 
 .nav-item {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8rpx;
+  gap: 6rpx;
   color: rgba(227, 233, 255, 0.95);
-  min-width: 88rpx;
+  min-width: 76rpx;
 }
 
 .bottom-nav--expanded .nav-item {

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -339,14 +339,12 @@ page {
   gap: 16rpx;
   box-shadow: 0 18rpx 36rpx rgba(16, 13, 55, 0.45);
   overflow: hidden;
-  width: 100%;
-  max-width: 100%;
   transition: max-width 280ms ease, padding-right 280ms ease, padding-left 280ms ease;
   transform-origin: left center;
 }
 
 .bottom-nav--collapsed {
-  max-width: 520rpx;
+  max-width: 320rpx;
   padding-right: 20rpx;
 }
 

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -330,13 +330,65 @@ page {
 .bottom-nav {
   margin-top: auto;
   margin-bottom: 32rpx;
-  padding: 18rpx 24rpx;
+  padding: 18rpx 20rpx;
   border-radius: 36rpx;
   background: rgba(21, 32, 84, 0.85);
   border: 1rpx solid rgba(119, 138, 230, 0.35);
   display: flex;
-  justify-content: space-between;
+  align-items: center;
+  gap: 20rpx;
   box-shadow: 0 18rpx 36rpx rgba(16, 13, 55, 0.45);
+  overflow: hidden;
+}
+
+.bottom-nav__items {
+  display: flex;
+  align-items: center;
+  gap: 24rpx;
+  flex-wrap: nowrap;
+  transition: width 260ms ease, max-width 260ms ease, padding 260ms ease, gap 260ms ease;
+}
+
+.bottom-nav--collapsed .bottom-nav__items {
+  width: calc(3 * 112rpx);
+  max-width: calc(3 * 112rpx);
+  justify-content: space-between;
+  gap: 12rpx;
+}
+
+.bottom-nav--expanded .bottom-nav__items {
+  width: 100%;
+  max-width: 100%;
+  justify-content: space-between;
+  gap: 20rpx;
+}
+
+.bottom-nav__more {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rpx 8rpx;
+  border-radius: 24rpx;
+  color: rgba(227, 233, 255, 0.95);
+  background: rgba(255, 255, 255, 0.06);
+  line-height: 1.2;
+  font-size: 20rpx;
+  transition: transform 200ms ease, background 200ms ease, opacity 200ms ease;
+}
+
+.bottom-nav__more:active {
+  transform: scale(0.92);
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.bottom-nav__more-icon {
+  font-size: 28rpx;
+  line-height: 1;
+}
+
+.bottom-nav__more-label {
+  margin-top: 2rpx;
 }
 
 .nav-item {
@@ -345,6 +397,15 @@ page {
   align-items: center;
   gap: 8rpx;
   color: rgba(227, 233, 255, 0.95);
+  min-width: 88rpx;
+}
+
+.bottom-nav--expanded .nav-item {
+  flex: 1;
+}
+
+.bottom-nav--collapsed .nav-item {
+  flex: none;
 }
 
 .nav-icon-wrapper {


### PR DESCRIPTION
## Summary
- collapse the home bottom toolbar by default and add an expandable "more" entry
- animate the toolbar to reveal all shortcuts and remember the expanded state via storage
- tighten styles so the condensed icons stay compact while the expanded row fills one line

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df4cac31488330b16f47f10cc499ae