### PR TITLE
feat: add stone mall entry

### DIFF
--- a/cloudfunctions/stones/index.js
+++ b/cloudfunctions/stones/index.js
@@ -4,11 +4,42 @@ cloud.init({ env: cloud.DYNAMIC_CURRENT_ENV });
 
 const db = cloud.database();
 const $ = db.command.aggregate;
+const _ = db.command;
 
 const COLLECTIONS = {
   MEMBERS: 'members',
   STONE_TRANSACTIONS: 'stoneTransactions'
 };
+
+const MALL_ITEMS = [
+  {
+    id: 'rename_card_single',
+    name: '改名卡',
+    icon: '🪪',
+    price: 120,
+    description: '兑换额外的改名次数，随时焕新道号。',
+    effectLabel: '兑换后 +1 张改名卡',
+    effects: { renameCards: 1 }
+  },
+  {
+    id: 'rename_card_bundle_5',
+    name: '改名福袋（5 张）',
+    icon: '🎁',
+    price: 550,
+    description: '限时福袋，内含 5 张改名卡，比单买更划算。',
+    effectLabel: '兑换后 +5 张改名卡',
+    effects: { renameCards: 5 }
+  },
+  {
+    id: 'rename_card_bundle_10',
+    name: '改名福袋（10 张）',
+    icon: '💎',
+    price: 1080,
+    description: '尊享礼包，适合频繁焕新道号的高阶仙友。',
+    effectLabel: '兑换后 +10 张改名卡',
+    effects: { renameCards: 10 }
+  }
+];
 
 exports.main = async (event) => {
   const { OPENID } = cloud.getWXContext();
@@ -17,10 +48,21 @@ exports.main = async (event) => {
   switch (action) {
     case 'summary':
       return getSummary(OPENID);
+    case 'catalog':
+      return getCatalog();
+    case 'purchase':
+      return purchaseItem(OPENID, event.itemId, event.quantity || 1);
     default:
       throw new Error(`Unknown action: ${action}`);
   }
 };
+
+function createError(code, message) {
+  const error = new Error(message || '发生未知错误');
+  error.code = code;
+  error.errCode = code;
+  return error;
+}
 
 async function getSummary(openid) {
   const [memberDoc, transactionsSnapshot, totalsSnapshot] = await Promise.all([
@@ -159,3 +201,92 @@ const transactionTypeLabel = {
   task: '任务奖励',
   reward: '奖励'
 };
+
+function getCatalog() {
+  return {
+    items: MALL_ITEMS.map((item) => ({
+      id: item.id,
+      name: item.name,
+      icon: item.icon || '',
+      price: Math.max(0, Math.floor(Number(item.price) || 0)),
+      description: item.description || '',
+      effectLabel: item.effectLabel || ''
+    }))
+  };
+}
+
+async function purchaseItem(openid, itemId, quantity = 1) {
+  if (!openid) {
+    throw createError('AUTH_REQUIRED', '请先登录后再兑换');
+  }
+  const normalizedId = typeof itemId === 'string' ? itemId.trim() : '';
+  if (!normalizedId) {
+    throw createError('INVALID_ITEM', '请选择要兑换的道具');
+  }
+  const item = MALL_ITEMS.find((entry) => entry.id === normalizedId);
+  if (!item) {
+    throw createError('ITEM_NOT_FOUND', '道具不存在或已下架');
+  }
+
+  const quantityNumber = Number(quantity);
+  if (!Number.isFinite(quantityNumber) || quantityNumber <= 0) {
+    throw createError('INVALID_QUANTITY', '兑换数量无效');
+  }
+  const normalizedQuantity = Math.max(1, Math.floor(quantityNumber));
+  const totalCost = Math.max(0, Math.floor(Number(item.price) || 0)) * normalizedQuantity;
+  if (totalCost <= 0) {
+    throw createError('INVALID_PRICE', '该道具暂无法兑换');
+  }
+
+  const membersCollection = db.collection(COLLECTIONS.MEMBERS);
+  const existing = await membersCollection.doc(openid).get().catch(() => null);
+  if (!existing || !existing.data) {
+    throw createError('MEMBER_NOT_FOUND', '请先完成会员注册');
+  }
+  const member = existing.data;
+  const balance = resolveStoneBalance(member);
+  if (balance < totalCost) {
+    throw createError('STONE_INSUFFICIENT', '灵石不足');
+  }
+
+  const updates = {
+    stoneBalance: _.inc(-totalCost),
+    updatedAt: new Date()
+  };
+
+  if (item.effects && item.effects.renameCards) {
+    const renameAmount = Math.max(0, Math.floor(Number(item.effects.renameCards) || 0));
+    if (renameAmount > 0) {
+      updates.renameCards = _.inc(renameAmount * normalizedQuantity);
+    }
+  }
+
+  await membersCollection.doc(openid).update({
+    data: updates
+  });
+
+  const serverDate = typeof db.serverDate === 'function' ? db.serverDate() : new Date();
+  const description = normalizedQuantity > 1 ? `${item.name} x${normalizedQuantity}` : item.name;
+  await db.collection(COLLECTIONS.STONE_TRANSACTIONS).add({
+    data: {
+      memberId: openid,
+      amount: -totalCost,
+      type: 'spend',
+      source: 'mall',
+      description: `购买${description}`,
+      meta: { itemId: item.id, quantity: normalizedQuantity },
+      createdAt: serverDate
+    }
+  });
+
+  const summary = await getSummary(openid);
+  return {
+    success: true,
+    item: {
+      id: item.id,
+      name: item.name
+    },
+    quantity: normalizedQuantity,
+    summary
+  };
+}

--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -7,6 +7,7 @@
     "pages/tasks/tasks",
     "pages/reservation/reservation",
     "pages/stones/stones",
+    "pages/mall/index",
     "pages/pve/pve",
     "pages/role/index",
     "pages/wallet/wallet",

--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -869,6 +869,10 @@ Page({
     wx.navigateTo({ url: '/pages/stones/stones' });
   },
 
+  handleMallTap() {
+    wx.navigateTo({ url: '/pages/mall/index' });
+  },
+
   handleLevelTap() {
     wx.navigateTo({ url: '/pages/membership/membership' });
   },

--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -58,10 +58,20 @@
         </view>
       </view>
 
-      <view class="activity-panel">
-        <view class="activity-item" wx:for="{{activityIcons}}" wx:key="label" data-url="{{item.url}}" data-label="{{item.label}}" bindtap="handleActivityTap">
-          <view class="activity-icon">{{item.icon}}</view>
-          <view class="activity-label">{{item.label}}</view>
+      <view class="top-bar__actions">
+        <view class="mall-entry" bindtap="handleMallTap">
+          <view class="mall-entry__icon">🏪</view>
+          <view class="mall-entry__info">
+            <view class="mall-entry__label">灵石商城</view>
+            <view class="mall-entry__hint">兑换虚拟道具</view>
+          </view>
+        </view>
+
+        <view class="activity-panel">
+          <view class="activity-item" wx:for="{{activityIcons}}" wx:key="label" data-url="{{item.url}}" data-label="{{item.label}}" bindtap="handleActivityTap">
+            <view class="activity-icon">{{item.icon}}</view>
+            <view class="activity-label">{{item.label}}</view>
+          </view>
         </view>
       </view>
     </view>

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -118,6 +118,53 @@ page {
   align-items: flex-start;
 }
 
+.top-bar__actions {
+  display: flex;
+  align-items: flex-start;
+  gap: 24rpx;
+}
+
+.mall-entry {
+  display: flex;
+  align-items: center;
+  gap: 16rpx;
+  padding: 20rpx 24rpx;
+  background: rgba(36, 41, 82, 0.78);
+  border-radius: 28rpx;
+  border: 1px solid rgba(118, 144, 255, 0.35);
+  box-shadow: 0 10rpx 24rpx rgba(8, 10, 34, 0.4);
+  transition: transform 160ms ease, box-shadow 160ms ease;
+  flex-shrink: 0;
+}
+
+.mall-entry:active {
+  transform: scale(0.98);
+  box-shadow: 0 6rpx 16rpx rgba(8, 10, 34, 0.4);
+}
+
+.mall-entry__icon {
+  font-size: 40rpx;
+  line-height: 1;
+}
+
+.mall-entry__info {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.mall-entry__label {
+  font-size: 26rpx;
+  font-weight: 600;
+}
+
+.mall-entry__hint {
+  margin-top: 4rpx;
+  font-size: 22rpx;
+  color: rgba(212, 220, 255, 0.75);
+  white-space: nowrap;
+}
+
 .profile-card {
   display: flex;
   align-items: center;

--- a/miniprogram/pages/mall/index.js
+++ b/miniprogram/pages/mall/index.js
@@ -1,0 +1,89 @@
+import { StoneService } from '../../services/api';
+import { formatStones } from '../../utils/format';
+
+Page({
+  data: {
+    loading: true,
+    items: [],
+    stoneBalance: 0,
+    stoneBalanceText: '0',
+    submittingId: '',
+    error: ''
+  },
+
+  onShow() {
+    this.bootstrap();
+  },
+
+  async bootstrap() {
+    this.setData({ loading: true, error: '' });
+    try {
+      const [catalog, summary] = await Promise.all([
+        StoneService.catalog(),
+        StoneService.summary()
+      ]);
+      const items = Array.isArray(catalog && catalog.items)
+        ? catalog.items.map((item) => ({
+            ...item,
+            price: Math.max(0, Math.floor(Number(item.price) || 0)),
+            icon: item.icon || '🛒',
+            description: item.description || '',
+            effectLabel: item.effectLabel || ''
+          }))
+        : [];
+      this.applySummary(summary);
+      this.setData({
+        items,
+        loading: false
+      });
+    } catch (error) {
+      console.error('[mall] bootstrap failed', error);
+      this.setData({
+        error: '商城暂时不可用，请稍后再试',
+        loading: false
+      });
+    }
+  },
+
+  async handlePurchase(event) {
+    const { id } = event.currentTarget.dataset;
+    if (!id || this.data.submittingId) {
+      return;
+    }
+    const item = this.data.items.find((entry) => entry.id === id);
+    if (!item) {
+      return;
+    }
+    this.setData({ submittingId: id });
+    try {
+      const result = await StoneService.purchase(id, 1);
+      if (result && result.summary) {
+        this.applySummary(result.summary);
+      } else {
+        const nextBalance = Math.max(this.data.stoneBalance - item.price, 0);
+        this.applySummary({ balance: nextBalance, stoneBalance: nextBalance });
+      }
+      wx.showToast({ title: '兑换成功', icon: 'success' });
+    } catch (error) {
+      console.error('[mall] purchase failed', error);
+      // 错误提示在 callCloud 中已处理，此处仅保持状态同步。
+    } finally {
+      this.setData({ submittingId: '' });
+    }
+  },
+
+  applySummary(summary) {
+    if (!summary || typeof summary !== 'object') {
+      return;
+    }
+    const balance = Number(summary.balance ?? summary.stoneBalance ?? this.data.stoneBalance);
+    if (!Number.isFinite(balance)) {
+      return;
+    }
+    const normalized = Math.max(0, Math.floor(balance));
+    this.setData({
+      stoneBalance: normalized,
+      stoneBalanceText: formatStones(normalized)
+    });
+  }
+});

--- a/miniprogram/pages/mall/index.json
+++ b/miniprogram/pages/mall/index.json
@@ -1,0 +1,5 @@
+{
+  "usingComponents": {
+    "custom-nav": "/components/custom-nav/custom-nav"
+  }
+}

--- a/miniprogram/pages/mall/index.wxml
+++ b/miniprogram/pages/mall/index.wxml
@@ -1,0 +1,41 @@
+<custom-nav title="灵石商城" theme="dark"></custom-nav>
+<view class="mall-page">
+  <view class="mall-balance-card">
+    <view class="mall-balance-card__label">当前灵石</view>
+    <view class="mall-balance-card__value">{{stoneBalanceText}} 枚</view>
+    <view class="mall-balance-card__hint">可用于兑换虚拟道具，无法折现。</view>
+  </view>
+
+  <view wx:if="{{error}}" class="mall-error">{{error}}</view>
+  <view wx:elif="{{loading}}" class="mall-loading">灵石气息汇聚中...</view>
+  <block wx:else>
+    <view class="mall-item-list" wx:if="{{items.length}}">
+      <view
+        class="mall-item-card"
+        wx:for="{{items}}"
+        wx:key="id"
+        data-id="{{item.id}}"
+      >
+        <view class="mall-item-card__icon">{{item.icon}}</view>
+        <view class="mall-item-card__body">
+          <view class="mall-item-card__header">
+            <text class="mall-item-card__name">{{item.name}}</text>
+            <text class="mall-item-card__price">{{item.price}} 灵石</text>
+          </view>
+          <view class="mall-item-card__desc">{{item.description}}</view>
+          <view class="mall-item-card__meta" wx:if="{{item.effectLabel}}">{{item.effectLabel}}</view>
+          <button
+            class="mall-item-card__action"
+            type="primary"
+            size="mini"
+            data-id="{{item.id}}"
+            loading="{{submittingId === item.id}}"
+            disabled="{{submittingId === item.id}}"
+            bindtap="handlePurchase"
+          >兑换</button>
+        </view>
+      </view>
+    </view>
+    <view wx:if="{{!items.length}}" class="mall-empty">商城暂未上架可兑换的道具，敬请期待。</view>
+  </block>
+</view>

--- a/miniprogram/pages/mall/index.wxss
+++ b/miniprogram/pages/mall/index.wxss
@@ -1,0 +1,119 @@
+page {
+  background: linear-gradient(180deg, #0b102f 0%, #1f1140 100%);
+  min-height: 100vh;
+  color: #fdfcff;
+}
+
+.mall-page {
+  padding: 32rpx 32rpx calc(32rpx + constant(safe-area-inset-bottom));
+  padding-bottom: calc(32rpx + env(safe-area-inset-bottom));
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 32rpx;
+}
+
+.mall-balance-card {
+  background: rgba(34, 39, 78, 0.8);
+  border: 1px solid rgba(123, 145, 255, 0.35);
+  border-radius: 24rpx;
+  padding: 32rpx;
+  box-shadow: 0 12rpx 32rpx rgba(10, 12, 38, 0.45);
+}
+
+.mall-balance-card__label {
+  font-size: 26rpx;
+  color: rgba(212, 220, 255, 0.85);
+}
+
+.mall-balance-card__value {
+  margin-top: 12rpx;
+  font-size: 48rpx;
+  font-weight: 600;
+  letter-spacing: 2rpx;
+}
+
+.mall-balance-card__hint {
+  margin-top: 8rpx;
+  font-size: 24rpx;
+  color: rgba(212, 220, 255, 0.65);
+}
+
+.mall-loading,
+.mall-error,
+.mall-empty {
+  padding: 48rpx 32rpx;
+  text-align: center;
+  font-size: 26rpx;
+  color: rgba(212, 220, 255, 0.8);
+  background: rgba(27, 30, 63, 0.6);
+  border-radius: 20rpx;
+}
+
+.mall-error {
+  color: #ffb4b4;
+  border: 1px solid rgba(255, 102, 102, 0.4);
+}
+
+.mall-item-list {
+  display: flex;
+  flex-direction: column;
+  gap: 24rpx;
+}
+
+.mall-item-card {
+  display: flex;
+  gap: 24rpx;
+  padding: 24rpx;
+  background: rgba(36, 41, 82, 0.78);
+  border-radius: 24rpx;
+  border: 1px solid rgba(118, 144, 255, 0.35);
+  box-shadow: 0 10rpx 28rpx rgba(8, 10, 34, 0.4);
+}
+
+.mall-item-card__icon {
+  font-size: 56rpx;
+  width: 80rpx;
+  text-align: center;
+  line-height: 80rpx;
+}
+
+.mall-item-card__body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16rpx;
+}
+
+.mall-item-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16rpx;
+}
+
+.mall-item-card__name {
+  font-size: 30rpx;
+  font-weight: 600;
+}
+
+.mall-item-card__price {
+  font-size: 26rpx;
+  color: #ffd166;
+}
+
+.mall-item-card__desc {
+  font-size: 24rpx;
+  color: rgba(212, 220, 255, 0.8);
+  line-height: 1.5;
+}
+
+.mall-item-card__meta {
+  font-size: 22rpx;
+  color: rgba(178, 196, 255, 0.85);
+}
+
+.mall-item-card__action {
+  align-self: flex-end;
+  padding: 0 32rpx;
+}

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -325,6 +325,16 @@ export const PveService = {
 export const StoneService = {
   async summary() {
     return callCloud(CLOUD_FUNCTIONS.STONES, { action: 'summary' });
+  },
+  async catalog() {
+    return callCloud(CLOUD_FUNCTIONS.STONES, { action: 'catalog' });
+  },
+  async purchase(itemId, quantity = 1) {
+    return callCloud(CLOUD_FUNCTIONS.STONES, {
+      action: 'purchase',
+      itemId,
+      quantity
+    });
   }
 };
 


### PR DESCRIPTION
## Summary
- extend the stones cloud function with a mall catalog and purchase workflow that sells rename-card bundles and records stone spending
- add StoneService helpers plus a dedicated mall page to browse items, view stone balance, and redeem goods with stones
- expose the mall from the home screen via a new top-right entry and register the page in the mini program config

## Testing
- not run (mini program environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68df5984e3f48330bca35cd00c4bbf60