### PR TITLE
feat: add dining tab and category totals to membership ordering

### DIFF
--- a/miniprogram/pages/membership/order/index.wxml
+++ b/miniprogram/pages/membership/order/index.wxml
@@ -1,5 +1,18 @@
 <custom-nav title="会员点餐" theme="dark"></custom-nav>
 <view class="order-page">
+  <view class="menu-tabs" wx:if="{{tabs.length}}">
+    <view
+      class="menu-tab {{activeTab === tab.id ? 'menu-tab--active' : ''}}"
+      wx:for="{{tabs}}"
+      wx:key="id"
+      wx:for-item="tab"
+      data-id="{{tab.id}}"
+      bindtap="handleSelectTab"
+    >
+      {{tab.title}}
+    </view>
+  </view>
+
   <view class="category-bar" wx:if="{{categories.length}}">
     <scroll-view scroll-x scroll-with-animation>
       <view class="category-track">
@@ -49,34 +62,39 @@
       <button class="cart-clear" size="mini" type="default" bindtap="handleClearCart">清空</button>
     </view>
     <view class="cart-list">
-      <view class="cart-item" wx:for="{{cart}}" wx:key="key" wx:for-item="cartItem">
-        <view class="cart-main">
-          <view class="cart-name">{{cartItem.title}}</view>
-          <view class="cart-spec">
-            <text class="cart-spec-price">{{cartItem.priceLabel}}{{cartItem.unit}}</text>
+      <block wx:for="{{cartGroups}}" wx:key="section" wx:for-item="group">
+        <view class="cart-group">
+          <view class="cart-group-title">{{group.title}}</view>
+          <view class="cart-item" wx:for="{{group.items}}" wx:key="key" wx:for-item="cartItem">
+            <view class="cart-main">
+              <view class="cart-name">{{cartItem.title}}</view>
+              <view class="cart-spec">
+                <text class="cart-spec-price">{{cartItem.priceLabel}}{{cartItem.unit}}</text>
+              </view>
+            </view>
+            <view class="cart-qty">
+              <button
+                class="qty-btn"
+                size="mini"
+                type="default"
+                data-key="{{cartItem.key}}"
+                data-delta="-1"
+                bindtap="handleAdjustQuantity"
+              >-</button>
+              <text class="qty-value">{{cartItem.quantity}}</text>
+              <button
+                class="qty-btn"
+                size="mini"
+                type="default"
+                data-key="{{cartItem.key}}"
+                data-delta="1"
+                bindtap="handleAdjustQuantity"
+              >+</button>
+            </view>
+            <view class="cart-amount">{{cartItem.amountLabel}}</view>
           </view>
         </view>
-        <view class="cart-qty">
-          <button
-            class="qty-btn"
-            size="mini"
-            type="default"
-            data-key="{{cartItem.key}}"
-            data-delta="-1"
-            bindtap="handleAdjustQuantity"
-          >-</button>
-          <text class="qty-value">{{cartItem.quantity}}</text>
-          <button
-            class="qty-btn"
-            size="mini"
-            type="default"
-            data-key="{{cartItem.key}}"
-            data-delta="1"
-            bindtap="handleAdjustQuantity"
-          >+</button>
-        </view>
-        <view class="cart-amount">{{cartItem.amountLabel}}</view>
-      </view>
+      </block>
     </view>
     <textarea
       class="remark-input"
@@ -105,16 +123,21 @@
         <view class="order-time">{{order.createdAtLabel}}</view>
       </view>
       <view class="order-items">
-        <view class="order-line" wx:for="{{order.items}}" wx:key="{{index}}" wx:for-item="orderLine">
-          <view class="line-main">
-            <text class="line-title">{{orderLine.title}}</text>
-            <view class="line-meta">
-              <text class="line-spec-price">{{orderLine.priceLabel}}{{orderLine.unit}}</text>
-              <text class="line-spec-quantity"> × {{orderLine.quantity}}</text>
+        <block wx:for="{{order.groupedItems}}" wx:key="section" wx:for-item="group">
+          <view class="order-group">
+            <view class="order-group-title">{{group.title}}</view>
+            <view class="order-line" wx:for="{{group.items}}" wx:key="{{index}}" wx:for-item="orderLine">
+              <view class="line-main">
+                <text class="line-title">{{orderLine.title}}</text>
+                <view class="line-meta">
+                  <text class="line-spec-price">{{orderLine.priceLabel}}{{orderLine.unit}}</text>
+                  <text class="line-spec-quantity"> × {{orderLine.quantity}}</text>
+                </view>
+              </view>
+              <text class="line-amount">{{orderLine.amountLabel}}</text>
             </view>
           </view>
-          <text class="line-amount">{{orderLine.amountLabel}}</text>
-        </view>
+        </block>
       </view>
       <view class="order-remark" wx:if="{{order.remark}}">备注：{{order.remark}}</view>
       <view class="order-summary">

--- a/miniprogram/pages/membership/order/index.wxss
+++ b/miniprogram/pages/membership/order/index.wxss
@@ -5,6 +5,27 @@
   color: #f5f6ff;
 }
 
+.menu-tabs {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.menu-tab {
+  padding: 10px 22px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #d9dcff;
+  font-size: 28rpx;
+  white-space: nowrap;
+}
+
+.menu-tab--active {
+  background: linear-gradient(135deg, #6a7cff, #4b5dff);
+  color: #fff;
+  font-weight: 600;
+}
+
 .category-bar {
   margin-bottom: 12px;
 }
@@ -140,8 +161,26 @@
 .cart-list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 0;
   margin-bottom: 16px;
+}
+
+.cart-group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.cart-group:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+
+.cart-group-title {
+  font-size: 26rpx;
+  color: rgba(255, 255, 255, 0.65);
 }
 
 .cart-item {
@@ -285,8 +324,26 @@
 .order-items {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 0;
   margin-bottom: 12px;
+}
+
+.order-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.order-group:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+
+.order-group-title {
+  font-size: 26rpx;
+  color: rgba(255, 255, 255, 0.65);
 }
 
 .order-line {

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -531,11 +531,12 @@ export const AdminService = {
 };
 
 export const MenuOrderService = {
-  async createOrder({ items = [], remark = '' } = {}) {
+  async createOrder({ items = [], remark = '', categoryTotals = {} } = {}) {
     return callCloud(CLOUD_FUNCTIONS.MENU_ORDER, {
       action: 'createOrder',
       items,
-      remark
+      remark,
+      categoryTotals
     });
   },
   async listOrders() {

--- a/miniprogram/shared/menu-data.js
+++ b/miniprogram/shared/menu-data.js
@@ -692,9 +692,143 @@ export const menuData = {
       ]
     }
   ],
+  "diningCategories": [
+    {
+      "id": "pairing",
+      "name": "下酒菜"
+    },
+    {
+      "id": "cold",
+      "name": "凉菜"
+    },
+    {
+      "id": "staple",
+      "name": "主食"
+    },
+    {
+      "id": "bbq",
+      "name": "烤串"
+    }
+  ],
+  "diningItems": [
+    {
+      "id": "pairing-nuts",
+      "cat": "pairing",
+      "title": "秘制坚果拼盘",
+      "desc": "每日烘焙腰果、扁桃仁与碧根果，佐以少量干果点缀。",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 5900
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "pairing-olive",
+      "cat": "pairing",
+      "title": "香草橄榄",
+      "desc": "西班牙青橄榄搭配初榨橄榄油与迷迭香。",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 4900
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "cold-beef",
+      "cat": "cold",
+      "title": "酱香牛肉",
+      "desc": "精选前腿肉低温卤制，入口软糯回甜。",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 8900
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "cold-salad",
+      "cat": "cold",
+      "title": "芝麻菠菜",
+      "desc": "冷拌芝麻酱菠菜，清爽解腻。",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 5900
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "staple-noodle",
+      "cat": "staple",
+      "title": "葱油拌面",
+      "desc": "手工面条佐以葱油与秘制酱油。",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 7900
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "staple-friedrice",
+      "cat": "staple",
+      "title": "松露牛油炒饭",
+      "desc": "日本越光米搭配松露酱与牛油快炒。",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 11900
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-lamb",
+      "cat": "bbq",
+      "title": "香料烤羊排",
+      "desc": "小羔羊排刷以孜然与迷迭香，现烤上桌。",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 15900
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-shrimp",
+      "cat": "bbq",
+      "title": "蒜香烤虾串",
+      "desc": "海捕大虾腌制后炭烤，蒜香浓郁。",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 6900
+        }
+      ],
+      "img": ""
+    }
+  ],
   "generatedAt": "2025-10-02T16:06:51.230Z"
 };
 export const categories = menuData.categories;
 export const items = menuData.items;
 export const softDrinks = menuData.softDrinks;
+export const diningCategories = menuData.diningCategories || [];
+export const diningItems = menuData.diningItems || [];
 export default menuData;


### PR DESCRIPTION
## Summary
- add a tabbed experience for 酒水/用餐 in the membership ordering page while grouping the cart and past orders by section
- extend the shared menu data with dining categories and dishes to populate the new 用餐 catalogue
- persist per-section totals through the client API and menu order cloud function for future financial reporting
- dynamically reorder the 酒水分类 sequence based on the current time window so daytime and evening sessions surface the appropriate categories first

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dfa874f5a0833085610f1708715f43