### PR TITLE
Keep equipment grant dialog open for consecutive grants

### DIFF
--- a/miniprogram/pages/admin/member-detail/index.js
+++ b/miniprogram/pages/admin/member-detail/index.js
@@ -648,10 +648,7 @@ Page({
       wx.showToast({ title: '请选择装备', icon: 'none' });
       return;
     }
-    const success = await this.grantEquipmentToMember(itemId);
-    if (success) {
-      this.hideEquipmentGrantDialog();
-    }
+    await this.grantEquipmentToMember(itemId);
   },
 
   async grantEquipmentToMember(itemId) {

--- a/miniprogram/pages/admin/member-detail/index.wxml
+++ b/miniprogram/pages/admin/member-detail/index.wxml
@@ -445,11 +445,10 @@
       </radio-group>
     </scroll-view>
     <view class="equipment-dialog__actions">
-      <button size="mini" class="dialog-btn" bindtap="hideEquipmentGrantDialog">取消</button>
+      <button size="mini" class="equipment-dialog__btn" bindtap="hideEquipmentGrantDialog">取消</button>
       <button
         size="mini"
-        class="dialog-btn primary"
-        type="primary"
+        class="equipment-dialog__btn equipment-dialog__btn--primary"
         loading="{{grantingEquipment}}"
         disabled="{{!equipmentSelectionId}}"
         bindtap="handleEquipmentGrantConfirm"

--- a/miniprogram/pages/admin/member-detail/index.wxss
+++ b/miniprogram/pages/admin/member-detail/index.wxss
@@ -480,6 +480,22 @@ page {
   gap: 24rpx;
 }
 
+.equipment-dialog__btn {
+  border: none;
+  border-radius: 24rpx;
+  padding: 16rpx 32rpx;
+  background: rgba(148, 163, 184, 0.16);
+  color: #d0deff;
+  font-size: 26rpx;
+}
+
+.equipment-dialog__btn--primary {
+  background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+  color: #f8fafc;
+  font-weight: 600;
+  box-shadow: 0 10rpx 28rpx rgba(79, 70, 229, 0.32);
+}
+
 .equipment-dialog__empty {
   padding: 48rpx 0;
   text-align: center;


### PR DESCRIPTION
## Summary
- keep the equipment grant dialog visible after a successful grant so admins can issue multiple items consecutively
- refresh the equipment dialog action button styles to match the overall interface palette

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df8764b9148330b55c9c2f28de9a64