### PR TITLE
fix: enlarge price input in admin order dialog

### DIFF
--- a/miniprogram/pages/admin/orders/index.wxss
+++ b/miniprogram/pages/admin/orders/index.wxss
@@ -520,6 +520,9 @@ page {
 
 .price-dialog__input {
   font-size: 28rpx;
+  height: 88rpx;
+  padding: 28rpx 24rpx;
+  line-height: 32rpx;
 }
 
 .price-dialog__textarea {


### PR DESCRIPTION
## Summary
- increase the height and padding of the price adjustment input to keep text fully visible

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dff590ce0c8330a1e5092381a18567