### PR TITLE
feat: show member real names across admin

### DIFF
--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -1489,6 +1489,7 @@ function decorateMemberRecord(member, levelMap) {
   return {
     _id: member._id,
     nickName: member.nickName || '',
+    realName: typeof member.realName === 'string' ? member.realName : '',
     avatarUrl: member.avatarUrl || '',
     mobile: member.mobile || '',
     balance: cashBalance,
@@ -1520,6 +1521,7 @@ function decorateReservationRecord(reservation, member, room) {
     _id: reservation._id,
     memberId: reservation.memberId || '',
     memberName: member ? member.nickName || member.name || '' : '',
+    memberRealName: member ? member.realName || '' : '',
     memberMobile: member ? member.mobile || '' : '',
     roomId: reservation.roomId || '',
     roomName: room ? room.name || '' : '',
@@ -1977,6 +1979,9 @@ function buildUpdatePayload(updates, existing = {}, extras = {}) {
 
   if (Object.prototype.hasOwnProperty.call(updates, 'mobile')) {
     memberUpdates.mobile = updates.mobile || '';
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, 'realName')) {
+    memberUpdates.realName = typeof updates.realName === 'string' ? updates.realName.trim() : '';
   }
   if (Object.prototype.hasOwnProperty.call(updates, 'levelId')) {
     memberUpdates.levelId = updates.levelId || '';
@@ -2441,6 +2446,7 @@ function decorateChargeOrderRecord(order, member) {
     statusLabel: describeChargeOrderStatus(order.status),
     memberId: order.memberId || '',
     memberName: member ? member.nickName || '' : '',
+    memberRealName: member ? member.realName || '' : '',
     memberMobile: member ? member.mobile || '' : '',
     originalTotalAmount: originalAmount,
     originalTotalAmountLabel: originalAmount ? `¥${formatFenToYuan(originalAmount)}` : '',
@@ -2467,12 +2473,14 @@ function buildMemberSnapshot(member) {
   if (!member || typeof member !== 'object') {
     return {
       nickName: '',
+      realName: '',
       mobile: '',
       levelId: ''
     };
   }
   return {
     nickName: typeof member.nickName === 'string' ? member.nickName : '',
+    realName: typeof member.realName === 'string' ? member.realName : '',
     mobile: typeof member.mobile === 'string' ? member.mobile : '',
     levelId: typeof member.levelId === 'string' ? member.levelId : ''
   };

--- a/cloudfunctions/menuOrder/index.js
+++ b/cloudfunctions/menuOrder/index.js
@@ -812,12 +812,14 @@ function buildMemberSnapshot(raw) {
   if (!raw || typeof raw !== 'object') {
     return {
       nickName: '',
+      realName: '',
       mobile: '',
       levelId: ''
     };
   }
   return {
     nickName: typeof raw.nickName === 'string' ? raw.nickName : '',
+    realName: typeof raw.realName === 'string' ? raw.realName : '',
     mobile: typeof raw.mobile === 'string' ? raw.mobile : '',
     levelId: typeof raw.levelId === 'string' ? raw.levelId : ''
   };

--- a/miniprogram/pages/admin/member-detail/index.js
+++ b/miniprogram/pages/admin/member-detail/index.js
@@ -247,6 +247,7 @@ Page({
     avatarOptionGroups: buildAvatarOptionGroups([]),
     form: {
       nickName: '',
+      realName: '',
       mobile: '',
       experience: '',
       cashBalance: '',
@@ -407,6 +408,7 @@ Page({
       loading: false,
       form: {
         nickName: member.nickName || '',
+        realName: member.realName || '',
         mobile: member.mobile || '',
         experience: String(member.experience ?? 0),
         cashBalance: this.formatYuan(member.cashBalance ?? member.balance ?? 0),
@@ -735,6 +737,7 @@ Page({
     try {
       const payload = {
         nickName: (this.data.form.nickName || '').trim(),
+        realName: (this.data.form.realName || '').trim(),
         mobile: (this.data.form.mobile || '').trim(),
         experience: Number(this.data.form.experience || 0),
         cashBalance: this.parseYuanToFen(this.data.form.cashBalance),

--- a/miniprogram/pages/admin/member-detail/index.wxml
+++ b/miniprogram/pages/admin/member-detail/index.wxml
@@ -42,6 +42,16 @@
       />
     </view>
     <view class="form-item">
+      <view class="form-label">真实姓名</view>
+      <input
+        class="form-input"
+        value="{{form.realName}}"
+        placeholder="请输入真实姓名"
+        data-field="realName"
+        bindinput="handleInputChange"
+      />
+    </view>
+    <view class="form-item">
       <view class="form-label">剩余改名次数</view>
       <input
         class="form-input"

--- a/miniprogram/pages/admin/members/index.js
+++ b/miniprogram/pages/admin/members/index.js
@@ -1,4 +1,5 @@
 import { AdminService } from '../../../services/api';
+import { formatMemberDisplayName } from '../../../utils/format';
 
 const PAGE_SIZE = 20;
 const DEFAULT_AVATAR =
@@ -58,7 +59,10 @@ Page({
         page: nextPage,
         pageSize: this.data.pageSize
       });
-      const incoming = response.members || [];
+      const incoming = (response.members || []).map((member) => ({
+        ...member,
+        displayName: formatMemberDisplayName(member.nickName, member.realName, '未命名会员')
+      }));
       const merged = reset ? incoming : [...this.data.members, ...incoming];
       const total = response.total || merged.length;
       const finished = merged.length >= total || incoming.length < this.data.pageSize;

--- a/miniprogram/pages/admin/members/index.wxml
+++ b/miniprogram/pages/admin/members/index.wxml
@@ -25,7 +25,7 @@
     >
       <image class="member-avatar" src="{{item.avatarUrl || defaultAvatar}}" mode="aspectFill"></image>
       <view class="member-info">
-        <view class="member-name">{{item.nickName || '未命名会员'}}</view>
+        <view class="member-name">{{item.displayName || '未命名会员'}}</view>
         <view class="member-meta">
           <text>ID：{{item._id}}</text>
           <text wx:if="{{item.mobile}}"> · 手机：{{item.mobile}}</text>

--- a/miniprogram/pages/admin/menu-orders/index.js
+++ b/miniprogram/pages/admin/menu-orders/index.js
@@ -1,5 +1,5 @@
 import { AdminMenuOrderService } from '../../../services/api';
-import { formatCurrency } from '../../../utils/format';
+import { formatCurrency, formatMemberDisplayName } from '../../../utils/format';
 
 const STATUS_TABS = [
   { id: 'submitted', label: '待备餐' },
@@ -103,6 +103,20 @@ function decorateOrder(order) {
     cancelledByLabel = '会员';
   }
   const canCancel = order.status === 'submitted' || order.status === 'pendingMember';
+  const memberSnapshot = order.memberSnapshot || {};
+  const memberDisplayName = formatMemberDisplayName(
+    typeof memberSnapshot.nickName === 'string' && memberSnapshot.nickName
+      ? memberSnapshot.nickName
+      : typeof order.memberName === 'string'
+      ? order.memberName
+      : '',
+    typeof memberSnapshot.realName === 'string' && memberSnapshot.realName
+      ? memberSnapshot.realName
+      : typeof order.memberRealName === 'string'
+      ? order.memberRealName
+      : '',
+    ''
+  );
   return {
     ...order,
     _id: id,
@@ -120,6 +134,7 @@ function decorateOrder(order) {
     memberConfirmedAtLabel: formatDateTime(order.memberConfirmedAt),
     cancelledAtLabel,
     cancelledByLabel,
+    memberDisplayName,
     adminRemark,
     cancelRemark,
     shortId,

--- a/miniprogram/pages/admin/menu-orders/index.wxml
+++ b/miniprogram/pages/admin/menu-orders/index.wxml
@@ -21,7 +21,7 @@
       <view class="order-id">#{{order.shortId}}</view>
       <view class="order-status">{{order.statusLabel}}</view>
     </view>
-    <view class="order-meta">会员：{{order.memberSnapshot && order.memberSnapshot.nickName ? order.memberSnapshot.nickName : '未知'}}</view>
+    <view class="order-meta">会员：{{order.memberDisplayName || '未知'}}</view>
     <view class="order-meta">提交时间：{{order.createdAtLabel}}</view>
     <view class="order-meta" wx:if="{{order.remark}}">备注：{{order.remark}}</view>
     <view class="order-meta" wx:if="{{order.adminRemark}}">管理员备注：{{order.adminRemark}}</view>

--- a/miniprogram/pages/admin/orders/index.js
+++ b/miniprogram/pages/admin/orders/index.js
@@ -1,5 +1,5 @@
 import { AdminService } from '../../../services/api';
-import { formatCurrency } from '../../../utils/format';
+import { formatCurrency, formatMemberDisplayName } from '../../../utils/format';
 
 function formatDateTime(value) {
   if (!value) return '';
@@ -113,6 +113,11 @@ function decorateOrder(order) {
       })
     : [];
   const stoneRewardLabel = `${Math.max(0, Math.floor(stoneReward))} 枚`;
+  const memberDisplayName = formatMemberDisplayName(
+    typeof order.memberName === 'string' ? order.memberName : '',
+    typeof order.memberRealName === 'string' ? order.memberRealName : '',
+    typeof order.memberName === 'string' && order.memberName ? order.memberName : ''
+  );
   return {
     ...order,
     items,
@@ -128,7 +133,8 @@ function decorateOrder(order) {
     statusLabel: order.statusLabel || describeStatus(order.status),
     createdAtLabel: order.createdAtLabel || formatDateTime(order.createdAt),
     updatedAtLabel: order.updatedAtLabel || formatDateTime(order.updatedAt),
-    confirmedAtLabel: order.confirmedAtLabel || formatDateTime(order.confirmedAt)
+    confirmedAtLabel: order.confirmedAtLabel || formatDateTime(order.confirmedAt),
+    memberDisplayName
   };
 }
 
@@ -226,6 +232,12 @@ Page({
       const memberInfo = {
         _id: targetOrder.memberId,
         nickName: targetOrder.memberName || memberSnapshot.nickName || '',
+        realName: targetOrder.memberRealName || memberSnapshot.realName || '',
+        displayName: formatMemberDisplayName(
+          targetOrder.memberName || memberSnapshot.nickName || '',
+          targetOrder.memberRealName || memberSnapshot.realName || '',
+          targetOrder.memberName || memberSnapshot.nickName || ''
+        ),
         mobile: targetOrder.memberMobile || memberSnapshot.mobile || '',
         levelName: targetOrder.memberLevelName || '',
         balanceLabel: targetOrder.memberBalanceLabel || ''
@@ -418,6 +430,8 @@ Page({
         ? response.members.map((member) => ({
             _id: member._id,
             nickName: member.nickName || '',
+            realName: member.realName || '',
+            displayName: formatMemberDisplayName(member.nickName, member.realName, '未命名'),
             mobile: member.mobile || '',
             levelName: member.levelName || '',
             balanceLabel: formatCurrency(member.cashBalance)

--- a/miniprogram/pages/admin/orders/index.wxml
+++ b/miniprogram/pages/admin/orders/index.wxml
@@ -44,7 +44,7 @@
           <text class="meta-text" wx:if="{{item.confirmedAtLabel}}">完成：{{item.confirmedAtLabel}}</text>
         </view>
         <view class="order-member">
-          <text class="meta-text">会员：{{item.memberName || '—'}}</text>
+          <text class="meta-text">会员：{{item.memberDisplayName || '—'}}</text>
           <text class="meta-text" wx:if="{{item.memberId}}">编号：{{item.memberId}}</text>
           <text class="meta-text" wx:if="{{item.memberMobile}}">手机：{{item.memberMobile}}</text>
         </view>
@@ -140,7 +140,7 @@
                 data-id="{{member._id}}"
                 bindtap="handleSelectForceChargeMember"
               >
-                <view class="member-name">{{member.nickName || '未命名'}}</view>
+                <view class="member-name">{{member.displayName || member.nickName || '未命名'}}</view>
                 <view class="member-meta">
                   <text wx:if="{{member.mobile}}">{{member.mobile}}</text>
                   <text wx:if="{{member.levelName}}">{{member.levelName}}</text>
@@ -152,7 +152,7 @@
         </block>
         <block wx:else>
           <view class="force-dialog__locked">
-            <view class="member-name">{{(forceChargeDialog.memberInfo && forceChargeDialog.memberInfo.nickName) || '未命名'}}</view>
+            <view class="member-name">{{(forceChargeDialog.memberInfo && forceChargeDialog.memberInfo.displayName) || '未命名'}}</view>
             <view class="member-meta">
               <text wx:if="{{forceChargeDialog.memberInfo && forceChargeDialog.memberInfo.mobile}}">{{forceChargeDialog.memberInfo.mobile}}</text>
               <text wx:if="{{forceChargeDialog.memberInfo && forceChargeDialog.memberInfo.levelName}}">{{forceChargeDialog.memberInfo.levelName}}</text>

--- a/miniprogram/pages/admin/reservations/index.js
+++ b/miniprogram/pages/admin/reservations/index.js
@@ -1,4 +1,5 @@
 import { AdminService } from '../../../services/api';
+import { formatMemberDisplayName } from '../../../utils/format';
 
 const STATUS_OPTIONS = [
   { value: 'pendingApproval', label: '待审核' },
@@ -95,9 +96,15 @@ Page({
     if (!item || typeof item !== 'object') {
       return item;
     }
+    const memberDisplayName = formatMemberDisplayName(
+      item.memberName,
+      item.memberRealName,
+      item.memberName || item.memberId || ''
+    );
     return {
       ...item,
-      canCancel: CANCELABLE_STATUSES.includes(item.status)
+      canCancel: CANCELABLE_STATUSES.includes(item.status),
+      memberDisplayName
     };
   },
 

--- a/miniprogram/pages/admin/reservations/index.wxml
+++ b/miniprogram/pages/admin/reservations/index.wxml
@@ -23,7 +23,7 @@
     </view>
     <view class="item-time">{{item.date}} {{item.startTime}} - {{item.endTime}}</view>
     <view class="item-member">
-      申请人：{{item.memberName || item.memberId}}
+      申请人：{{item.memberDisplayName || item.memberId}}
       <text wx:if="{{item.memberMobile}}"> · {{item.memberMobile}}</text>
     </view>
     <view class="item-meta" wx:if="{{item.usageCredits}}">占用使用次数：{{item.usageCredits}}</view>

--- a/miniprogram/pages/admin/wine-storage/index.js
+++ b/miniprogram/pages/admin/wine-storage/index.js
@@ -1,5 +1,5 @@
 import { AdminService } from '../../../services/api';
-import { formatDate } from '../../../utils/format';
+import { formatDate, formatMemberDisplayName } from '../../../utils/format';
 
 const EXPIRY_OPTIONS = [
   { value: '7d', label: '7天' },
@@ -92,7 +92,12 @@ Page({
     this.setData({ loadingMembers: true });
     try {
       const result = await AdminService.listMembers({ keyword, page: 1, pageSize: 20 });
-      const members = Array.isArray(result.members) ? result.members : [];
+      const members = Array.isArray(result.members)
+        ? result.members.map((member) => ({
+            ...member,
+            displayName: formatMemberDisplayName(member.nickName, member.realName, '未命名会员')
+          }))
+        : [];
       this.setData({ members, loadingMembers: false });
     } catch (error) {
       console.error('[wine-storage] load members failed', error);

--- a/miniprogram/pages/admin/wine-storage/index.wxml
+++ b/miniprogram/pages/admin/wine-storage/index.wxml
@@ -24,7 +24,7 @@
         data-id="{{item._id}}"
         bindtap="handleSelectMember"
       >
-        <view class="member-name">{{item.nickName || '未命名会员'}}</view>
+        <view class="member-name">{{item.displayName || '未命名会员'}}</view>
         <view class="member-meta">ID：{{item._id}}<text wx:if="{{item.mobile}}"> · 手机：{{item.mobile}}</text></view>
         <view class="member-extra">余额：¥{{item.cashBalanceYuan}} · 灵石：{{item.stoneBalanceLabel}}</view>
       </view>
@@ -38,7 +38,7 @@
         <button class="ghost-button" size="mini" bindtap="handleResetSelection">更换会员</button>
       </view>
       <view class="selected-member">
-        <view class="selected-name">{{selectedMember.nickName || '未命名会员'}}</view>
+        <view class="selected-name">{{selectedMember.displayName || '未命名会员'}}</view>
         <view class="selected-meta">ID：{{selectedMember._id}}</view>
         <view class="selected-meta" wx:if="{{selectedMember.mobile}}">手机：{{selectedMember.mobile}}</view>
       </view>

--- a/miniprogram/utils/format.js
+++ b/miniprogram/utils/format.js
@@ -92,3 +92,18 @@ export const levelBadgeColor = (order = 1) => {
   const index = Math.max((order || 1) - 1, 0) % colors.length;
   return colors[index];
 };
+
+export const formatMemberDisplayName = (nickName, realName, fallback = '') => {
+  const primary = typeof nickName === 'string' ? nickName.trim() : '';
+  const secondary = typeof realName === 'string' ? realName.trim() : '';
+  if (primary && secondary) {
+    return `${primary}（${secondary}）`;
+  }
+  if (primary) {
+    return primary;
+  }
+  if (secondary) {
+    return secondary;
+  }
+  return fallback;
+};


### PR DESCRIPTION
## Summary
- add a shared formatter that appends real names to daohao displays and use it across the admin members list, wine storage, orders, menu orders, and reservations views
- include member realName values in admin and menu order snapshots so the UI consistently receives the data it needs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0a6095ab08330bb007efe8ef835ce