### PR TITLE
Replace deprecated system info usage

### DIFF
--- a/miniprogram/utils/qrcode.js
+++ b/miniprogram/utils/qrcode.js
@@ -584,11 +584,28 @@ function drawWith2dContext({ canvas, modules, size, background, foreground }) {
   if (!ctx) {
     return Promise.resolve();
   }
-  const dpr = wx.getWindowInfo
-    ? wx.getWindowInfo().pixelRatio || 1
-    : wx.getSystemInfoSync
-      ? wx.getSystemInfoSync().pixelRatio || 1
-      : 1;
+  const getPixelRatio = () => {
+    if (wx.getWindowInfo) {
+      const { pixelRatio } = wx.getWindowInfo();
+      if (pixelRatio) {
+        return pixelRatio;
+      }
+    }
+
+    if (wx.getDeviceInfo) {
+      const deviceInfo = wx.getDeviceInfo();
+      if (deviceInfo.pixelRatio) {
+        return deviceInfo.pixelRatio;
+      }
+      if (deviceInfo.devicePixelRatio) {
+        return deviceInfo.devicePixelRatio;
+      }
+    }
+
+    return 1;
+  };
+
+  const dpr = getPixelRatio();
   if (typeof canvas.width === 'number') {
     canvas.width = size * dpr;
   }


### PR DESCRIPTION
## Summary
- replace the use of the deprecated synchronous system info API with modern window/device info helpers
- default navigation metrics and safe area data before asynchronously updating them when legacy APIs are unavailable
- derive the QR code renderer pixel ratio from the new APIs instead of the deprecated synchronous call

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e10da1ddc48330ba32411ac2154aa2