### PR TITLE
feat: add dining tab and category totals to membership ordering

### DIFF
--- a/miniprogram/pages/membership/order/index.js
+++ b/miniprogram/pages/membership/order/index.js
@@ -1,6 +1,47 @@
 import { MenuOrderService } from '../../../services/api';
 import { formatCurrency, formatStones } from '../../../utils/format';
-import { categories as rawCategories, items as rawItems, softDrinks } from '../../../shared/menu-data';
+import {
+  categories as rawDrinkCategories,
+  items as rawDrinkItems,
+  softDrinks,
+  diningCategories as rawDiningCategories,
+  diningItems as rawDiningItems
+} from '../../../shared/menu-data';
+
+const SECTION_META = {
+  drinks: { id: 'drinks', title: '酒水' },
+  dining: { id: 'dining', title: '用餐' }
+};
+
+const SECTION_ORDER = ['drinks', 'dining'];
+
+function normalizeSection(value) {
+  if (typeof value === 'string') {
+    const key = value.toLowerCase();
+    if (SECTION_META[key]) {
+      return key;
+    }
+  }
+  return SECTION_ORDER[0];
+}
+
+function createEmptyCategoryTotals() {
+  return SECTION_ORDER.reduce((acc, section) => {
+    acc[section] = 0;
+    return acc;
+  }, {});
+}
+
+function normalizeCategoryTotals(input) {
+  const totals = createEmptyCategoryTotals();
+  if (input && typeof input === 'object') {
+    SECTION_ORDER.forEach((section) => {
+      const value = Number(input[section] || 0);
+      totals[section] = Number.isFinite(value) && value > 0 ? value : 0;
+    });
+  }
+  return totals;
+}
 
 function normalizeVariant(variant) {
   if (!variant) {
@@ -34,13 +75,15 @@ function normalizeItem(item, overrides = {}) {
   if (!variants.length) {
     return null;
   }
-  const category = overrides.cat || item.cat;
+  const category = (overrides.cat || item.cat || '').trim();
   if (!category) {
     return null;
   }
+  const section = normalizeSection(overrides.section || item.section);
   return {
     id: item.id,
     cat: category,
+    section,
     title: typeof item.title === 'string' ? item.title : '',
     desc: typeof item.desc === 'string' ? item.desc : '',
     img: typeof item.img === 'string' ? item.img : '',
@@ -48,46 +91,109 @@ function normalizeItem(item, overrides = {}) {
   };
 }
 
-function buildMenuItems() {
-  const list = [];
-  rawItems.forEach((item) => {
-    const normalized = normalizeItem(item);
-    if (normalized) {
-      list.push(normalized);
-    }
-  });
-  if (Array.isArray(softDrinks)) {
-    softDrinks.forEach((item) => {
-      const normalized = normalizeItem(
-        {
-          ...item,
-          desc: item.desc || '',
-          img: item.img || ''
-        },
-        { cat: 'soft' }
-      );
-      if (normalized) {
-        list.push(normalized);
-      }
-    });
+function pushNormalizedItem(target, item, overrides = {}) {
+  const normalized = normalizeItem(item, overrides);
+  if (normalized) {
+    target.push(normalized);
   }
-  return list;
 }
 
-const MENU_ITEMS = buildMenuItems();
-const ITEM_MAP = MENU_ITEMS.reduce((acc, item) => {
-  acc[item.id] = item;
-  return acc;
-}, {});
-const CATEGORY_ITEMS = MENU_ITEMS.reduce((acc, item) => {
-  if (!acc[item.cat]) {
-    acc[item.cat] = [];
+function buildSection(sectionId, categories, baseItems, options = {}) {
+  const items = [];
+  const extras = Array.isArray(options.extras) ? options.extras : [];
+  const primaryItems = Array.isArray(baseItems) ? baseItems : [];
+  const sectionMeta = SECTION_META[sectionId] || { title: '' };
+  primaryItems.forEach((item) => {
+    pushNormalizedItem(items, item, { section: sectionId });
+  });
+  extras.forEach((extra) => {
+    if (!extra) {
+      return;
+    }
+    const { item, overrides = {} } = extra;
+    if (item) {
+      pushNormalizedItem(items, item, { section: sectionId, ...overrides });
+    } else {
+      pushNormalizedItem(items, extra, { section: sectionId });
+    }
+  });
+  const itemMap = {};
+  const categoryItems = {};
+  items.forEach((menuItem) => {
+    itemMap[menuItem.id] = menuItem;
+    if (!categoryItems[menuItem.cat]) {
+      categoryItems[menuItem.cat] = [];
+    }
+    categoryItems[menuItem.cat].push(menuItem);
+  });
+  const filteredCategories = Array.isArray(categories)
+    ? categories.filter((cat) => categoryItems[cat.id] && categoryItems[cat.id].length)
+    : [];
+  const defaultCategoryId = filteredCategories.length ? filteredCategories[0].id : '';
+  return {
+    id: sectionId,
+    title: sectionMeta.title,
+    categories: filteredCategories,
+    categoryItems,
+    items,
+    itemMap,
+    defaultCategoryId
+  };
+}
+
+function buildMenuSections() {
+  const sections = [];
+  const softDrinkExtras = Array.isArray(softDrinks)
+    ? softDrinks.map((drink) => ({
+        item: {
+          ...drink,
+          desc: drink.desc || '',
+          img: drink.img || ''
+        },
+        overrides: { cat: 'soft' }
+      }))
+    : [];
+  const builders = {
+    drinks: () =>
+      buildSection('drinks', rawDrinkCategories, rawDrinkItems, {
+        extras: softDrinkExtras
+      }),
+    dining: () => buildSection('dining', rawDiningCategories, rawDiningItems)
+  };
+  SECTION_ORDER.forEach((sectionId) => {
+    if (!SECTION_META[sectionId]) {
+      return;
+    }
+    const builder = builders[sectionId];
+    if (typeof builder === 'function') {
+      sections.push(builder());
+    }
+  });
+  return sections;
+}
+
+const MENU_SECTIONS = buildMenuSections();
+const SECTION_MAP = MENU_SECTIONS.reduce((acc, section) => {
+  if (section && section.id) {
+    acc[section.id] = section;
   }
-  acc[item.cat].push(item);
   return acc;
 }, {});
-const CATEGORIES = rawCategories.filter((cat) => CATEGORY_ITEMS[cat.id] && CATEGORY_ITEMS[cat.id].length);
-const DEFAULT_CATEGORY_ID = CATEGORIES.length ? CATEGORIES[0].id : '';
+const ITEM_MAP = MENU_SECTIONS.reduce((acc, section) => {
+  if (section && Array.isArray(section.items)) {
+    section.items.forEach((item) => {
+      acc[item.id] = item;
+    });
+  }
+  return acc;
+}, {});
+const TABS = MENU_SECTIONS.map((section) => ({ id: section.id, title: section.title }));
+const DEFAULT_TAB_ID = TABS.length ? TABS[0].id : '';
+const DEFAULT_SECTION = DEFAULT_TAB_ID ? SECTION_MAP[DEFAULT_TAB_ID] : null;
+const DEFAULT_CATEGORY_ID = DEFAULT_SECTION ? DEFAULT_SECTION.defaultCategoryId : '';
+const DEFAULT_CATEGORIES = DEFAULT_SECTION ? DEFAULT_SECTION.categories : [];
+const DEFAULT_VISIBLE_ITEMS =
+  DEFAULT_SECTION && DEFAULT_CATEGORY_ID ? DEFAULT_SECTION.categoryItems[DEFAULT_CATEGORY_ID] || [] : [];
 
 function formatDateTime(value) {
   if (!value) return '';
@@ -131,8 +237,12 @@ function decorateOrder(order) {
         const price = Number(item.price || 0);
         const quantity = Math.max(1, Number(item.quantity || 0));
         const amount = Number.isFinite(item.amount) ? Number(item.amount) : price * quantity;
+        const fallbackMenu = item.menuId && ITEM_MAP[item.menuId] ? ITEM_MAP[item.menuId] : null;
+        const section = normalizeSection(item.categoryType || (fallbackMenu ? fallbackMenu.section : ''));
         return {
           ...item,
+          section,
+          sectionTitle: SECTION_META[section].title,
           price,
           quantity,
           amount,
@@ -141,7 +251,17 @@ function decorateOrder(order) {
         };
       })
     : [];
+  const groupedItems = groupLinesBySection(items);
   const totalAmount = Number(order.totalAmount || 0);
+  const categoryTotals = normalizeCategoryTotals(order.categoryTotals);
+  if (items.length) {
+    const computedTotals = calculateSectionTotals(items);
+    SECTION_ORDER.forEach((section) => {
+      if (!categoryTotals[section] && computedTotals[section]) {
+        categoryTotals[section] = computedTotals[section];
+      }
+    });
+  }
   const stoneRewardRaw = Number(
     Object.prototype.hasOwnProperty.call(order, 'stoneReward') ? order.stoneReward : order.totalAmount
   );
@@ -150,6 +270,8 @@ function decorateOrder(order) {
     ...order,
     _id: id,
     items,
+    groupedItems,
+    categoryTotals,
     totalAmount,
     totalAmountLabel: formatCurrency(totalAmount),
     stoneReward,
@@ -177,13 +299,18 @@ function showConfirmDialog(options) {
 function decorateCart(cart) {
   return cart.map((line) => {
     const quantity = Math.max(1, Number(line.quantity || 1));
-    const amount = line.price * quantity;
+    const price = Number(line.price || 0);
+    const amount = price * quantity;
+    const section = normalizeSection(line.section);
     return {
       ...line,
+      section,
+      sectionTitle: SECTION_META[section].title,
+      price,
       quantity,
       amount,
       amountLabel: formatCurrency(amount),
-      priceLabel: formatCurrency(line.price)
+      priceLabel: formatCurrency(price)
     };
   });
 }
@@ -192,12 +319,43 @@ function computeCartTotal(cart) {
   return cart.reduce((sum, line) => sum + line.price * line.quantity, 0);
 }
 
+function groupLinesBySection(lines) {
+  return SECTION_ORDER.map((section) => {
+    const sectionLines = lines.filter((line) => normalizeSection(line.section) === section);
+    if (!sectionLines.length) {
+      return null;
+    }
+    return {
+      section,
+      title: SECTION_META[section].title,
+      items: sectionLines
+    };
+  }).filter(Boolean);
+}
+
+function calculateSectionTotals(lines) {
+  const totals = createEmptyCategoryTotals();
+  lines.forEach((line) => {
+    const amount = Number(line.amount);
+    const resolvedAmount = Number.isFinite(amount) ? amount : Number(line.price || 0) * Number(line.quantity || 0);
+    const section = normalizeSection(line.section);
+    if (resolvedAmount > 0) {
+      totals[section] += resolvedAmount;
+    }
+  });
+  return totals;
+}
+
 Page({
   data: {
-    categories: CATEGORIES,
+    tabs: TABS,
+    activeTab: DEFAULT_TAB_ID,
+    categories: DEFAULT_CATEGORIES,
     activeCategory: DEFAULT_CATEGORY_ID,
-    visibleItems: DEFAULT_CATEGORY_ID ? CATEGORY_ITEMS[DEFAULT_CATEGORY_ID] || [] : [],
+    visibleItems: DEFAULT_VISIBLE_ITEMS,
     cart: [],
+    cartGroups: [],
+    cartSectionTotals: createEmptyCategoryTotals(),
     cartTotal: 0,
     cartTotalLabel: formatCurrency(0),
     cartStoneReward: 0,
@@ -217,14 +375,62 @@ Page({
     this.loadOrders().finally(() => wx.stopPullDownRefresh());
   },
 
+  applySectionState(sectionId, categoryId) {
+    const section = SECTION_MAP[sectionId];
+    if (!section) {
+      this.setData({
+        categories: [],
+        activeCategory: '',
+        visibleItems: []
+      });
+      return;
+    }
+    const nextCategory = categoryId && section.categoryItems[categoryId] ? categoryId : section.defaultCategoryId;
+    this.setData({
+      categories: section.categories,
+      activeCategory: nextCategory,
+      visibleItems: nextCategory ? section.categoryItems[nextCategory] || [] : []
+    });
+  },
+
+  handleSelectTab(event) {
+    const { id } = event.currentTarget.dataset || {};
+    const tabId = typeof id === 'string' ? id : '';
+    if (!tabId || tabId === this.data.activeTab) {
+      return;
+    }
+    this.setData({ activeTab: tabId });
+    this.applySectionState(tabId);
+  },
+
   handleSelectCategory(event) {
     const { id } = event.currentTarget.dataset || {};
     if (!id || id === this.data.activeCategory) {
       return;
     }
+    const section = SECTION_MAP[this.data.activeTab];
+    if (!section || !section.categoryItems[id]) {
+      return;
+    }
     this.setData({
       activeCategory: id,
-      visibleItems: CATEGORY_ITEMS[id] || []
+      visibleItems: section.categoryItems[id] || []
+    });
+  },
+
+  updateCartState(nextCart) {
+    const decorated = decorateCart(nextCart);
+    const total = computeCartTotal(decorated);
+    const sectionTotals = calculateSectionTotals(decorated);
+    const stoneReward = Math.max(0, Math.floor(total));
+    this.setData({
+      cart: decorated,
+      cartGroups: groupLinesBySection(decorated),
+      cartSectionTotals: sectionTotals,
+      cartTotal: total,
+      cartTotalLabel: formatCurrency(total),
+      cartStoneReward: stoneReward,
+      cartStoneRewardLabel: formatStones(stoneReward)
     });
   },
 
@@ -242,7 +448,7 @@ Page({
       return;
     }
     const key = `${item.id}|${variant.label}`;
-    const cart = [...this.data.cart];
+    const cart = this.data.cart.map((line) => ({ ...line }));
     const existingIndex = cart.findIndex((line) => line.key === key);
     if (existingIndex >= 0) {
       cart[existingIndex] = {
@@ -257,19 +463,11 @@ Page({
         spec: variant.label,
         unit: variant.unit || '',
         price: variant.price,
-        quantity: 1
+        quantity: 1,
+        section: item.section
       });
     }
-    const decorated = decorateCart(cart);
-    const total = computeCartTotal(decorated);
-    const stoneReward = Math.max(0, Math.floor(total));
-    this.setData({
-      cart: decorated,
-      cartTotal: total,
-      cartTotalLabel: formatCurrency(total),
-      cartStoneReward: stoneReward,
-      cartStoneRewardLabel: formatStones(stoneReward)
-    });
+    this.updateCartState(cart);
   },
 
   handleAdjustQuantity(event) {
@@ -289,26 +487,11 @@ Page({
     } else {
       cart[index].quantity = nextQuantity;
     }
-    const decorated = decorateCart(cart);
-    const total = computeCartTotal(decorated);
-    const stoneReward = Math.max(0, Math.floor(total));
-    this.setData({
-      cart: decorated,
-      cartTotal: total,
-      cartTotalLabel: formatCurrency(total),
-      cartStoneReward: stoneReward,
-      cartStoneRewardLabel: formatStones(stoneReward)
-    });
+    this.updateCartState(cart);
   },
 
   handleClearCart() {
-    this.setData({
-      cart: [],
-      cartTotal: 0,
-      cartTotalLabel: formatCurrency(0),
-      cartStoneReward: 0,
-      cartStoneRewardLabel: formatStones(0)
-    });
+    this.updateCartState([]);
   },
 
   handleRemarkInput(event) {
@@ -327,22 +510,18 @@ Page({
       spec: line.spec,
       unit: line.unit,
       price: line.price,
-      quantity: line.quantity
+      quantity: line.quantity,
+      categoryType: line.section
     }));
     try {
       await MenuOrderService.createOrder({
         items,
-        remark: this.data.remark
+        remark: this.data.remark,
+        categoryTotals: this.data.cartSectionTotals
       });
       wx.showToast({ title: '订单已提交', icon: 'success' });
-      this.setData({
-        cart: [],
-        cartTotal: 0,
-        cartTotalLabel: formatCurrency(0),
-        cartStoneReward: 0,
-        cartStoneRewardLabel: formatStones(0),
-        remark: ''
-      });
+      this.updateCartState([]);
+      this.setData({ remark: '' });
       await this.loadOrders();
     } catch (error) {
       const message =

--- a/miniprogram/pages/membership/order/index.wxml
+++ b/miniprogram/pages/membership/order/index.wxml
@@ -1,5 +1,18 @@
 <custom-nav title="会员点餐" theme="dark"></custom-nav>
 <view class="order-page">
+  <view class="menu-tabs" wx:if="{{tabs.length}}">
+    <view
+      class="menu-tab {{activeTab === tab.id ? 'menu-tab--active' : ''}}"
+      wx:for="{{tabs}}"
+      wx:key="id"
+      wx:for-item="tab"
+      data-id="{{tab.id}}"
+      bindtap="handleSelectTab"
+    >
+      {{tab.title}}
+    </view>
+  </view>
+
   <view class="category-bar" wx:if="{{categories.length}}">
     <scroll-view scroll-x scroll-with-animation>
       <view class="category-track">
@@ -49,34 +62,39 @@
       <button class="cart-clear" size="mini" type="default" bindtap="handleClearCart">清空</button>
     </view>
     <view class="cart-list">
-      <view class="cart-item" wx:for="{{cart}}" wx:key="key" wx:for-item="cartItem">
-        <view class="cart-main">
-          <view class="cart-name">{{cartItem.title}}</view>
-          <view class="cart-spec">
-            <text class="cart-spec-price">{{cartItem.priceLabel}}{{cartItem.unit}}</text>
+      <block wx:for="{{cartGroups}}" wx:key="section" wx:for-item="group">
+        <view class="cart-group">
+          <view class="cart-group-title">{{group.title}}</view>
+          <view class="cart-item" wx:for="{{group.items}}" wx:key="key" wx:for-item="cartItem">
+            <view class="cart-main">
+              <view class="cart-name">{{cartItem.title}}</view>
+              <view class="cart-spec">
+                <text class="cart-spec-price">{{cartItem.priceLabel}}{{cartItem.unit}}</text>
+              </view>
+            </view>
+            <view class="cart-qty">
+              <button
+                class="qty-btn"
+                size="mini"
+                type="default"
+                data-key="{{cartItem.key}}"
+                data-delta="-1"
+                bindtap="handleAdjustQuantity"
+              >-</button>
+              <text class="qty-value">{{cartItem.quantity}}</text>
+              <button
+                class="qty-btn"
+                size="mini"
+                type="default"
+                data-key="{{cartItem.key}}"
+                data-delta="1"
+                bindtap="handleAdjustQuantity"
+              >+</button>
+            </view>
+            <view class="cart-amount">{{cartItem.amountLabel}}</view>
           </view>
         </view>
-        <view class="cart-qty">
-          <button
-            class="qty-btn"
-            size="mini"
-            type="default"
-            data-key="{{cartItem.key}}"
-            data-delta="-1"
-            bindtap="handleAdjustQuantity"
-          >-</button>
-          <text class="qty-value">{{cartItem.quantity}}</text>
-          <button
-            class="qty-btn"
-            size="mini"
-            type="default"
-            data-key="{{cartItem.key}}"
-            data-delta="1"
-            bindtap="handleAdjustQuantity"
-          >+</button>
-        </view>
-        <view class="cart-amount">{{cartItem.amountLabel}}</view>
-      </view>
+      </block>
     </view>
     <textarea
       class="remark-input"
@@ -105,16 +123,21 @@
         <view class="order-time">{{order.createdAtLabel}}</view>
       </view>
       <view class="order-items">
-        <view class="order-line" wx:for="{{order.items}}" wx:key="{{index}}" wx:for-item="orderLine">
-          <view class="line-main">
-            <text class="line-title">{{orderLine.title}}</text>
-            <view class="line-meta">
-              <text class="line-spec-price">{{orderLine.priceLabel}}{{orderLine.unit}}</text>
-              <text class="line-spec-quantity"> × {{orderLine.quantity}}</text>
+        <block wx:for="{{order.groupedItems}}" wx:key="section" wx:for-item="group">
+          <view class="order-group">
+            <view class="order-group-title">{{group.title}}</view>
+            <view class="order-line" wx:for="{{group.items}}" wx:key="{{index}}" wx:for-item="orderLine">
+              <view class="line-main">
+                <text class="line-title">{{orderLine.title}}</text>
+                <view class="line-meta">
+                  <text class="line-spec-price">{{orderLine.priceLabel}}{{orderLine.unit}}</text>
+                  <text class="line-spec-quantity"> × {{orderLine.quantity}}</text>
+                </view>
+              </view>
+              <text class="line-amount">{{orderLine.amountLabel}}</text>
             </view>
           </view>
-          <text class="line-amount">{{orderLine.amountLabel}}</text>
-        </view>
+        </block>
       </view>
       <view class="order-remark" wx:if="{{order.remark}}">备注：{{order.remark}}</view>
       <view class="order-summary">

--- a/miniprogram/pages/membership/order/index.wxss
+++ b/miniprogram/pages/membership/order/index.wxss
@@ -5,6 +5,27 @@
   color: #f5f6ff;
 }
 
+.menu-tabs {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.menu-tab {
+  padding: 10px 22px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #d9dcff;
+  font-size: 28rpx;
+  white-space: nowrap;
+}
+
+.menu-tab--active {
+  background: linear-gradient(135deg, #6a7cff, #4b5dff);
+  color: #fff;
+  font-weight: 600;
+}
+
 .category-bar {
   margin-bottom: 12px;
 }
@@ -140,8 +161,26 @@
 .cart-list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 0;
   margin-bottom: 16px;
+}
+
+.cart-group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.cart-group:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+
+.cart-group-title {
+  font-size: 26rpx;
+  color: rgba(255, 255, 255, 0.65);
 }
 
 .cart-item {
@@ -285,8 +324,26 @@
 .order-items {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 0;
   margin-bottom: 12px;
+}
+
+.order-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.order-group:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+
+.order-group-title {
+  font-size: 26rpx;
+  color: rgba(255, 255, 255, 0.65);
 }
 
 .order-line {

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -531,11 +531,12 @@ export const AdminService = {
 };
 
 export const MenuOrderService = {
-  async createOrder({ items = [], remark = '' } = {}) {
+  async createOrder({ items = [], remark = '', categoryTotals = {} } = {}) {
     return callCloud(CLOUD_FUNCTIONS.MENU_ORDER, {
       action: 'createOrder',
       items,
-      remark
+      remark,
+      categoryTotals
     });
   },
   async listOrders() {

--- a/miniprogram/shared/menu-data.js
+++ b/miniprogram/shared/menu-data.js
@@ -692,9 +692,143 @@ export const menuData = {
       ]
     }
   ],
+  "diningCategories": [
+    {
+      "id": "pairing",
+      "name": "下酒菜"
+    },
+    {
+      "id": "cold",
+      "name": "凉菜"
+    },
+    {
+      "id": "staple",
+      "name": "主食"
+    },
+    {
+      "id": "bbq",
+      "name": "烤串"
+    }
+  ],
+  "diningItems": [
+    {
+      "id": "pairing-nuts",
+      "cat": "pairing",
+      "title": "秘制坚果拼盘",
+      "desc": "每日烘焙腰果、扁桃仁与碧根果，佐以少量干果点缀。",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 5900
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "pairing-olive",
+      "cat": "pairing",
+      "title": "香草橄榄",
+      "desc": "西班牙青橄榄搭配初榨橄榄油与迷迭香。",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 4900
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "cold-beef",
+      "cat": "cold",
+      "title": "酱香牛肉",
+      "desc": "精选前腿肉低温卤制，入口软糯回甜。",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 8900
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "cold-salad",
+      "cat": "cold",
+      "title": "芝麻菠菜",
+      "desc": "冷拌芝麻酱菠菜，清爽解腻。",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 5900
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "staple-noodle",
+      "cat": "staple",
+      "title": "葱油拌面",
+      "desc": "手工面条佐以葱油与秘制酱油。",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 7900
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "staple-friedrice",
+      "cat": "staple",
+      "title": "松露牛油炒饭",
+      "desc": "日本越光米搭配松露酱与牛油快炒。",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 11900
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-lamb",
+      "cat": "bbq",
+      "title": "香料烤羊排",
+      "desc": "小羔羊排刷以孜然与迷迭香，现烤上桌。",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 15900
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-shrimp",
+      "cat": "bbq",
+      "title": "蒜香烤虾串",
+      "desc": "海捕大虾腌制后炭烤，蒜香浓郁。",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 6900
+        }
+      ],
+      "img": ""
+    }
+  ],
   "generatedAt": "2025-10-02T16:06:51.230Z"
 };
 export const categories = menuData.categories;
 export const items = menuData.items;
 export const softDrinks = menuData.softDrinks;
+export const diningCategories = menuData.diningCategories || [];
+export const diningItems = menuData.diningItems || [];
 export default menuData;


### PR DESCRIPTION
## Summary
- add a tabbed experience for 酒水/用餐 in the membership ordering page while grouping the cart and past orders by section
- extend the shared menu data with dining categories and dishes to populate the new 用餐 catalogue
- persist per-section totals through the client API and menu order cloud function for future financial reporting

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dfa874f5a0833085610f1708715f43