### PR TITLE
feat: support cancelling menu orders and annotate force charge

### DIFF
--- a/cloudfunctions/menuOrder/index.js
+++ b/cloudfunctions/menuOrder/index.js
@@ -103,10 +103,14 @@ exports.main = async (event) => {
       return listMemberOrders(OPENID);
     case 'confirmMemberOrder':
       return confirmMemberOrder(OPENID, event.orderId);
+    case 'cancelMemberOrder':
+      return cancelMemberOrder(OPENID, event.orderId, event.remark || event.reason || '');
     case 'listPrepOrders':
       return listPrepOrders(OPENID, event.status || 'submitted', event.pageSize || 100);
     case 'markOrderReady':
       return markOrderReady(OPENID, event.orderId, event.remark || '');
+    case 'cancelOrder':
+      return cancelOrder(OPENID, event.orderId, event.remark || event.reason || '');
     default:
       throw new Error(`Unknown action: ${action}`);
   }
@@ -281,7 +285,7 @@ async function listPrepOrders(openid, status = 'submitted', pageSize = 100) {
   const normalizedSize = Math.min(Math.max(Number(pageSize) || 20, 1), 200);
   let statuses;
   if (status === 'all') {
-    statuses = ['submitted', 'pendingMember'];
+    statuses = ['submitted', 'pendingMember', 'cancelled'];
   } else if (status === 'pendingMember') {
     statuses = ['pendingMember'];
   } else {
@@ -445,6 +449,86 @@ async function confirmMemberOrder(openid, orderId) {
   return { order: orderSnapshot, experienceGain, stoneReward };
 }
 
+async function cancelOrder(openid, orderId, remarkInput = '') {
+  await ensureAdmin(openid);
+  return cancelMenuOrder(openid, orderId, remarkInput, { role: 'admin' });
+}
+
+async function cancelMemberOrder(openid, orderId, remarkInput = '') {
+  return cancelMenuOrder(openid, orderId, remarkInput, { role: 'member' });
+}
+
+async function cancelMenuOrder(actorId, orderId, remarkInput = '', { role } = {}) {
+  if (!orderId) {
+    throw new Error('缺少订单编号');
+  }
+  const normalizedRole = role === 'admin' ? 'admin' : 'member';
+  const remark = normalizeRemark(remarkInput, 200);
+  const now = new Date();
+  let orderSnapshot = null;
+  await Promise.all([
+    ensureCollection(COLLECTIONS.MENU_ORDERS),
+    ensureCollection(COLLECTIONS.CHARGE_ORDERS)
+  ]);
+  await db.runTransaction(async (transaction) => {
+    const orderRef = transaction.collection(COLLECTIONS.MENU_ORDERS).doc(orderId);
+    const snapshot = await orderRef.get().catch(() => null);
+    if (!snapshot || !snapshot.data) {
+      throw new Error('订单不存在');
+    }
+    const order = snapshot.data;
+    if (order.status === 'paid') {
+      throw new Error('订单已完成，无法取消');
+    }
+    if (order.status === 'cancelled') {
+      orderSnapshot = mapOrder({ _id: orderId, ...order });
+      return;
+    }
+    if (normalizedRole === 'member') {
+      if (order.memberId !== actorId) {
+        throw new Error('无法操作该订单');
+      }
+      if (order.status !== 'pendingMember') {
+        throw new Error('订单当前不可取消');
+      }
+    } else if (!['submitted', 'pendingMember'].includes(order.status)) {
+      throw new Error('订单当前不可取消');
+    }
+    const cancelRemark = remark || (normalizedRole === 'admin' ? '管理员取消订单' : '会员取消订单');
+    const cancelReason = normalizedRole === 'admin' ? 'adminCancelled' : 'memberCancelled';
+    const updates = {
+      status: 'cancelled',
+      cancelledAt: now,
+      cancelledBy: actorId,
+      cancelledByRole: normalizedRole,
+      cancelRemark,
+      cancelReason,
+      updatedAt: now
+    };
+    await orderRef.update({ data: updates });
+    const chargeOrderId = typeof order.chargeOrderId === 'string' ? order.chargeOrderId.trim() : '';
+    if (chargeOrderId) {
+      const chargeOrderRef = transaction.collection(COLLECTIONS.CHARGE_ORDERS).doc(chargeOrderId);
+      const chargeSnapshot = await chargeOrderRef.get().catch(() => null);
+      if (chargeSnapshot && chargeSnapshot.data) {
+        await chargeOrderRef
+          .update({
+            data: {
+              status: 'cancelled',
+              updatedAt: now,
+              cancelRemark,
+              cancelledBy: actorId,
+              cancelledByRole: normalizedRole
+            }
+          })
+          .catch(() => null);
+      }
+    }
+    orderSnapshot = mapOrder({ _id: orderId, ...order, ...updates });
+  });
+  return { order: orderSnapshot };
+}
+
 async function ensureMember(openid) {
   if (!openid) {
     throw new Error('未获取到用户身份');
@@ -567,7 +651,12 @@ function mapOrder(doc) {
     updatedAt: doc.updatedAt || null,
     adminConfirmedAt: doc.adminConfirmedAt || null,
     memberConfirmedAt: doc.memberConfirmedAt || null,
-    chargeOrderId: doc.chargeOrderId || ''
+    chargeOrderId: doc.chargeOrderId || '',
+    cancelRemark: doc.cancelRemark || '',
+    cancelReason: doc.cancelReason || '',
+    cancelledAt: doc.cancelledAt || null,
+    cancelledBy: doc.cancelledBy || '',
+    cancelledByRole: doc.cancelledByRole || ''
   };
 }
 

--- a/miniprogram/pages/admin/menu-orders/index.wxml
+++ b/miniprogram/pages/admin/menu-orders/index.wxml
@@ -24,6 +24,10 @@
     <view class="order-meta">会员：{{order.memberSnapshot && order.memberSnapshot.nickName ? order.memberSnapshot.nickName : '未知'}}</view>
     <view class="order-meta">提交时间：{{order.createdAtLabel}}</view>
     <view class="order-meta" wx:if="{{order.remark}}">备注：{{order.remark}}</view>
+    <view class="order-meta" wx:if="{{order.adminRemark}}">管理员备注：{{order.adminRemark}}</view>
+    <view class="order-meta order-meta--cancel" wx:if="{{order.status === 'cancelled' && order.cancelRemark}}">取消说明：{{order.cancelRemark}}</view>
+    <view class="order-meta order-meta--cancel" wx:if="{{order.status === 'cancelled' && order.cancelledAtLabel}}">取消时间：{{order.cancelledAtLabel}}</view>
+    <view class="order-meta order-meta--cancel" wx:if="{{order.status === 'cancelled' && order.cancelledByLabel}}">取消方：{{order.cancelledByLabel}}</view>
     <view class="order-items">
       <view class="order-line" wx:for="{{order.items}}" wx:key="{{index}}" wx:for-item="orderItem">
         <view class="line-main">
@@ -45,9 +49,19 @@
       wx:if="{{order.status === 'submitted'}}"
       class="action-btn"
       type="primary"
-      loading="{{processingId === order._id}}"
+      loading="{{processingId === order._id && processingAction === 'ready'}}"
+      disabled="{{!!processingId && processingId !== order._id}}"
       data-id="{{order._id}}"
       bindtap="handleMarkReady"
     >推送给会员</button>
+    <button
+      wx:if="{{order.canCancel}}"
+      class="action-btn action-btn--cancel"
+      type="default"
+      loading="{{processingId === order._id && processingAction === 'cancel'}}"
+      disabled="{{!!processingId && processingId !== order._id}}"
+      data-id="{{order._id}}"
+      bindtap="handleCancelOrder"
+    >取消订单</button>
   </view>
 </view>

--- a/miniprogram/pages/admin/menu-orders/index.wxss
+++ b/miniprogram/pages/admin/menu-orders/index.wxss
@@ -126,3 +126,12 @@
 .action-btn {
   margin-top: 8px;
 }
+
+.action-btn--cancel {
+  color: #ffb6b6;
+  border: 1px solid rgba(255, 182, 182, 0.4);
+}
+
+.order-meta--cancel {
+  color: rgba(255, 150, 150, 0.8);
+}

--- a/miniprogram/pages/admin/orders/index.wxml
+++ b/miniprogram/pages/admin/orders/index.wxml
@@ -90,45 +90,70 @@
     <view class="force-dialog">
       <view class="force-dialog__title">关联会员</view>
       <view class="force-dialog__body">
-        <view class="force-dialog__search">
-          <input
-            class="force-dialog__input"
-            placeholder="输入昵称 / 手机号 / 编号"
-            value="{{forceChargeDialog.keyword}}"
-            confirm-type="search"
-            bindinput="handleForceChargeMemberInput"
-            bindconfirm="handleForceChargeMemberSearch"
-          />
-          <button class="force-dialog__search-btn" size="mini" bindtap="handleForceChargeMemberSearch">
-            搜索
-          </button>
-        </view>
-        <view class="force-dialog__error" wx:if="{{forceChargeDialog.error}}">{{forceChargeDialog.error}}</view>
-        <view class="force-dialog__results">
-          <view class="force-dialog__loading" wx:if="{{forceChargeDialog.loading}}">搜索中...</view>
-          <view
-            class="force-dialog__empty"
-            wx:elif="{{!forceChargeDialog.loading && (!forceChargeDialog.results.length)}}"
-          >
-            请输入关键词搜索会员
+        <block wx:if="{{!forceChargeDialog.memberLocked}}">
+          <view class="force-dialog__search">
+            <input
+              class="force-dialog__input"
+              placeholder="输入昵称 / 手机号 / 编号"
+              value="{{forceChargeDialog.keyword}}"
+              confirm-type="search"
+              bindinput="handleForceChargeMemberInput"
+              bindconfirm="handleForceChargeMemberSearch"
+            />
+            <button class="force-dialog__search-btn" size="mini" bindtap="handleForceChargeMemberSearch">
+              搜索
+            </button>
           </view>
-          <block wx:else>
+          <view class="force-dialog__error" wx:if="{{forceChargeDialog.error}}">{{forceChargeDialog.error}}</view>
+          <view class="force-dialog__results">
+            <view class="force-dialog__loading" wx:if="{{forceChargeDialog.loading}}">搜索中...</view>
             <view
-              class="force-dialog__member {{forceChargeDialog.selectedMemberId === member._id ? 'is-active' : ''}}"
-              wx:for="{{forceChargeDialog.results}}"
-              wx:for-item="member"
-              wx:key="_id"
-              data-id="{{member._id}}"
-              bindtap="handleSelectForceChargeMember"
+              class="force-dialog__empty"
+              wx:elif="{{!forceChargeDialog.loading && (!forceChargeDialog.results.length)}}"
             >
-              <view class="member-name">{{member.nickName || '未命名'}}</view>
-              <view class="member-meta">
-                <text wx:if="{{member.mobile}}">{{member.mobile}}</text>
-                <text wx:if="{{member.levelName}}">{{member.levelName}}</text>
-                <text>余额：{{member.balanceLabel}}</text>
-              </view>
+              请输入关键词搜索会员
             </view>
-          </block>
+            <block wx:else>
+              <view
+                class="force-dialog__member {{forceChargeDialog.selectedMemberId === member._id ? 'is-active' : ''}}"
+                wx:for="{{forceChargeDialog.results}}"
+                wx:for-item="member"
+                wx:key="_id"
+                data-id="{{member._id}}"
+                bindtap="handleSelectForceChargeMember"
+              >
+                <view class="member-name">{{member.nickName || '未命名'}}</view>
+                <view class="member-meta">
+                  <text wx:if="{{member.mobile}}">{{member.mobile}}</text>
+                  <text wx:if="{{member.levelName}}">{{member.levelName}}</text>
+                  <text>余额：{{member.balanceLabel}}</text>
+                </view>
+              </view>
+            </block>
+          </view>
+        </block>
+        <block wx:else>
+          <view class="force-dialog__locked">
+            <view class="member-name">{{(forceChargeDialog.memberInfo && forceChargeDialog.memberInfo.nickName) || '未命名'}}</view>
+            <view class="member-meta">
+              <text wx:if="{{forceChargeDialog.memberInfo && forceChargeDialog.memberInfo.mobile}}">{{forceChargeDialog.memberInfo.mobile}}</text>
+              <text wx:if="{{forceChargeDialog.memberInfo && forceChargeDialog.memberInfo.levelName}}">{{forceChargeDialog.memberInfo.levelName}}</text>
+              <text wx:if="{{forceChargeDialog.memberInfo && forceChargeDialog.memberInfo.balanceLabel}}">
+                余额：{{forceChargeDialog.memberInfo.balanceLabel}}
+              </text>
+            </view>
+            <view class="force-dialog__hint">将对以上会员扣除订单金额</view>
+          </view>
+        </block>
+        <view class="force-dialog__remark">
+          <textarea
+            class="force-dialog__remark-input"
+            placeholder="扣款备注（可选，会员可见）"
+            maxlength="140"
+            value="{{forceChargeDialog.remark}}"
+            bindinput="handleForceChargeRemarkInput"
+          ></textarea>
+          <view class="force-dialog__remark-hint">备注将展示在会员消费记录中，亦可说明改价原因</view>
         </view>
       </view>
       <view class="force-dialog__footer">
@@ -138,7 +163,7 @@
           size="mini"
           type="primary"
           loading="{{forceChargingId && forceChargeDialog.orderId === forceChargingId}}"
-          disabled="{{!forceChargeDialog.selectedMemberId || forceChargingId}}"
+          disabled="{{( !forceChargeDialog.memberLocked && !forceChargeDialog.selectedMemberId) || forceChargingId}}"
           bindtap="handleConfirmForceChargeWithMember"
         >确认扣款</button>
       </view>

--- a/miniprogram/pages/admin/orders/index.wxss
+++ b/miniprogram/pages/admin/orders/index.wxss
@@ -301,6 +301,21 @@ page {
   gap: 16rpx;
 }
 
+.force-dialog__locked {
+  background: rgba(30, 41, 59, 0.6);
+  border-radius: 18rpx;
+  padding: 24rpx 28rpx;
+  display: flex;
+  flex-direction: column;
+  gap: 12rpx;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.force-dialog__hint {
+  font-size: 22rpx;
+  color: rgba(148, 163, 184, 0.85);
+}
+
 .force-dialog__loading,
 .force-dialog__empty {
   text-align: center;
@@ -336,6 +351,27 @@ page {
   gap: 12rpx 20rpx;
   font-size: 22rpx;
   color: rgba(203, 213, 225, 0.85);
+}
+
+.force-dialog__remark {
+  display: flex;
+  flex-direction: column;
+  gap: 12rpx;
+}
+
+.force-dialog__remark-input {
+  min-height: 120rpx;
+  padding: 16rpx 20rpx;
+  border-radius: 16rpx;
+  background: rgba(15, 23, 42, 0.6);
+  color: #f8fafc;
+  font-size: 24rpx;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+}
+
+.force-dialog__remark-hint {
+  font-size: 22rpx;
+  color: rgba(148, 163, 184, 0.75);
 }
 
 .force-dialog__footer {

--- a/miniprogram/pages/membership/order/index.js
+++ b/miniprogram/pages/membership/order/index.js
@@ -342,6 +342,18 @@ function decorateOrder(order) {
   );
   const stoneReward = Math.max(0, Math.floor(stoneRewardRaw));
   const createdAtTimestamp = resolveTimestamp(order.createdAt);
+  const adminRemark = typeof order.adminRemark === 'string' ? order.adminRemark : '';
+  const cancelRemark = typeof order.cancelRemark === 'string' ? order.cancelRemark : '';
+  const cancelledAtLabel = formatDateTime(order.cancelledAt);
+  const cancelledByRole = typeof order.cancelledByRole === 'string' ? order.cancelledByRole : '';
+  let cancelledByLabel = '';
+  if (cancelledByRole === 'admin') {
+    cancelledByLabel = '管理员';
+  } else if (cancelledByRole === 'member') {
+    cancelledByLabel = '会员';
+  }
+  const canConfirm = order.status === 'pendingMember';
+  const canCancel = order.status === 'pendingMember';
   return {
     ...order,
     _id: id,
@@ -356,7 +368,13 @@ function decorateOrder(order) {
     createdAtLabel: formatDateTime(order.createdAt),
     adminConfirmedAtLabel: formatDateTime(order.adminConfirmedAt),
     memberConfirmedAtLabel: formatDateTime(order.memberConfirmedAt),
-    createdAtTimestamp
+    cancelledAtLabel,
+    cancelledByLabel,
+    adminRemark,
+    cancelRemark,
+    createdAtTimestamp,
+    canConfirm,
+    canCancel
   };
 }
 
@@ -444,7 +462,8 @@ Page({
     displayOrders: [],
     hasMoreOrders: false,
     showingAllOrders: false,
-    confirmingId: ''
+    confirmingId: '',
+    cancellingId: ''
   },
 
   onLoad() {
@@ -705,6 +724,38 @@ Page({
       });
     } finally {
       this.setData({ confirmingId: '' });
+    }
+  },
+
+  async handleCancelOrder(event) {
+    const { id } = event.currentTarget.dataset || {};
+    if (!id || this.data.cancellingId === id) {
+      return;
+    }
+    const result = await showConfirmDialog({
+      title: '取消订单',
+      content: '确定取消本次消费吗？',
+      confirmText: '确认取消'
+    });
+    if (!result.confirm) {
+      return;
+    }
+    this.setData({ cancellingId: id });
+    try {
+      await MenuOrderService.cancelOrder(id);
+      wx.showToast({ title: '订单已取消', icon: 'success' });
+      await this.loadOrders();
+    } catch (error) {
+      const message =
+        (error && (error.errMsg || error.message))
+          ? String(error.errMsg || error.message)
+          : '取消失败';
+      wx.showToast({
+        title: message.length > 14 ? `${message.slice(0, 13)}…` : message,
+        icon: 'none'
+      });
+    } finally {
+      this.setData({ cancellingId: '' });
     }
   },
 

--- a/miniprogram/pages/membership/order/index.wxml
+++ b/miniprogram/pages/membership/order/index.wxml
@@ -140,18 +140,38 @@
         </block>
       </view>
       <view class="order-remark" wx:if="{{order.remark}}">备注：{{order.remark}}</view>
+      <view class="order-remark admin" wx:if="{{order.adminRemark}}">管理员备注：{{order.adminRemark}}</view>
+      <view class="order-meta order-meta--cancel" wx:if="{{order.status === 'cancelled' && order.cancelRemark}}">
+        取消说明：{{order.cancelRemark}}
+      </view>
+      <view class="order-meta order-meta--cancel" wx:if="{{order.status === 'cancelled' && order.cancelledAtLabel}}">
+        取消时间：{{order.cancelledAtLabel}}
+      </view>
+      <view class="order-meta order-meta--cancel" wx:if="{{order.status === 'cancelled' && order.cancelledByLabel}}">
+        取消方：{{order.cancelledByLabel}}
+      </view>
       <view class="order-summary">
         <view class="order-total">合计 {{order.totalAmountLabel}}</view>
         <view class="order-stones">送 {{order.stoneRewardLabel}} 灵石</view>
       </view>
       <button
-        wx:if="{{order.status === 'pendingMember'}}"
+        wx:if="{{order.canConfirm}}"
         class="confirm-btn"
         type="primary"
         loading="{{confirmingId === order._id}}"
+        disabled="{{(!!cancellingId && cancellingId !== order._id)}}"
         data-id="{{order._id}}"
         bindtap="handleConfirmOrder"
       >确认扣费</button>
+      <button
+        wx:if="{{order.canCancel}}"
+        class="cancel-btn"
+        type="default"
+        loading="{{cancellingId === order._id}}"
+        disabled="{{(!!confirmingId && confirmingId !== order._id)}}"
+        data-id="{{order._id}}"
+        bindtap="handleCancelOrder"
+      >取消订单</button>
       <view class="order-meta" wx:if="{{order.adminConfirmedAtLabel && order.status !== 'submitted'}}">
         管理员已确认：{{order.adminConfirmedAtLabel}}
       </view>

--- a/miniprogram/pages/membership/order/index.wxss
+++ b/miniprogram/pages/membership/order/index.wxss
@@ -399,6 +399,10 @@
   color: rgba(255, 255, 255, 0.75);
 }
 
+.order-remark.admin {
+  color: rgba(255, 231, 188, 0.9);
+}
+
 .orders-footer {
   display: flex;
   justify-content: center;
@@ -431,8 +435,18 @@
   margin-top: 8px;
 }
 
+.cancel-btn {
+  margin-top: 8px;
+  color: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
 .order-meta {
   font-size: 22rpx;
   color: rgba(255, 255, 255, 0.55);
   margin-top: 4px;
+}
+
+.order-meta--cancel {
+  color: rgba(255, 160, 160, 0.85);
 }

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -564,6 +564,13 @@ export const MenuOrderService = {
       throw error;
     }
     return result;
+  },
+  async cancelOrder(orderId, remark = '') {
+    return callCloud(CLOUD_FUNCTIONS.MENU_ORDER, {
+      action: 'cancelMemberOrder',
+      orderId,
+      remark
+    });
   }
 };
 
@@ -578,6 +585,13 @@ export const AdminMenuOrderService = {
   async markOrderReady(orderId, remark = '') {
     return callCloud(CLOUD_FUNCTIONS.MENU_ORDER, {
       action: 'markOrderReady',
+      orderId,
+      remark
+    });
+  },
+  async cancelOrder(orderId, remark = '') {
+    return callCloud(CLOUD_FUNCTIONS.MENU_ORDER, {
+      action: 'cancelOrder',
       orderId,
       remark
     });


### PR DESCRIPTION
## Summary
- allow admins to cancel menu orders and propagate cancellation metadata across related charge orders
- expose order cancellation actions to the member mini program and show cancellation details in the recent orders list
- enhance the forced charge flow with optional remarks and updated admin prep UI actions

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dfe17c65d48330be0d87aeed7ab402