### PR TITLE
Limit membership recent orders to last 12 hours

### DIFF
--- a/miniprogram/pages/membership/order/index.wxml
+++ b/miniprogram/pages/membership/order/index.wxml
@@ -157,8 +157,8 @@
       </view>
       <view class="order-meta" wx:if="{{order.memberConfirmedAtLabel}}">会员确认：{{order.memberConfirmedAtLabel}}</view>
     </view>
-    <view class="orders-footer" wx:if="{{hasMoreOrders}}">
-      <button class="view-more-btn" type="default" size="mini" bindtap="handleShowMoreOrders">查看更多</button>
+    <view class="orders-footer" wx:if="{{hasMoreOrders}}" bindtap="handleShowMoreOrders">
+      <text class="view-more-link">查看更多</text>
     </view>
   </view>
 </view>

--- a/miniprogram/pages/membership/order/index.wxml
+++ b/miniprogram/pages/membership/order/index.wxml
@@ -117,7 +117,7 @@
     <view class="section-title">最近订单</view>
     <view class="orders-placeholder" wx:if="{{loadingOrders}}">加载中...</view>
     <view class="orders-placeholder" wx:elif="{{!orders.length}}">暂无订单记录</view>
-    <view class="order-card" wx:for="{{orders}}" wx:key="_id" wx:for-item="order">
+    <view class="order-card" wx:for="{{displayOrders}}" wx:key="_id" wx:for-item="order">
       <view class="order-header">
         <view class="order-status">{{order.statusLabel}}</view>
         <view class="order-time">{{order.createdAtLabel}}</view>
@@ -156,6 +156,9 @@
         管理员已确认：{{order.adminConfirmedAtLabel}}
       </view>
       <view class="order-meta" wx:if="{{order.memberConfirmedAtLabel}}">会员确认：{{order.memberConfirmedAtLabel}}</view>
+    </view>
+    <view class="orders-footer" wx:if="{{hasMoreOrders}}">
+      <button class="view-more-btn" type="default" size="mini" bindtap="handleShowMoreOrders">查看更多</button>
     </view>
   </view>
 </view>

--- a/miniprogram/pages/membership/order/index.wxss
+++ b/miniprogram/pages/membership/order/index.wxss
@@ -399,6 +399,22 @@
   color: rgba(255, 255, 255, 0.75);
 }
 
+.orders-footer {
+  display: flex;
+  justify-content: center;
+  margin-top: 8px;
+}
+
+.view-more-btn {
+  min-width: 0;
+  padding: 0 28rpx;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #a2a9ff;
+  border: 1px solid rgba(162, 169, 255, 0.4);
+  font-size: 26rpx;
+}
+
 .order-summary {
   display: flex;
   flex-direction: column;

--- a/miniprogram/pages/membership/order/index.wxss
+++ b/miniprogram/pages/membership/order/index.wxss
@@ -405,14 +405,9 @@
   margin-top: 8px;
 }
 
-.view-more-btn {
-  min-width: 0;
-  padding: 0 28rpx;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.06);
-  color: #a2a9ff;
-  border: 1px solid rgba(162, 169, 255, 0.4);
+.view-more-link {
   font-size: 26rpx;
+  color: #a2a9ff;
 }
 
 .order-summary {


### PR DESCRIPTION
## Summary
- only show member menu orders from the past 12 hours by default and keep the latest order if none are recent
- add a “查看更多” control to reveal older orders along with the necessary state handling and styles

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dfb865be1883308d1737d2d7ef0c91