### PR TITLE
Use modern window info APIs

### DIFF
--- a/miniprogram/app.js
+++ b/miniprogram/app.js
@@ -34,7 +34,9 @@ App({
 
   setupSystemMetrics() {
     try {
-      const systemInfo = wx.getSystemInfoSync();
+      const systemInfo = wx.getWindowInfo
+        ? wx.getWindowInfo()
+        : wx.getSystemInfoSync();
       const menuButtonRect = wx.getMenuButtonBoundingClientRect
         ? wx.getMenuButtonBoundingClientRect()
         : null;

--- a/miniprogram/utils/qrcode.js
+++ b/miniprogram/utils/qrcode.js
@@ -584,7 +584,11 @@ function drawWith2dContext({ canvas, modules, size, background, foreground }) {
   if (!ctx) {
     return Promise.resolve();
   }
-  const dpr = wx.getSystemInfoSync ? wx.getSystemInfoSync().pixelRatio || 1 : 1;
+  const dpr = wx.getWindowInfo
+    ? wx.getWindowInfo().pixelRatio || 1
+    : wx.getSystemInfoSync
+      ? wx.getSystemInfoSync().pixelRatio || 1
+      : 1;
   if (typeof canvas.width === 'number') {
     canvas.width = size * dpr;
   }


### PR DESCRIPTION
## Summary
- prefer `wx.getWindowInfo` when collecting system metrics during app launch
- update QR code renderer to use the modern API for pixel ratio detection

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e10cd26a448330ae9d3309a57d409b