### PR TITLE
feat: restyle stone mall with categorized grid

### DIFF
--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -7,6 +7,7 @@
     "pages/tasks/tasks",
     "pages/reservation/reservation",
     "pages/stones/stones",
+    "pages/mall/index",
     "pages/pve/pve",
     "pages/role/index",
     "pages/wallet/wallet",

--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -575,6 +575,7 @@ Page({
     heroImage: HERO_IMAGE,
     defaultAvatar: DEFAULT_AVATAR,
     activityIcons: [
+      { icon: '🏪', label: '商城', url: '/pages/mall/index' },
       { icon: '⚔️', label: '秘境', url: '/pages/pve/pve' },
       { icon: '🎉', label: '盛典', url: '/pages/rights/rights' },
       { icon: '🔥', label: '比武' }

--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -58,10 +58,12 @@
         </view>
       </view>
 
-      <view class="activity-panel">
-        <view class="activity-item" wx:for="{{activityIcons}}" wx:key="label" data-url="{{item.url}}" data-label="{{item.label}}" bindtap="handleActivityTap">
-          <view class="activity-icon">{{item.icon}}</view>
-          <view class="activity-label">{{item.label}}</view>
+      <view class="top-bar__actions">
+        <view class="activity-panel">
+          <view class="activity-item" wx:for="{{activityIcons}}" wx:key="label" data-url="{{item.url}}" data-label="{{item.label}}" bindtap="handleActivityTap">
+            <view class="activity-icon">{{item.icon}}</view>
+            <view class="activity-label">{{item.label}}</view>
+          </view>
         </view>
       </view>
     </view>

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -118,6 +118,12 @@ page {
   align-items: flex-start;
 }
 
+.top-bar__actions {
+  display: flex;
+  align-items: flex-start;
+  gap: 24rpx;
+}
+
 .profile-card {
   display: flex;
   align-items: center;

--- a/miniprogram/pages/mall/index.js
+++ b/miniprogram/pages/mall/index.js
@@ -1,0 +1,264 @@
+import { StoneService } from '../../services/api';
+import { formatStones } from '../../utils/format';
+
+const DEFAULT_CATEGORY_KEY = 'general';
+const DEFAULT_CATEGORY_LABEL = '奇珍异宝';
+
+Page({
+  data: {
+    loading: true,
+    items: [],
+    categories: [],
+    activeCategoryKey: '',
+    activeCategoryIndex: 0,
+    activeCategory: null,
+    stoneBalance: 0,
+    stoneBalanceText: '0',
+    submittingId: '',
+    showDetail: false,
+    detailItem: null,
+    error: ''
+  },
+
+  onShow() {
+    this.bootstrap();
+  },
+
+  async bootstrap() {
+    this.setData({ loading: true, error: '' });
+    try {
+      const [catalog, summary] = await Promise.all([
+        StoneService.catalog(),
+        StoneService.summary()
+      ]);
+      const items = this.normalizeCatalogItems(catalog);
+      const categories = this.buildCategories(items);
+      const { activeCategoryKey, activeCategoryIndex, activeCategory } =
+        this.resolveActiveCategoryState(categories);
+      this.applySummary(summary);
+      this.setData({
+        items,
+        categories,
+        activeCategoryKey,
+        activeCategoryIndex,
+        activeCategory,
+        loading: false,
+        error: ''
+      });
+    } catch (error) {
+      console.error('[mall] bootstrap failed', error);
+      this.setData({
+        error: '商城暂时不可用，请稍后再试',
+        loading: false
+      });
+    }
+  },
+
+  async handlePurchase(event) {
+    const { id } = event.currentTarget.dataset || {};
+    if (!id) {
+      return;
+    }
+    this.purchaseItem(id);
+  },
+
+  async handleModalPurchase() {
+    const { detailItem } = this.data;
+    if (!detailItem) {
+      return;
+    }
+    this.purchaseItem(detailItem.id);
+  },
+
+  async purchaseItem(id) {
+    if (!id || this.data.submittingId) {
+      return;
+    }
+    const item = this.data.items.find((entry) => entry.id === id);
+    if (!item) {
+      return;
+    }
+    this.setData({ submittingId: id });
+    try {
+      const result = await StoneService.purchase(id, 1);
+      if (result && result.summary) {
+        this.applySummary(result.summary);
+      } else {
+        const nextBalance = Math.max(this.data.stoneBalance - item.price, 0);
+        this.applySummary({ balance: nextBalance, stoneBalance: nextBalance });
+      }
+      if (this.data.detailItem && this.data.detailItem.id === id) {
+        this.setData({ showDetail: false, detailItem: null });
+      }
+      wx.showToast({ title: '兑换成功', icon: 'success' });
+    } catch (error) {
+      console.error('[mall] purchase failed', error);
+      // 错误提示在 callCloud 中已处理，此处仅保持状态同步。
+    } finally {
+      this.setData({ submittingId: '' });
+    }
+  },
+
+  handleCategoryChange(event) {
+    const { key } = event.currentTarget.dataset || {};
+    if (!key || key === this.data.activeCategoryKey) {
+      return;
+    }
+    const { categories } = this.data;
+    const index = Array.isArray(categories)
+      ? categories.findIndex((item) => item.key === key)
+      : -1;
+    if (index === -1) {
+      return;
+    }
+    const category = categories[index];
+    this.setData({
+      activeCategoryKey: key,
+      activeCategoryIndex: index,
+      activeCategory: category
+    });
+  },
+
+  handleItemTap(event) {
+    const { id } = event.currentTarget.dataset || {};
+    if (!id) {
+      return;
+    }
+    const item = this.data.items.find((entry) => entry.id === id);
+    if (!item) {
+      return;
+    }
+    this.setData({
+      detailItem: item,
+      showDetail: true
+    });
+  },
+
+  handleModalClose() {
+    if (!this.data.showDetail) {
+      return;
+    }
+    this.setData({ showDetail: false, detailItem: null });
+  },
+
+  noop() {},
+
+  applySummary(summary) {
+    if (!summary || typeof summary !== 'object') {
+      return;
+    }
+    const balance = Number(summary.balance ?? summary.stoneBalance ?? this.data.stoneBalance);
+    if (!Number.isFinite(balance)) {
+      return;
+    }
+    const normalized = Math.max(0, Math.floor(balance));
+    this.setData({
+      stoneBalance: normalized,
+      stoneBalanceText: formatStones(normalized)
+    });
+  },
+
+  normalizeCatalogItems(catalog) {
+    if (!catalog || !Array.isArray(catalog.items)) {
+      return [];
+    }
+    return catalog.items
+      .map((item) => {
+        const price = Math.max(0, Math.floor(Number(item.price) || 0));
+        const icon = (item.icon || '🛒').trim();
+        const iconUrl = (item.iconUrl || '').trim();
+        const categoryKey = (item.category || DEFAULT_CATEGORY_KEY).trim() || DEFAULT_CATEGORY_KEY;
+        const categoryLabel =
+          (item.categoryLabel || '').trim() || DEFAULT_CATEGORY_LABEL;
+        const categoryOrder = Number.isFinite(Number(item.categoryOrder))
+          ? Number(item.categoryOrder)
+          : null;
+        const order = Number.isFinite(Number(item.order)) ? Number(item.order) : null;
+        return {
+          ...item,
+          price,
+          icon,
+          iconUrl,
+          iconText: icon && icon.length > 2 ? icon.slice(0, 2) : icon,
+          category: categoryKey,
+          categoryLabel,
+          categoryOrder,
+          order,
+          description: item.description || '',
+          effectLabel: item.effectLabel || ''
+        };
+      })
+      .filter((item) => !!item.id);
+  },
+
+  buildCategories(items) {
+    if (!Array.isArray(items) || !items.length) {
+      return [];
+    }
+    const map = new Map();
+    items.forEach((item) => {
+      const key = item.category || DEFAULT_CATEGORY_KEY;
+      if (!map.has(key)) {
+        map.set(key, {
+          key,
+          label: item.categoryLabel || DEFAULT_CATEGORY_LABEL,
+          order: Number.isFinite(item.categoryOrder)
+            ? item.categoryOrder
+            : Number.MAX_SAFE_INTEGER,
+          items: []
+        });
+      }
+      const category = map.get(key);
+      if (
+        Number.isFinite(item.categoryOrder) &&
+        item.categoryOrder < category.order
+      ) {
+        category.order = item.categoryOrder;
+      }
+      category.items.push(item);
+    });
+    return Array.from(map.values())
+      .map((category) => ({
+        ...category,
+        items: category.items.sort((a, b) => {
+          const orderA = Number.isFinite(a.order)
+            ? a.order
+            : Number.MAX_SAFE_INTEGER;
+          const orderB = Number.isFinite(b.order)
+            ? b.order
+            : Number.MAX_SAFE_INTEGER;
+          if (orderA !== orderB) {
+            return orderA - orderB;
+          }
+          return a.name.localeCompare(b.name);
+        })
+      }))
+      .sort((a, b) => {
+        if (a.order !== b.order) {
+          return a.order - b.order;
+        }
+        return a.label.localeCompare(b.label);
+      });
+  },
+
+  resolveActiveCategoryState(categories) {
+    if (!Array.isArray(categories) || !categories.length) {
+      return {
+        activeCategoryKey: '',
+        activeCategoryIndex: 0,
+        activeCategory: null
+      };
+    }
+    const fallbackKey = categories[0].key;
+    const currentKey = this.data.activeCategoryKey;
+    const targetKey = categories.some((category) => category.key === currentKey)
+      ? currentKey
+      : fallbackKey;
+    const index = categories.findIndex((category) => category.key === targetKey);
+    return {
+      activeCategoryKey: targetKey,
+      activeCategoryIndex: index,
+      activeCategory: index >= 0 ? categories[index] : null
+    };
+  }
+});

--- a/miniprogram/pages/mall/index.json
+++ b/miniprogram/pages/mall/index.json
@@ -1,0 +1,5 @@
+{
+  "usingComponents": {
+    "custom-nav": "/components/custom-nav/custom-nav"
+  }
+}

--- a/miniprogram/pages/mall/index.wxml
+++ b/miniprogram/pages/mall/index.wxml
@@ -1,0 +1,93 @@
+<custom-nav title="灵石商城" theme="dark"></custom-nav>
+<view class="mall-page">
+  <view class="section-card mall-balance-card">
+    <view class="mall-balance-card__label">当前灵石</view>
+    <view class="mall-balance-card__value">{{stoneBalanceText}} 枚</view>
+    <view class="mall-balance-card__hint">可用于兑换虚拟道具，无法折现。</view>
+  </view>
+
+  <view wx:if="{{error}}" class="section-card mall-message mall-message--error">{{error}}</view>
+  <view wx:elif="{{loading}}" class="section-card mall-message">灵石气息汇聚中...</view>
+  <block wx:else>
+    <view wx:if="{{categories.length}}" class="section-card mall-catalog">
+      <view class="section-header">
+        <view class="section-title">灵石兑换</view>
+        <view class="section-subtitle">按类型挑选心仪道具</view>
+      </view>
+      <view wx:if="{{categories.length > 1}}" class="mall-tabs">
+        <view
+          wx:for="{{categories}}"
+          wx:key="key"
+          class="mall-tab {{activeCategoryKey === item.key ? 'mall-tab--active' : ''}}"
+          data-key="{{item.key}}"
+          bindtap="handleCategoryChange"
+          hover-class="mall-tab--hover"
+        >
+          <text class="mall-tab__label">{{item.label}}</text>
+        </view>
+      </view>
+      <view wx:if="{{activeCategory && activeCategory.items.length}}" class="mall-grid">
+        <block wx:for="{{activeCategory.items}}" wx:key="id">
+          <view
+            class="mall-slot {{item.iconUrl ? 'mall-slot--has-icon' : ''}}"
+            data-id="{{item.id}}"
+            bindtap="handleItemTap"
+            hover-class="mall-slot--hover"
+          >
+            <view class="mall-slot__frame {{item.iconUrl ? 'mall-slot__frame--image' : ''}}">
+              <block wx:if="{{item.iconUrl}}">
+                <image class="mall-slot__image" src="{{item.iconUrl}}" mode="aspectFill" lazy-load="true" />
+              </block>
+              <view wx:elif="{{item.icon}}" class="mall-slot__emoji">{{item.icon}}</view>
+              <view wx:else class="mall-slot__placeholder">{{item.iconText || item.name}}</view>
+              <view class="mall-slot__price">{{item.price}} 灵石</view>
+            </view>
+          </view>
+        </block>
+      </view>
+      <view wx:elif="{{activeCategory}}" class="mall-empty">该类别暂未上架道具</view>
+    </view>
+    <view wx:else class="section-card mall-empty-card">
+      <view class="mall-empty">商城暂未上架可兑换的道具，敬请期待。</view>
+    </view>
+  </block>
+</view>
+
+<view wx:if="{{showDetail && detailItem}}" class="mall-modal" catchtouchmove="noop">
+  <view class="mall-modal__mask" bindtap="handleModalClose"></view>
+  <view class="mall-modal__panel">
+    <view class="mall-modal__icon-wrapper">
+      <view class="mall-modal__icon-frame {{detailItem.iconUrl ? 'mall-modal__icon-frame--image' : ''}}">
+        <block wx:if="{{detailItem.iconUrl}}">
+          <image class="mall-modal__icon-image" src="{{detailItem.iconUrl}}" mode="aspectFill" lazy-load="true" />
+        </block>
+        <view wx:elif="{{detailItem.icon}}" class="mall-modal__icon-emoji">{{detailItem.icon}}</view>
+        <view wx:else class="mall-modal__icon-placeholder">{{detailItem.iconText || detailItem.name}}</view>
+      </view>
+    </view>
+    <view class="mall-modal__header">
+      <view class="mall-modal__title">{{detailItem.name}}</view>
+      <view class="mall-modal__price">{{detailItem.price}} 灵石</view>
+    </view>
+    <view class="mall-modal__body">
+      <view wx:if="{{detailItem.categoryLabel}}" class="mall-modal__tag">{{detailItem.categoryLabel}}</view>
+      <view wx:if="{{detailItem.effectLabel}}" class="mall-modal__highlight">{{detailItem.effectLabel}}</view>
+      <view class="mall-modal__desc">{{detailItem.description || '暂无道具描述'}}</view>
+    </view>
+    <view class="mall-modal__actions">
+      <button
+        class="mall-modal__button mall-modal__button--ghost"
+        hover-class="mall-modal__button--ghost-hover"
+        bindtap="handleModalClose"
+      >稍后再看</button>
+      <button
+        class="mall-modal__button mall-modal__button--primary"
+        hover-class="mall-modal__button--primary-hover"
+        data-id="{{detailItem.id}}"
+        loading="{{submittingId === detailItem.id}}"
+        disabled="{{submittingId === detailItem.id}}"
+        bindtap="handleModalPurchase"
+      >兑换</button>
+    </view>
+  </view>
+</view>

--- a/miniprogram/pages/mall/index.wxss
+++ b/miniprogram/pages/mall/index.wxss
@@ -1,0 +1,390 @@
+page {
+  background: #050921;
+  min-height: 100%;
+  color: #e5ecff;
+}
+
+.mall-page {
+  padding: 32rpx;
+  padding-bottom: calc(32rpx + constant(safe-area-inset-bottom));
+  padding-bottom: calc(32rpx + env(safe-area-inset-bottom));
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 32rpx;
+}
+
+.section-card {
+  background: rgba(15, 25, 60, 0.92);
+  border-radius: 28rpx;
+  padding: 32rpx;
+  box-shadow: 0 18rpx 36rpx rgba(4, 8, 28, 0.55);
+  border: 1rpx solid rgba(90, 118, 255, 0.24);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24rpx;
+  gap: 24rpx;
+  flex-wrap: wrap;
+}
+
+.section-title {
+  font-size: 32rpx;
+  font-weight: 700;
+  color: #f3f6ff;
+}
+
+.section-subtitle {
+  font-size: 24rpx;
+  color: rgba(194, 206, 255, 0.78);
+}
+
+.mall-balance-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12rpx;
+}
+
+.mall-balance-card__label {
+  font-size: 26rpx;
+  color: rgba(212, 220, 255, 0.78);
+}
+
+.mall-balance-card__value {
+  font-size: 52rpx;
+  font-weight: 700;
+  letter-spacing: 2rpx;
+}
+
+.mall-balance-card__hint {
+  font-size: 24rpx;
+  color: rgba(190, 202, 255, 0.7);
+}
+
+.mall-message {
+  text-align: center;
+  font-size: 26rpx;
+  color: rgba(212, 220, 255, 0.85);
+  background: rgba(20, 30, 68, 0.72);
+}
+
+.mall-message--error {
+  color: #ffb4b4;
+  border-color: rgba(255, 102, 102, 0.45);
+  background: rgba(62, 16, 32, 0.72);
+}
+
+.mall-catalog {
+  position: relative;
+}
+
+.mall-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16rpx;
+  margin-bottom: 24rpx;
+}
+
+.mall-tab {
+  padding: 14rpx 26rpx;
+  border-radius: 999rpx;
+  border: 1rpx solid rgba(86, 112, 220, 0.32);
+  background: rgba(20, 34, 84, 0.62);
+  color: rgba(198, 210, 255, 0.82);
+  font-size: 24rpx;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  transition: all 0.2s ease;
+}
+
+.mall-tab__label {
+  font-weight: 600;
+}
+
+.mall-tab--active {
+  border-color: rgba(130, 156, 255, 0.6);
+  background: linear-gradient(120deg, rgba(94, 124, 248, 0.92), rgba(144, 94, 255, 0.92));
+  color: #f8faff;
+  box-shadow: 0 10rpx 22rpx rgba(86, 108, 228, 0.28);
+}
+
+.mall-tab--hover {
+  background: rgba(44, 64, 138, 0.72);
+  color: rgba(222, 232, 255, 0.92);
+  border-color: rgba(126, 152, 240, 0.4);
+}
+
+.mall-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 20rpx;
+}
+
+.mall-slot {
+  position: relative;
+  border-radius: 22rpx;
+  border: 1rpx solid rgba(86, 116, 210, 0.34);
+  background: rgba(16, 28, 70, 0.85);
+  overflow: hidden;
+}
+
+.mall-slot::before {
+  content: '';
+  display: block;
+  padding-top: 100%;
+}
+
+.mall-slot--has-icon {
+  border: none;
+  background: transparent;
+}
+
+.mall-slot__frame {
+  position: absolute;
+  inset: 12rpx;
+  border-radius: 18rpx;
+  border: 4rpx solid rgba(118, 146, 250, 0.58);
+  background: rgba(10, 18, 48, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  box-sizing: border-box;
+  transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.mall-slot__frame--image {
+  inset: 0;
+  border: none;
+  background: transparent;
+  border-radius: 22rpx;
+}
+
+.mall-slot--hover .mall-slot__frame {
+  border-color: rgba(150, 176, 255, 0.68);
+  box-shadow: 0 12rpx 26rpx rgba(90, 118, 240, 0.32);
+  transform: translateY(-2rpx);
+}
+
+.mall-slot__image {
+  width: 100%;
+  height: 100%;
+  display: block;
+  border-radius: inherit;
+}
+
+.mall-slot__emoji {
+  font-size: 52rpx;
+}
+
+.mall-slot__placeholder {
+  padding: 0 16rpx;
+  text-align: center;
+  font-size: 24rpx;
+  color: rgba(214, 224, 255, 0.85);
+}
+
+.mall-slot__price {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 12rpx;
+  font-size: 22rpx;
+  text-align: center;
+  color: #f7f9ff;
+  background: linear-gradient(180deg, rgba(8, 14, 34, 0) 0%, rgba(8, 14, 34, 0.92) 100%);
+  box-sizing: border-box;
+}
+
+.mall-empty {
+  text-align: center;
+  font-size: 26rpx;
+  color: rgba(198, 210, 255, 0.82);
+  padding: 40rpx 24rpx;
+}
+
+.mall-empty-card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mall-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 40rpx 32rpx calc(48rpx + constant(safe-area-inset-bottom));
+  padding-bottom: calc(48rpx + env(safe-area-inset-bottom));
+  box-sizing: border-box;
+}
+
+.mall-modal__mask {
+  position: absolute;
+  inset: 0;
+  background: rgba(4, 6, 18, 0.72);
+}
+
+.mall-modal__panel {
+  position: relative;
+  width: 100%;
+  background: rgba(18, 24, 58, 0.96);
+  border-radius: 36rpx;
+  border: 1rpx solid rgba(108, 134, 255, 0.32);
+  box-shadow: 0 28rpx 48rpx rgba(6, 10, 28, 0.55);
+  padding: 48rpx 32rpx 40rpx;
+  box-sizing: border-box;
+  color: #f3f6ff;
+}
+
+.mall-modal__icon-wrapper {
+  position: absolute;
+  top: -68rpx;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.mall-modal__icon-frame {
+  width: 136rpx;
+  height: 136rpx;
+  border-radius: 32rpx;
+  border: 6rpx solid rgba(130, 156, 255, 0.65);
+  background: rgba(12, 18, 46, 0.95);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  box-shadow: 0 18rpx 38rpx rgba(40, 64, 180, 0.42);
+}
+
+.mall-modal__icon-frame--image {
+  border: none;
+  background: transparent;
+}
+
+.mall-modal__icon-image {
+  width: 100%;
+  height: 100%;
+  display: block;
+  border-radius: inherit;
+}
+
+.mall-modal__icon-emoji {
+  font-size: 72rpx;
+}
+
+.mall-modal__icon-placeholder {
+  padding: 0 16rpx;
+  text-align: center;
+  font-size: 28rpx;
+  color: rgba(222, 232, 255, 0.9);
+}
+
+.mall-modal__header {
+  padding-top: 96rpx;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16rpx;
+}
+
+.mall-modal__title {
+  font-size: 36rpx;
+  font-weight: 700;
+}
+
+.mall-modal__price {
+  font-size: 30rpx;
+  color: #ffd166;
+  font-weight: 600;
+}
+
+.mall-modal__body {
+  margin-top: 24rpx;
+  display: flex;
+  flex-direction: column;
+  gap: 16rpx;
+  font-size: 26rpx;
+  color: rgba(214, 224, 255, 0.9);
+}
+
+.mall-modal__tag {
+  align-self: flex-start;
+  padding: 8rpx 18rpx;
+  font-size: 22rpx;
+  border-radius: 999rpx;
+  background: rgba(84, 112, 220, 0.28);
+  color: rgba(220, 230, 255, 0.9);
+}
+
+.mall-modal__highlight {
+  font-size: 24rpx;
+  color: #f8e7ac;
+}
+
+.mall-modal__desc {
+  line-height: 1.6;
+}
+
+.mall-modal__actions {
+  margin-top: 36rpx;
+  display: flex;
+  gap: 24rpx;
+}
+
+.mall-modal__button {
+  flex: 1;
+  padding: 20rpx;
+  border-radius: 999rpx;
+  font-size: 28rpx;
+  font-weight: 600;
+  border: 1rpx solid rgba(118, 146, 250, 0.42);
+  background: rgba(46, 66, 152, 0.3);
+  color: #dee6ff;
+  line-height: 1;
+  transition: all 0.2s ease;
+}
+
+.mall-modal__button::after {
+  display: none;
+}
+
+.mall-modal__button--ghost {
+  background: rgba(46, 66, 152, 0.3);
+}
+
+.mall-modal__button--ghost-hover,
+.mall-modal__button--ghost[hover] {
+  background: rgba(58, 80, 170, 0.42);
+  border-color: rgba(134, 162, 255, 0.52);
+}
+
+.mall-modal__button--primary {
+  background: linear-gradient(120deg, rgba(102, 132, 255, 0.95), rgba(140, 91, 255, 0.95));
+  border-color: rgba(140, 159, 255, 0.72);
+  color: #f7f9ff;
+  box-shadow: 0 14rpx 32rpx rgba(90, 110, 232, 0.36);
+}
+
+.mall-modal__button--primary-hover,
+.mall-modal__button--primary[hover] {
+  background: linear-gradient(120deg, rgba(116, 145, 255, 0.98), rgba(150, 100, 255, 0.98));
+  border-color: rgba(158, 176, 255, 0.82);
+  box-shadow: 0 18rpx 38rpx rgba(96, 120, 240, 0.38);
+}
+
+button.mall-modal__button[disabled] {
+  opacity: 0.68;
+  background: rgba(44, 62, 132, 0.32);
+  border-color: rgba(112, 138, 224, 0.28);
+  color: rgba(210, 220, 255, 0.62);
+  box-shadow: none;
+}

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -325,6 +325,16 @@ export const PveService = {
 export const StoneService = {
   async summary() {
     return callCloud(CLOUD_FUNCTIONS.STONES, { action: 'summary' });
+  },
+  async catalog() {
+    return callCloud(CLOUD_FUNCTIONS.STONES, { action: 'catalog' });
+  },
+  async purchase(itemId, quantity = 1) {
+    return callCloud(CLOUD_FUNCTIONS.STONES, {
+      action: 'purchase',
+      itemId,
+      quantity
+    });
   }
 };
 


### PR DESCRIPTION
## Summary
- organize the stone mall catalog into typed categories and expose the metadata needed by the client
- mirror the role storage layout with a tiled icon grid, category tabs, and price overlays in the stone mall page
- add an item detail modal with descriptive text and an exchange entry point that updates the balance summary

## Testing
- not run (mini program environment not available)

------
https://chatgpt.com/codex/tasks/task_e_68df5984e3f48330bca35cd00c4bbf60