### PR TITLE
Fix wx:key warning in membership order page

### DIFF
--- a/miniprogram/pages/membership/order/index.wxml
+++ b/miniprogram/pages/membership/order/index.wxml
@@ -126,7 +126,7 @@
         <block wx:for="{{order.groupedItems}}" wx:key="section" wx:for-item="group">
           <view class="order-group">
             <view class="order-group-title">{{group.title}}</view>
-            <view class="order-line" wx:for="{{group.items}}" wx:key="{{index}}" wx:for-item="orderLine">
+            <view class="order-line" wx:for="{{group.items}}" wx:key="index" wx:for-item="orderLine">
               <view class="line-main">
                 <text class="line-title">{{orderLine.title}}</text>
                 <view class="line-meta">


### PR DESCRIPTION
## Summary
- update the membership order page list markup to use a valid wx:key binding
- silence the WXML runtime warning shown on the order page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1096a54a883308e42864908098332