### PR TITLE
Adjust admin prep order action buttons layout

### DIFF
--- a/miniprogram/pages/admin/menu-orders/index.wxml
+++ b/miniprogram/pages/admin/menu-orders/index.wxml
@@ -54,23 +54,25 @@
     </view>
     <view class="order-meta" wx:if="{{order.adminConfirmedAtLabel}}">管理员确认：{{order.adminConfirmedAtLabel}}</view>
     <view class="order-meta" wx:if="{{order.memberConfirmedAtLabel}}">会员确认：{{order.memberConfirmedAtLabel}}</view>
-    <button
-      wx:if="{{order.status === 'submitted'}}"
-      class="action-btn"
-      type="primary"
-      loading="{{processingId === order._id && processingAction === 'ready'}}"
-      disabled="{{!!processingId && processingId !== order._id}}"
-      data-id="{{order._id}}"
-      bindtap="handleMarkReady"
-    >推送给会员</button>
-    <button
-      wx:if="{{order.canCancel}}"
-      class="action-btn action-btn--cancel"
-      type="default"
-      loading="{{processingId === order._id && processingAction === 'cancel'}}"
-      disabled="{{!!processingId && processingId !== order._id}}"
-      data-id="{{order._id}}"
-      bindtap="handleCancelOrder"
-    >取消订单</button>
+    <view class="action-btn-group" wx:if="{{order.status === 'submitted' || order.canCancel}}">
+      <button
+        wx:if="{{order.status === 'submitted'}}"
+        class="action-btn"
+        type="primary"
+        loading="{{processingId === order._id && processingAction === 'ready'}}"
+        disabled="{{!!processingId && processingId !== order._id}}"
+        data-id="{{order._id}}"
+        bindtap="handleMarkReady"
+      >推送给会员</button>
+      <button
+        wx:if="{{order.canCancel}}"
+        class="action-btn action-btn--cancel"
+        type="default"
+        loading="{{processingId === order._id && processingAction === 'cancel'}}"
+        disabled="{{!!processingId && processingId !== order._id}}"
+        data-id="{{order._id}}"
+        bindtap="handleCancelOrder"
+      >取消订单</button>
+    </view>
   </view>
 </view>

--- a/miniprogram/pages/admin/menu-orders/index.wxss
+++ b/miniprogram/pages/admin/menu-orders/index.wxss
@@ -130,8 +130,19 @@
   text-decoration: line-through;
 }
 
+.action-btn-group {
+  display: flex;
+  gap: 12px;
+  margin-top: 12px;
+}
+
 .action-btn {
-  margin-top: 8px;
+  flex: 1;
+  margin-top: 0;
+  height: 80rpx;
+  line-height: 80rpx;
+  font-size: 26rpx;
+  border-radius: 12px;
 }
 
 .action-btn--cancel {

--- a/miniprogram/pages/admin/menu-orders/index.wxss
+++ b/miniprogram/pages/admin/menu-orders/index.wxss
@@ -139,8 +139,11 @@
 .action-btn {
   flex: 1;
   margin-top: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   height: 80rpx;
-  line-height: 80rpx;
+  padding: 0;
   font-size: 26rpx;
   border-radius: 12px;
 }

--- a/miniprogram/pages/membership/order/index.wxml
+++ b/miniprogram/pages/membership/order/index.wxml
@@ -171,24 +171,26 @@
         </view>
         <view class="order-stones">送 {{order.stoneRewardLabel}} 灵石</view>
       </view>
-      <button
-        wx:if="{{order.canConfirm}}"
-        class="confirm-btn"
-        type="primary"
-        loading="{{confirmingId === order._id}}"
-        disabled="{{(!!cancellingId && cancellingId !== order._id)}}"
-        data-id="{{order._id}}"
-        bindtap="handleConfirmOrder"
-      >确认扣费</button>
-      <button
-        wx:if="{{order.canCancel}}"
-        class="cancel-btn"
-        type="default"
-        loading="{{cancellingId === order._id}}"
-        disabled="{{(!!confirmingId && confirmingId !== order._id)}}"
-        data-id="{{order._id}}"
-        bindtap="handleCancelOrder"
-      >取消订单</button>
+      <view class="order-action-btn-group" wx:if="{{order.canConfirm || order.canCancel}}">
+        <button
+          wx:if="{{order.canConfirm}}"
+          class="order-action-btn order-action-btn--confirm"
+          type="primary"
+          loading="{{confirmingId === order._id}}"
+          disabled="{{(!!cancellingId && cancellingId !== order._id)}}"
+          data-id="{{order._id}}"
+          bindtap="handleConfirmOrder"
+        >确认扣费</button>
+        <button
+          wx:if="{{order.canCancel}}"
+          class="order-action-btn order-action-btn--cancel"
+          type="default"
+          loading="{{cancellingId === order._id}}"
+          disabled="{{(!!confirmingId && confirmingId !== order._id)}}"
+          data-id="{{order._id}}"
+          bindtap="handleCancelOrder"
+        >取消订单</button>
+      </view>
       <view class="order-meta" wx:if="{{order.adminConfirmedAtLabel && order.status !== 'submitted'}}">
         管理员已确认：{{order.adminConfirmedAtLabel}}
       </view>

--- a/miniprogram/pages/membership/order/index.wxss
+++ b/miniprogram/pages/membership/order/index.wxss
@@ -480,12 +480,25 @@
   color: rgba(255, 255, 255, 0.7);
 }
 
-.confirm-btn {
-  margin-top: 8px;
+.order-action-btn-group {
+  display: flex;
+  gap: 12px;
+  margin-top: 12px;
 }
 
-.cancel-btn {
-  margin-top: 8px;
+.order-action-btn {
+  flex: 1;
+  margin-top: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 80rpx;
+  padding: 0;
+  font-size: 26rpx;
+  border-radius: 12px;
+}
+
+.order-action-btn--cancel {
   color: rgba(255, 255, 255, 0.9);
   border: 1px solid rgba(255, 255, 255, 0.2);
 }


### PR DESCRIPTION
## Summary
- align the admin prep order action buttons within a shared container so they display side by side
- tweak the button styling to ensure consistent sizing and spacing when shown together

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dfef4b61ec8330b48263cba00ec130