### PR TITLE
feat: add real name field to admin member detail

### DIFF
--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -1489,6 +1489,7 @@ function decorateMemberRecord(member, levelMap) {
   return {
     _id: member._id,
     nickName: member.nickName || '',
+    realName: typeof member.realName === 'string' ? member.realName : '',
     avatarUrl: member.avatarUrl || '',
     mobile: member.mobile || '',
     balance: cashBalance,
@@ -1977,6 +1978,9 @@ function buildUpdatePayload(updates, existing = {}, extras = {}) {
 
   if (Object.prototype.hasOwnProperty.call(updates, 'mobile')) {
     memberUpdates.mobile = updates.mobile || '';
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, 'realName')) {
+    memberUpdates.realName = typeof updates.realName === 'string' ? updates.realName.trim() : '';
   }
   if (Object.prototype.hasOwnProperty.call(updates, 'levelId')) {
     memberUpdates.levelId = updates.levelId || '';

--- a/miniprogram/pages/admin/member-detail/index.js
+++ b/miniprogram/pages/admin/member-detail/index.js
@@ -247,6 +247,7 @@ Page({
     avatarOptionGroups: buildAvatarOptionGroups([]),
     form: {
       nickName: '',
+      realName: '',
       mobile: '',
       experience: '',
       cashBalance: '',
@@ -407,6 +408,7 @@ Page({
       loading: false,
       form: {
         nickName: member.nickName || '',
+        realName: member.realName || '',
         mobile: member.mobile || '',
         experience: String(member.experience ?? 0),
         cashBalance: this.formatYuan(member.cashBalance ?? member.balance ?? 0),
@@ -735,6 +737,7 @@ Page({
     try {
       const payload = {
         nickName: (this.data.form.nickName || '').trim(),
+        realName: (this.data.form.realName || '').trim(),
         mobile: (this.data.form.mobile || '').trim(),
         experience: Number(this.data.form.experience || 0),
         cashBalance: this.parseYuanToFen(this.data.form.cashBalance),

--- a/miniprogram/pages/admin/member-detail/index.wxml
+++ b/miniprogram/pages/admin/member-detail/index.wxml
@@ -42,6 +42,16 @@
       />
     </view>
     <view class="form-item">
+      <view class="form-label">真实姓名</view>
+      <input
+        class="form-input"
+        value="{{form.realName}}"
+        placeholder="请输入真实姓名"
+        data-field="realName"
+        bindinput="handleInputChange"
+      />
+    </view>
+    <view class="form-item">
       <view class="form-label">剩余改名次数</view>
       <input
         class="form-input"


### PR DESCRIPTION
## Summary
- add a real name input field to the admin member detail page for record keeping
- persist the real name value through member update payloads and API responses

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e0a6095ab08330bb007efe8ef835ce