### PR TITLE
调整会员点餐商品卡数量控件展示

### DIFF
--- a/miniprogram/pages/membership/order/index.wxml
+++ b/miniprogram/pages/membership/order/index.wxml
@@ -42,14 +42,26 @@
               <text class="variant-price-unit" wx:if="{{variant.unit}}">{{variant.unit}}</text>
             </view>
           </view>
-          <button
-            class="variant-add"
-            size="mini"
-            type="primary"
-            data-item-id="{{menu.id}}"
-            data-variant-index="{{variantIndex}}"
-            bindtap="handleAddToCart"
-          >+</button>
+          <view class="variant-actions">
+            <button
+              class="variant-btn variant-btn--minus"
+              size="mini"
+              type="default"
+              data-key="{{variant.key}}"
+              data-delta="-1"
+              bindtap="handleAdjustQuantity"
+              wx:if="{{cartQuantityMap[variant.key]}}"
+            >-</button>
+            <text class="variant-qty" wx:if="{{cartQuantityMap[variant.key]}}">{{cartQuantityMap[variant.key]}}</text>
+            <button
+              class="variant-btn variant-btn--add"
+              size="mini"
+              type="primary"
+              data-item-id="{{menu.id}}"
+              data-variant-index="{{variantIndex}}"
+              bindtap="handleAddToCart"
+            >+</button>
+          </view>
         </view>
       </view>
     </view>

--- a/miniprogram/pages/membership/order/index.wxss
+++ b/miniprogram/pages/membership/order/index.wxss
@@ -93,20 +93,27 @@
 
 .variant-info {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  gap: 16rpx;
+  flex: 1;
+  min-width: 0;
 }
 
 .variant-label {
   font-size: 26rpx;
   color: rgba(255, 255, 255, 0.9);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .variant-price {
   display: flex;
-  align-items: baseline;
+  align-items: center;
+  gap: 6rpx;
   font-size: 24rpx;
   color: rgba(255, 255, 255, 0.7);
-  margin-top: 4rpx;
+  white-space: nowrap;
 }
 
 .variant-price-value {
@@ -118,15 +125,44 @@
   margin-left: 4rpx;
 }
 
-.variant-add {
-  min-width: 0;
+.variant-actions {
+  display: flex;
+  align-items: center;
+  gap: 10rpx;
+  flex-shrink: 0;
+}
+
+.variant-btn {
+  width: 48rpx;
+  height: 48rpx;
   padding: 0;
-  border-radius: 10rpx;
+  border-radius: 999px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 32rpx;
+  font-size: 28rpx;
+  line-height: 48rpx;
+}
+
+.variant-btn::after {
+  border: none;
+}
+
+.variant-btn--minus {
+  background: rgba(255, 255, 255, 0.08);
+  color: #aeb5ff;
+}
+
+.variant-btn--add {
+  min-width: 48rpx;
   margin-right: 0;
+}
+
+.variant-qty {
+  min-width: 36rpx;
+  text-align: center;
+  font-size: 26rpx;
+  color: #ffffff;
 }
 
 .empty-hint {

--- a/miniprogram/pages/membership/order/index.wxss
+++ b/miniprogram/pages/membership/order/index.wxss
@@ -133,15 +133,16 @@
 }
 
 .variant-btn {
-  width: 48rpx;
-  height: 48rpx;
+  width: 44rpx;
+  height: 44rpx;
   padding: 0;
-  border-radius: 999px;
-  display: flex;
+  border-radius: 50%;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   font-size: 28rpx;
-  line-height: 48rpx;
+  line-height: 1;
+  text-align: center;
 }
 
 .variant-btn::after {
@@ -154,7 +155,7 @@
 }
 
 .variant-btn--add {
-  min-width: 48rpx;
+  min-width: 44rpx;
   margin-right: 0;
 }
 


### PR DESCRIPTION
## Summary
- 为菜单变体生成唯一 key 并同步维护购物车数量映射，方便商品卡直接读取数量
- 在商品卡上新增减号与数量展示，并复用购物车数量调整逻辑
- 调整商品卡样式使文案与加购控件保持单行居中，并缩小加号按钮尺寸

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0191f463c8330b2a8e9f84aecbcdd