### PR TITLE
feat: add admin finance report view

### DIFF
--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -22,6 +22,7 @@
     "pages/admin/charge/index",
     "pages/admin/orders/index",
     "pages/admin/menu-orders/index",
+    "pages/admin/finance-report/index",
     "pages/wallet/charge-confirm/index"
   ],
   "window": {

--- a/miniprogram/pages/admin/finance-report/index.js
+++ b/miniprogram/pages/admin/finance-report/index.js
@@ -434,11 +434,6 @@ Page({
     return resolvedMonth;
   },
 
-  handleRefresh() {
-    const month = this.data.monthValue || getCurrentMonthKey();
-    this.loadReport(month);
-  },
-
   async loadReport(month) {
     const targetMonth = month || getCurrentMonthKey();
     this.setData({ loading: true });

--- a/miniprogram/pages/admin/finance-report/index.js
+++ b/miniprogram/pages/admin/finance-report/index.js
@@ -1,0 +1,300 @@
+import { AdminService } from '../../../services/api';
+import { formatCurrency, formatDate } from '../../../utils/format';
+
+const MIN_REPORT_MONTH = '2025-09';
+
+function parseMonthValue(value) {
+  if (!value) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return new Date(value.getFullYear(), value.getMonth(), 1);
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    const match = /^([0-9]{4})-([0-9]{2})$/.exec(trimmed);
+    if (match) {
+      const year = Number(match[1]);
+      const month = Number(match[2]);
+      if (Number.isInteger(year) && Number.isInteger(month) && month >= 1 && month <= 12) {
+        return new Date(year, month - 1, 1);
+      }
+    }
+  }
+  return null;
+}
+
+function formatMonthKey(date) {
+  if (!(date instanceof Date)) {
+    return '';
+  }
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  return `${year}-${month}`;
+}
+
+function normalizeMonthKey(value) {
+  const date = parseMonthValue(value);
+  if (!date) {
+    return '';
+  }
+  return formatMonthKey(date);
+}
+
+function formatMonthLabel(value) {
+  const date = parseMonthValue(value);
+  if (!date) {
+    return '';
+  }
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.toString().padStart(2, '0');
+  return `${year}年${month}月`;
+}
+
+function getCurrentMonthKey() {
+  return formatMonthKey(new Date());
+}
+
+function monthScore(value) {
+  const date = parseMonthValue(value);
+  if (!date) {
+    return NaN;
+  }
+  return date.getFullYear() * 12 + date.getMonth();
+}
+
+function clampMonthKey(value, min, max) {
+  const normalizedValue = normalizeMonthKey(value) || normalizeMonthKey(max) || normalizeMonthKey(min);
+  const normalizedMin = normalizeMonthKey(min);
+  const normalizedMax = normalizeMonthKey(max);
+  let result = normalizedValue || '';
+  if (result && normalizedMin && monthScore(result) < monthScore(normalizedMin)) {
+    result = normalizedMin;
+  }
+  if (result && normalizedMax && monthScore(result) > monthScore(normalizedMax)) {
+    result = normalizedMax;
+  }
+  return result;
+}
+
+function parseDateValue(value) {
+  if (!value) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return value;
+  }
+  if (typeof value === 'number') {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  if (typeof value === 'string') {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  if (value && typeof value.toDate === 'function') {
+    try {
+      const date = value.toDate();
+      return date instanceof Date && !Number.isNaN(date.getTime()) ? date : null;
+    } catch (error) {
+      return null;
+    }
+  }
+  if (value && typeof value === 'object') {
+    if (value.$date) {
+      return parseDateValue(value.$date);
+    }
+    if (value.time) {
+      return parseDateValue(value.time);
+    }
+  }
+  return null;
+}
+
+function formatDateTimeLabel(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return '';
+  }
+  const y = date.getFullYear();
+  const m = `${date.getMonth() + 1}`.padStart(2, '0');
+  const d = `${date.getDate()}`.padStart(2, '0');
+  const hh = `${date.getHours()}`.padStart(2, '0');
+  const mm = `${date.getMinutes()}`.padStart(2, '0');
+  return `${y}-${m}-${d} ${hh}:${mm}`;
+}
+
+function getMonthBoundaries(monthKey) {
+  const date = parseMonthValue(monthKey);
+  if (!date) {
+    return null;
+  }
+  const start = new Date(date.getFullYear(), date.getMonth(), 1);
+  const end = new Date(date.getFullYear(), date.getMonth() + 1, 1);
+  return { start, end };
+}
+
+function buildRangeLabel(range, monthKey) {
+  const start = parseDateValue(range && range.start);
+  const endExclusive = parseDateValue(range && range.end);
+  if (start && endExclusive) {
+    const endDate = new Date(endExclusive.getFullYear(), endExclusive.getMonth(), 0);
+    return `${formatDate(start)} 至 ${formatDate(endDate)}`;
+  }
+  const boundaries = getMonthBoundaries(monthKey);
+  if (boundaries) {
+    const endDate = new Date(boundaries.end.getFullYear(), boundaries.end.getMonth(), 0);
+    return `${formatDate(boundaries.start)} 至 ${formatDate(endDate)}`;
+  }
+  return '';
+}
+
+function toPositiveNumber(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return 0;
+  }
+  return Math.max(0, Math.round(numeric));
+}
+
+function buildMetrics(totals) {
+  const totalIncome = toPositiveNumber(totals.totalIncome);
+  const totalSpend = toPositiveNumber(totals.totalSpend);
+  const diningSpend = toPositiveNumber(totals.diningSpend);
+  return [
+    {
+      id: 'income',
+      label: '总收入',
+      value: totalIncome,
+      valueLabel: formatCurrency(totalIncome),
+      description: '会员充值合计'
+    },
+    {
+      id: 'spend',
+      label: '总消费',
+      value: totalSpend,
+      valueLabel: formatCurrency(totalSpend),
+      description: '会员余额支付合计'
+    },
+    {
+      id: 'dining',
+      label: '用餐消费',
+      value: diningSpend,
+      valueLabel: formatCurrency(diningSpend),
+      description: '点餐“用餐”分类消费'
+    }
+  ];
+}
+
+function buildReportState(result, fallbackMonthKey) {
+  const normalizedFallback = normalizeMonthKey(fallbackMonthKey);
+  const monthKey = normalizeMonthKey(result && result.month) || normalizedFallback;
+  const totalsSource = (result && result.totals) || {};
+  const totals = {
+    totalIncome: toPositiveNumber(totalsSource.totalIncome),
+    totalSpend: toPositiveNumber(totalsSource.totalSpend),
+    diningSpend: toPositiveNumber(totalsSource.diningSpend)
+  };
+  const monthLabel = (result && result.monthLabel) || formatMonthLabel(monthKey);
+  const rangeLabel = (result && result.rangeLabel) || buildRangeLabel(result && result.range, monthKey);
+  const generatedAtLabel = formatDateTimeLabel(parseDateValue(result && result.generatedAt));
+  return {
+    monthKey,
+    monthLabel,
+    rangeLabel,
+    generatedAtLabel,
+    metrics: buildMetrics(totals),
+    totals
+  };
+}
+
+Page({
+  data: {
+    loading: false,
+    monthValue: '',
+    displayMonthLabel: '',
+    startMonth: MIN_REPORT_MONTH,
+    endMonth: getCurrentMonthKey(),
+    metrics: [],
+    report: {
+      monthLabel: '',
+      rangeLabel: '',
+      generatedAtLabel: '',
+      totals: {
+        totalIncome: 0,
+        totalSpend: 0,
+        diningSpend: 0
+      }
+    }
+  },
+
+  onLoad() {
+    const currentMonth = getCurrentMonthKey();
+    const initialMonth = clampMonthKey(currentMonth, MIN_REPORT_MONTH, currentMonth);
+    this.setData({
+      monthValue: initialMonth,
+      displayMonthLabel: formatMonthLabel(initialMonth) || '—',
+      endMonth: currentMonth
+    });
+    this.loadReport(initialMonth);
+  },
+
+  onPullDownRefresh() {
+    const month = this.data.monthValue || getCurrentMonthKey();
+    this.loadReport(month);
+  },
+
+  handleMonthChange(event) {
+    const rawValue = event && event.detail ? event.detail.value : '';
+    const { startMonth, endMonth } = this.data;
+    const normalized = clampMonthKey(rawValue, startMonth, endMonth);
+    this.setData({
+      monthValue: normalized,
+      displayMonthLabel: formatMonthLabel(normalized) || '—'
+    });
+    this.loadReport(normalized);
+  },
+
+  handleRefresh() {
+    const month = this.data.monthValue || getCurrentMonthKey();
+    this.loadReport(month);
+  },
+
+  async loadReport(month) {
+    const targetMonth = month || getCurrentMonthKey();
+    this.setData({ loading: true });
+    try {
+      const result = await AdminService.getFinanceReport({ month: targetMonth });
+      const constraints = (result && result.constraints) || {};
+      const minMonth = constraints.minMonth || MIN_REPORT_MONTH;
+      const maxMonth = constraints.maxMonth || getCurrentMonthKey();
+      const normalizedMonth =
+        clampMonthKey(result && result.month, minMonth, maxMonth) ||
+        clampMonthKey(targetMonth, minMonth, maxMonth);
+      const reportState = buildReportState(result, normalizedMonth);
+      this.setData({
+        loading: false,
+        startMonth: minMonth,
+        endMonth: maxMonth,
+        monthValue: normalizedMonth,
+        displayMonthLabel: formatMonthLabel(normalizedMonth) || '—',
+        metrics: reportState.metrics,
+        report: {
+          monthLabel: reportState.monthLabel,
+          rangeLabel: reportState.rangeLabel,
+          generatedAtLabel: reportState.generatedAtLabel,
+          totals: reportState.totals
+        }
+      });
+    } catch (error) {
+      console.error('[finance-report] load report failed', error);
+      this.setData({ loading: false });
+      const message = (error && (error.errMsg || error.message)) || '';
+      wx.showToast({
+        title: message && message.length <= 7 ? message : '加载失败',
+        icon: 'none'
+      });
+    } finally {
+      wx.stopPullDownRefresh();
+    }
+  }
+});

--- a/miniprogram/pages/admin/finance-report/index.json
+++ b/miniprogram/pages/admin/finance-report/index.json
@@ -1,0 +1,6 @@
+{
+  "navigationBarTitleText": "财务报表",
+  "usingComponents": {
+    "custom-nav": "/components/custom-nav/custom-nav"
+  }
+}

--- a/miniprogram/pages/admin/finance-report/index.wxml
+++ b/miniprogram/pages/admin/finance-report/index.wxml
@@ -1,0 +1,55 @@
+<custom-nav title="财务报表" theme="dark"></custom-nav>
+<view class="report-page">
+  <view class="filters">
+    <view class="month-picker">
+      <view class="picker-label">统计月份</view>
+      <picker
+        mode="date"
+        fields="month"
+        value="{{monthValue}}"
+        start="{{startMonth}}"
+        end="{{endMonth}}"
+        bindchange="handleMonthChange"
+      >
+        <view class="picker-trigger">
+          <text class="picker-value">{{report.monthLabel || displayMonthLabel}}</text>
+          <text class="picker-arrow">▾</text>
+        </view>
+      </picker>
+    </view>
+    <button
+      class="refresh-btn"
+      size="mini"
+      type="primary"
+      loading="{{loading}}"
+      bindtap="handleRefresh"
+    >刷新</button>
+  </view>
+
+  <view class="summary-card">
+    <view class="summary-month">{{report.monthLabel || displayMonthLabel}}</view>
+    <view class="summary-range" wx:if="{{report.rangeLabel}}">{{report.rangeLabel}}</view>
+    <view class="summary-updated" wx:if="{{report.generatedAtLabel}}">更新于 {{report.generatedAtLabel}}</view>
+  </view>
+
+  <view class="loading" wx:if="{{loading}}">报表加载中...</view>
+
+  <view class="metrics" wx:if="{{!loading && metrics.length}}">
+    <block wx:for="{{metrics}}" wx:key="id">
+      <view class="metric-card">
+        <view class="metric-label">{{item.label}}</view>
+        <view class="metric-value">{{item.valueLabel}}</view>
+        <view class="metric-desc" wx:if="{{item.description}}">{{item.description}}</view>
+      </view>
+    </block>
+  </view>
+
+  <view class="empty" wx:if="{{!loading && !metrics.length}}">
+    暂无数据
+  </view>
+
+  <view class="notes">
+    <view class="note-line">报表仅统计会员钱包交易，已过滤管理员账号的数据。</view>
+    <view class="note-line">用餐费用来自点餐中“用餐”分类的实际扣费。</view>
+  </view>
+</view>

--- a/miniprogram/pages/admin/finance-report/index.wxml
+++ b/miniprogram/pages/admin/finance-report/index.wxml
@@ -30,13 +30,6 @@
         </block>
       </view>
     </view>
-    <button
-      class="refresh-btn"
-      size="mini"
-      type="primary"
-      loading="{{loading}}"
-      bindtap="handleRefresh"
-    >刷新</button>
   </view>
 
   <view class="summary-card">

--- a/miniprogram/pages/admin/finance-report/index.wxml
+++ b/miniprogram/pages/admin/finance-report/index.wxml
@@ -1,21 +1,34 @@
 <custom-nav title="财务报表" theme="dark"></custom-nav>
 <view class="report-page">
   <view class="filters">
-    <view class="month-picker">
-      <view class="picker-label">统计月份</view>
-      <picker
-        mode="date"
-        fields="month"
-        value="{{monthValue}}"
-        start="{{startMonth}}"
-        end="{{endMonth}}"
-        bindchange="handleMonthChange"
-      >
-        <view class="picker-trigger">
-          <text class="picker-value">{{report.monthLabel || displayMonthLabel}}</text>
-          <text class="picker-arrow">▾</text>
-        </view>
-      </picker>
+    <view class="month-selector">
+      <view class="year-picker">
+        <view class="picker-label">统计年份</view>
+        <picker
+          mode="selector"
+          range="{{yearOptions}}"
+          range-key="label"
+          value="{{selectedYearIndex}}"
+          disabled="{{!yearOptions.length}}"
+          bindchange="handleYearChange"
+        >
+          <view class="picker-trigger">
+            <text class="picker-value">{{selectedYearLabel || '—'}}</text>
+            <text class="picker-arrow">▾</text>
+          </view>
+        </picker>
+      </view>
+      <view class="month-grid" wx:if="{{visibleMonths.length}}">
+        <block wx:for="{{visibleMonths}}" wx:key="key">
+          <view
+            class="month-item {{item.active ? 'month-item--active' : ''}}"
+            data-month="{{item.key}}"
+            bindtap="handleMonthTap"
+          >
+            {{item.label}}
+          </view>
+        </block>
+      </view>
     </view>
     <button
       class="refresh-btn"

--- a/miniprogram/pages/admin/finance-report/index.wxss
+++ b/miniprogram/pages/admin/finance-report/index.wxss
@@ -8,13 +8,19 @@
 
 .filters {
   display: flex;
-  align-items: flex-end;
+  align-items: flex-start;
   gap: 12px;
   margin-bottom: 18px;
 }
 
-.month-picker {
+.month-selector {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.year-picker {
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -29,10 +35,38 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  width: 100%;
   padding: 14px 18px;
   border-radius: 14px;
   background: rgba(16, 20, 48, 0.85);
   border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.month-grid {
+  display: flex;
+  flex-wrap: wrap;
+  margin: -8rpx;
+}
+
+.month-item {
+  flex: 0 0 calc(25% - 16rpx);
+  margin: 8rpx;
+  padding: 16rpx 0;
+  border-radius: 12px;
+  box-sizing: border-box;
+  text-align: center;
+  background: rgba(16, 20, 48, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 26rpx;
+  color: rgba(255, 255, 255, 0.75);
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.month-item--active {
+  background: linear-gradient(140deg, rgba(70, 111, 255, 0.9), rgba(118, 146, 255, 0.95));
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, 0.85);
+  font-weight: 600;
 }
 
 .picker-value {

--- a/miniprogram/pages/admin/finance-report/index.wxss
+++ b/miniprogram/pages/admin/finance-report/index.wxss
@@ -1,0 +1,136 @@
+.report-page {
+  min-height: 100vh;
+  padding: 16px;
+  background: #070a1a;
+  color: #f5f6ff;
+  box-sizing: border-box;
+}
+
+.filters {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.month-picker {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.picker-label {
+  font-size: 24rpx;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.picker-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-radius: 14px;
+  background: rgba(16, 20, 48, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.picker-value {
+  font-size: 30rpx;
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.picker-arrow {
+  font-size: 28rpx;
+  color: rgba(255, 255, 255, 0.5);
+  margin-left: 8px;
+}
+
+.refresh-btn {
+  flex-shrink: 0;
+  height: 60rpx;
+  line-height: 60rpx;
+  padding: 0 24px;
+  border-radius: 14px;
+}
+
+.summary-card {
+  background: rgba(16, 20, 48, 0.85);
+  border-radius: 18px;
+  padding: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  margin-bottom: 20px;
+}
+
+.summary-month {
+  font-size: 34rpx;
+  font-weight: 600;
+  color: #ffffff;
+  margin-bottom: 6px;
+}
+
+.summary-range {
+  font-size: 26rpx;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.summary-updated {
+  margin-top: 6px;
+  font-size: 24rpx;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.loading,
+.empty {
+  text-align: center;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 26rpx;
+  margin: 26px 0;
+}
+
+.metrics {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.metric-card {
+  background: rgba(16, 20, 48, 0.82);
+  border-radius: 16px;
+  padding: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.metric-label {
+  font-size: 26rpx;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.metric-value {
+  margin-top: 8px;
+  font-size: 38rpx;
+  font-weight: 600;
+  color: #f7d774;
+}
+
+.metric-desc {
+  margin-top: 6px;
+  font-size: 24rpx;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.notes {
+  margin-top: 24px;
+  padding: 16px;
+  border-radius: 16px;
+  background: rgba(16, 20, 48, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  font-size: 24rpx;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.65);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}

--- a/miniprogram/pages/admin/finance-report/index.wxss
+++ b/miniprogram/pages/admin/finance-report/index.wxss
@@ -7,14 +7,10 @@
 }
 
 .filters {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
   margin-bottom: 18px;
 }
 
 .month-selector {
-  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -43,30 +39,27 @@
 }
 
 .month-grid {
-  display: flex;
-  flex-wrap: wrap;
-  margin: -8rpx;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12rpx;
 }
 
 .month-item {
-  flex: 0 0 calc(25% - 16rpx);
-  margin: 8rpx;
   padding: 16rpx 0;
   border-radius: 12px;
-  box-sizing: border-box;
   text-align: center;
   background: rgba(16, 20, 48, 0.65);
   border: 1px solid rgba(255, 255, 255, 0.08);
   font-size: 26rpx;
   color: rgba(255, 255, 255, 0.75);
+  font-weight: 500;
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
 .month-item--active {
-  background: linear-gradient(140deg, rgba(70, 111, 255, 0.9), rgba(118, 146, 255, 0.95));
+  background: rgba(70, 111, 255, 0.25);
+  border-color: rgba(102, 135, 255, 0.9);
   color: #ffffff;
-  border-color: rgba(255, 255, 255, 0.85);
-  font-weight: 600;
 }
 
 .picker-value {
@@ -79,14 +72,6 @@
   font-size: 28rpx;
   color: rgba(255, 255, 255, 0.5);
   margin-left: 8px;
-}
-
-.refresh-btn {
-  flex-shrink: 0;
-  height: 60rpx;
-  line-height: 60rpx;
-  padding: 0 24px;
-  border-radius: 14px;
 }
 
 .summary-card {

--- a/miniprogram/pages/admin/index.js
+++ b/miniprogram/pages/admin/index.js
@@ -26,6 +26,12 @@ const BASE_ACTIONS = [
     url: '/pages/admin/orders/index'
   },
   {
+    icon: '💹',
+    label: '财务报表',
+    description: '查看月度收入与消费统计',
+    url: '/pages/admin/finance-report/index'
+  },
+  {
     icon: '🏠',
     label: '预约审核',
     description: '查看并审核包房预约申请',

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -527,6 +527,15 @@ export const AdminService = {
     return callCloud(CLOUD_FUNCTIONS.ADMIN, {
       action: 'markReservationRead'
     });
+  },
+  async getFinanceReport({ month = '' } = {}) {
+    const payload = {
+      action: 'getFinanceReport'
+    };
+    if (month) {
+      payload.month = month;
+    }
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, payload);
   }
 };
 


### PR DESCRIPTION
## Summary
- add a cloud function endpoint that aggregates monthly wallet totals and menu dining spend while skipping admin accounts
- create a finance report page in the admin panel with month filtering and formatted metrics
- register the new admin screen in the mini program navigation and expose a service helper for it

## Testing
- not run (Mini Program UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dfbe235b1483309de8ed0c3f4875b3