### PR TITLE
更新会员用餐菜单数据

### DIFF
--- a/miniprogram/shared/menu-data.js
+++ b/miniprogram/shared/menu-data.js
@@ -695,7 +695,7 @@ export const menuData = {
   "diningCategories": [
     {
       "id": "pairing",
-      "name": "下酒菜"
+      "name": "酒菜"
     },
     {
       "id": "cold",
@@ -712,127 +712,799 @@ export const menuData = {
   ],
   "diningItems": [
     {
-      "id": "pairing-nuts",
+      "id": "pairing-lachaohuage",
       "cat": "pairing",
-      "title": "秘制坚果拼盘",
-      "desc": "每日烘焙腰果、扁桃仁与碧根果，佐以少量干果点缀。",
+      "title": "辣炒花蛤",
+      "desc": "",
       "variants": [
         {
           "label": "份",
           "unit": "/份",
-          "price": 5900
+          "price": 3800
         }
       ],
       "img": ""
     },
     {
-      "id": "pairing-olive",
+      "id": "pairing-lachaochengzi",
       "cat": "pairing",
-      "title": "香草橄榄",
-      "desc": "西班牙青橄榄搭配初榨橄榄油与迷迭香。",
+      "title": "辣炒蛏子",
+      "desc": "",
       "variants": [
         {
           "label": "份",
           "unit": "/份",
-          "price": 4900
+          "price": 4800
         }
       ],
       "img": ""
     },
     {
-      "id": "cold-beef",
+      "id": "pairing-ganzhahuangyu",
+      "cat": "pairing",
+      "title": "干炸小黄鱼",
+      "desc": "",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 3200
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "pairing-ganzhaxiaosourou",
+      "cat": "pairing",
+      "title": "干炸小酥肉",
+      "desc": "",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 3200
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "cold-shousisun",
       "cat": "cold",
-      "title": "酱香牛肉",
-      "desc": "精选前腿肉低温卤制，入口软糯回甜。",
+      "title": "手撕笋",
+      "desc": "",
       "variants": [
         {
           "label": "份",
           "unit": "/份",
-          "price": 8900
+          "price": 2500
         }
       ],
       "img": ""
     },
     {
-      "id": "cold-salad",
+      "id": "cold-shuangkoumuer",
       "cat": "cold",
-      "title": "芝麻菠菜",
-      "desc": "冷拌芝麻酱菠菜，清爽解腻。",
+      "title": "爽口木耳",
+      "desc": "",
       "variants": [
         {
           "label": "份",
           "unit": "/份",
-          "price": 5900
+          "price": 1800
         }
       ],
       "img": ""
     },
     {
-      "id": "staple-noodle",
+      "id": "cold-laohucai",
+      "cat": "cold",
+      "title": "老虎菜",
+      "desc": "",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 1800
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "cold-jiangzhisonghuadan",
+      "cat": "cold",
+      "title": "姜汁松花蛋",
+      "desc": "",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 1800
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "cold-banxinlimei",
+      "cat": "cold",
+      "title": "拌心里美",
+      "desc": "",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 1500
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "cold-xiangcongdoufusi",
+      "cat": "cold",
+      "title": "香葱豆腐丝",
+      "desc": "",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 1500
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "cold-zhahuashengmi",
+      "cat": "cold",
+      "title": "炸花生米",
+      "desc": "",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 1500
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "cold-paihuanggua",
+      "cat": "cold",
+      "title": "拍黄瓜",
+      "desc": "",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 1500
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "cold-pidandoufu",
+      "cat": "cold",
+      "title": "皮蛋豆腐",
+      "desc": "",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 1500
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "cold-shuangkoubacaixin",
+      "cat": "cold",
+      "title": "爽口白菜心",
+      "desc": "",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 1500
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "cold-tangbanxihongshi",
+      "cat": "cold",
+      "title": "糖拌西红柿",
+      "desc": "",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 1500
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "cold-huamaopin",
+      "cat": "cold",
+      "title": "花毛拼",
+      "desc": "",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 1500
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "staple-chaofangbianmian",
       "cat": "staple",
-      "title": "葱油拌面",
-      "desc": "手工面条佐以葱油与秘制酱油。",
+      "title": "炒方便面",
+      "desc": "",
       "variants": [
         {
           "label": "份",
           "unit": "/份",
-          "price": 7900
+          "price": 1800
         }
       ],
       "img": ""
     },
     {
-      "id": "staple-friedrice",
+      "id": "staple-zhufangbianmian",
       "cat": "staple",
-      "title": "松露牛油炒饭",
-      "desc": "日本越光米搭配松露酱与牛油快炒。",
+      "title": "煮方便面",
+      "desc": "",
       "variants": [
         {
           "label": "份",
           "unit": "/份",
-          "price": 11900
+          "price": 1800
         }
       ],
       "img": ""
     },
     {
-      "id": "bbq-lamb",
-      "cat": "bbq",
-      "title": "香料烤羊排",
-      "desc": "小羔羊排刷以孜然与迷迭香，现烤上桌。",
+      "id": "staple-danchaofan",
+      "cat": "staple",
+      "title": "蛋炒饭",
+      "desc": "",
       "variants": [
         {
           "label": "份",
           "unit": "/份",
-          "price": 15900
+          "price": 2200
         }
       ],
       "img": ""
     },
     {
-      "id": "bbq-shrimp",
+      "id": "staple-zhuroujiaozi",
+      "cat": "staple",
+      "title": "猪肉饺子",
+      "desc": "",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 2000
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "staple-sujiaozi",
+      "cat": "staple",
+      "title": "素饺子",
+      "desc": "",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 2000
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-kaoyuanyangyao",
       "cat": "bbq",
-      "title": "蒜香烤虾串",
-      "desc": "海捕大虾腌制后炭烤，蒜香浓郁。",
+      "title": "烤原油鲜羊腰",
+      "desc": "",
       "variants": [
         {
           "label": "串",
           "unit": "/串",
-          "price": 6900
+          "price": 3500
         }
       ],
       "img": ""
     },
     {
-      "id": "bbq-money",
+      "id": "bbq-kaoshenghao",
       "cat": "bbq",
-      "title": "烤串钱",
-      "desc": "补差价用",
+      "title": "烤生蚝",
+      "desc": "",
       "variants": [
         {
-          "label": "元",
-          "unit": "元",
-          "price": 100
+          "label": "个",
+          "unit": "/个",
+          "price": 1500
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-kaoshanbei",
+      "cat": "bbq",
+      "title": "烤扇贝",
+      "desc": "",
+      "variants": [
+        {
+          "label": "个",
+          "unit": "/个",
+          "price": 1800
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-kaodayouyu",
+      "cat": "bbq",
+      "title": "烤大鱿鱼",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 1500
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-kaoxiaohuangyu",
+      "cat": "bbq",
+      "title": "烤小黄鱼（3条）",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 1500
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-kaojizhua",
+      "cat": "bbq",
+      "title": "烤鸡爪（3个）",
+      "desc": "",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 1500
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-canyong",
+      "cat": "bbq",
+      "title": "蚕蛹",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 800
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-yangrouchuan",
+      "cat": "bbq",
+      "title": "羊肉串（5串起）",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 600
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-yangroujin",
+      "cat": "bbq",
+      "title": "羊肉筋（5串起）",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 600
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-niurouchuan",
+      "cat": "bbq",
+      "title": "牛肉串（5串起）",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 600
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-niuxinguan",
+      "cat": "bbq",
+      "title": "牛心管（5串起）",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 400
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-xiaoyao",
+      "cat": "bbq",
+      "title": "小腰（5串起）",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 400
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-banjin",
+      "cat": "bbq",
+      "title": "板筋（5串起）",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 400
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-zhucuigu",
+      "cat": "bbq",
+      "title": "猪脆骨（5串起）",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 400
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-btljichi",
+      "cat": "bbq",
+      "title": "BT辣鸡翅",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 1000
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-lueweijichi",
+      "cat": "bbq",
+      "title": "掠味鸡翅",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 1000
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-mizhijichi",
+      "cat": "bbq",
+      "title": "蜜汁鸡翅",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 1000
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-malajichi",
+      "cat": "bbq",
+      "title": "麻辣鸡翅",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 1000
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-heijiaojichi",
+      "cat": "bbq",
+      "title": "黑椒鸡翅",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 1000
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-youdoufuchuan",
+      "cat": "bbq",
+      "title": "鱼豆腐（3串起）",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 300
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-kaohaixia",
+      "cat": "bbq",
+      "title": "烤海虾（3串起）",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 500
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-jixin",
+      "cat": "bbq",
+      "title": "鸡心（5串起）",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 400
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-jizhen",
+      "cat": "bbq",
+      "title": "鸡胗（5串起）",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 400
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-zhangzhongbao",
+      "cat": "bbq",
+      "title": "掌中宝（5串起）",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 400
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-kaoshidan",
+      "cat": "bbq",
+      "title": "烤实蛋",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 300
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-kaohuotuichang",
+      "cat": "bbq",
+      "title": "烤火腿肠",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 500
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-kaojirouchang",
+      "cat": "bbq",
+      "title": "烤鸡肉肠",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 400
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-kaocaijuan",
+      "cat": "bbq",
+      "title": "烤菜卷",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 400
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-kaojianjiao",
+      "cat": "bbq",
+      "title": "烤尖椒",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 300
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-kaodasuang",
+      "cat": "bbq",
+      "title": "烤大蒜",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 300
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-kaoyumi",
+      "cat": "bbq",
+      "title": "烤玉米",
+      "desc": "",
+      "variants": [
+        {
+          "label": "个",
+          "unit": "/个",
+          "price": 500
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-kaomantoupian",
+      "cat": "bbq",
+      "title": "烤馒头片",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 300
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-kaomianbaopian",
+      "cat": "bbq",
+      "title": "烤面包片",
+      "desc": "",
+      "variants": [
+        {
+          "label": "串",
+          "unit": "/串",
+          "price": 300
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-kaojiucai",
+      "cat": "bbq",
+      "title": "烤韭菜",
+      "desc": "",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 1500
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-kaotudoupian",
+      "cat": "bbq",
+      "title": "烤土豆片",
+      "desc": "",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 1200
+        }
+      ],
+      "img": ""
+    },
+    {
+      "id": "bbq-kaoqiezi",
+      "cat": "bbq",
+      "title": "烤茄子",
+      "desc": "",
+      "variants": [
+        {
+          "label": "份",
+          "unit": "/份",
+          "price": 1800
         }
       ],
       "img": ""


### PR DESCRIPTION
## Summary
- 将“酒菜”分类名称更新，匹配新的会员点餐文案
- 清空原有用餐菜单，按酒菜、凉菜、主食、烤串分类录入新的菜品及价格

## Testing
- 未运行测试（数据更新）

------
https://chatgpt.com/codex/tasks/task_e_68e00cef2b7c83309a9b831c49f13683