### PR TITLE
Adjust admin order action buttons layout

### DIFF
--- a/miniprogram/pages/admin/menu-orders/index.wxml
+++ b/miniprogram/pages/admin/menu-orders/index.wxml
@@ -54,23 +54,28 @@
     </view>
     <view class="order-meta" wx:if="{{order.adminConfirmedAtLabel}}">管理员确认：{{order.adminConfirmedAtLabel}}</view>
     <view class="order-meta" wx:if="{{order.memberConfirmedAtLabel}}">会员确认：{{order.memberConfirmedAtLabel}}</view>
-    <button
-      wx:if="{{order.status === 'submitted'}}"
-      class="action-btn"
-      type="primary"
-      loading="{{processingId === order._id && processingAction === 'ready'}}"
-      disabled="{{!!processingId && processingId !== order._id}}"
-      data-id="{{order._id}}"
-      bindtap="handleMarkReady"
-    >推送给会员</button>
-    <button
-      wx:if="{{order.canCancel}}"
-      class="action-btn action-btn--cancel"
-      type="default"
-      loading="{{processingId === order._id && processingAction === 'cancel'}}"
-      disabled="{{!!processingId && processingId !== order._id}}"
-      data-id="{{order._id}}"
-      bindtap="handleCancelOrder"
-    >取消订单</button>
+    <view
+      class="action-buttons"
+      wx:if="{{order.status === 'submitted' || order.canCancel}}"
+    >
+      <button
+        wx:if="{{order.status === 'submitted'}}"
+        class="action-btn"
+        type="primary"
+        loading="{{processingId === order._id && processingAction === 'ready'}}"
+        disabled="{{!!processingId && processingId !== order._id}}"
+        data-id="{{order._id}}"
+        bindtap="handleMarkReady"
+      >推送给会员</button>
+      <button
+        wx:if="{{order.canCancel}}"
+        class="action-btn action-btn--cancel"
+        type="default"
+        loading="{{processingId === order._id && processingAction === 'cancel'}}"
+        disabled="{{!!processingId && processingId !== order._id}}"
+        data-id="{{order._id}}"
+        bindtap="handleCancelOrder"
+      >取消订单</button>
+    </view>
   </view>
 </view>

--- a/miniprogram/pages/admin/menu-orders/index.wxss
+++ b/miniprogram/pages/admin/menu-orders/index.wxss
@@ -130,8 +130,14 @@
   text-decoration: line-through;
 }
 
+.action-buttons {
+  display: flex;
+  gap: 12px;
+  margin-top: 12px;
+}
+
 .action-btn {
-  margin-top: 8px;
+  flex: 1;
 }
 
 .action-btn--cancel {


### PR DESCRIPTION
## Summary
- wrap admin prep list action buttons in a flex container to display them side by side
- add shared spacing styles so both actions align consistently

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfee5e37d8833080177f8e7fdbbdf3