### PR TITLE
Unify combat calculations across PVE and PVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ cd cloudfunctions/member && npm install && cd -
 
 当前仓库将通用的集合名称、管理员角色、交易状态等配置统一维护在 `cloudfunctions/nodejs-layer/node_modules/common-config` 目录。部署以下云函数时，请在云开发控制台的“层管理”中绑定 `common-config` 公共模块：`admin`、`avatar`、`bootstrap`、`member`、`menuOrder`、`reservation`、`stones`、`tasks`、`pve`、`pvp`、`wallet`。若缺少绑定，云函数会在加载配置时抛出 `Cannot find module 'common-config'` 等错误，导致接口调用失败。
 
+战斗相关的属性整合、命中/伤害公式与战力评分统一沉淀在 `cloudfunctions/nodejs-layer/node_modules/combat-system` 模块内，`pve` 与 `pvp` 云函数均通过 `require('combat-system')` 复用该逻辑。更新数值体系后，需要重新打包 `nodejs-layer` 并在对应云函数上绑定最新层版本，避免旧实例继续引用过期的战斗公式。
+
 ## 二次开发建议
 
 1. **会员权益重写**：

--- a/cloudfunctions/README.md
+++ b/cloudfunctions/README.md
@@ -20,6 +20,8 @@
 
 后续若有新增云函数引用 `require('common-config')`，也需要同步在部署说明中补充清单并在控制台完成层绑定。
 
+此外，`cloudfunctions/nodejs-layer/node_modules/combat-system` 封装了角色属性汇总、伤害结算与战力评分等公共战斗公式。目前 `pve`、`pvp` 云函数均通过 `require('combat-system')` 引用该模块，部署时请将更新后的 `nodejs-layer` 打包为新的层版本并在上述两个云函数中完成绑定，否则会出现 `Cannot find module 'combat-system'` 的运行时错误。
+
 ## 云函数开发原则
 
 - **禁止跨云函数调用**：跨云函数调用非常影响性能，禁止使用。

--- a/cloudfunctions/nodejs-layer/node_modules/combat-system/index.js
+++ b/cloudfunctions/nodejs-layer/node_modules/combat-system/index.js
@@ -1,0 +1,431 @@
+'use strict';
+
+const DEFAULT_COMBAT_STATS = {
+  maxHp: 4500,
+  physicalAttack: 320,
+  magicAttack: 320,
+  physicalDefense: 160,
+  magicDefense: 160,
+  speed: 120,
+  accuracy: 100,
+  dodge: 90,
+  critRate: 0.05,
+  critDamage: 1.5,
+  finalDamageBonus: 0,
+  finalDamageReduction: 0,
+  lifeSteal: 0,
+  healingBonus: 0,
+  healingReduction: 0,
+  controlHit: 0,
+  controlResist: 0,
+  physicalPenetration: 0,
+  magicPenetration: 0,
+  critResist: 0,
+  comboRate: 0,
+  block: 0,
+  counterRate: 0,
+  damageReduction: 0,
+  healingReceived: 0,
+  rageGain: 0,
+  controlStrength: 0,
+  shieldPower: 0,
+  summonPower: 0,
+  elementalVulnerability: 0
+};
+
+const DEFAULT_SPECIAL_STATS = {
+  shield: 0,
+  bonusDamage: 0,
+  dodgeChance: 0,
+  healOnHit: 0,
+  healOnKill: 0,
+  damageReflection: 0,
+  accuracyBonus: 0,
+  speedBonus: 0,
+  physicalPenetrationBonus: 0,
+  magicPenetrationBonus: 0
+};
+
+const STAT_ALIASES = {
+  hp: 'maxHp',
+  health: 'maxHp',
+  maxHP: 'maxHp',
+  attack: 'physicalAttack',
+  physicalAtk: 'physicalAttack',
+  physicalATK: 'physicalAttack',
+  weaponAttack: 'physicalAttack',
+  spellAttack: 'magicAttack',
+  magicAtk: 'magicAttack',
+  magicATK: 'magicAttack',
+  defense: 'physicalDefense',
+  armor: 'physicalDefense',
+  resistance: 'magicDefense',
+  magicResist: 'magicDefense',
+  hitRate: 'accuracy',
+  accuracyRate: 'accuracy',
+  evasion: 'dodge',
+  dodgeRate: 'dodge',
+  criticalRate: 'critRate',
+  critical: 'critRate',
+  crit: 'critRate',
+  criticalDamage: 'critDamage',
+  critDamageRate: 'critDamage',
+  finalDamage: 'finalDamageBonus',
+  finalReduce: 'finalDamageReduction',
+  damageReduce: 'finalDamageReduction',
+  armorPenetration: 'physicalPenetration',
+  armorPen: 'physicalPenetration',
+  spellPenetration: 'magicPenetration',
+  spellPen: 'magicPenetration',
+  magicPen: 'magicPenetration'
+};
+
+const LEGACY_PERCENT_KEYS = new Set([
+  'critRate',
+  'finalDamageBonus',
+  'finalDamageReduction',
+  'lifeSteal',
+  'healingBonus',
+  'healingReduction',
+  'controlHit',
+  'controlResist',
+  'critResist',
+  'comboRate',
+  'block',
+  'counterRate',
+  'damageReduction',
+  'healingReceived',
+  'rageGain',
+  'controlStrength',
+  'shieldPower',
+  'summonPower',
+  'elementalVulnerability'
+]);
+
+const SPECIAL_PERCENT_KEYS = new Set(['dodgeChance', 'damageReflection']);
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function toNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function normalizeStatValue(key, value, convertLegacyPercentages) {
+  let normalized = value;
+  if (convertLegacyPercentages) {
+    if (key === 'critRate') {
+      normalized = value > 1 ? value / 100 : value;
+    } else if (key === 'critDamage') {
+      normalized = value >= 3 ? 1.5 + value / 100 : value;
+    } else if (LEGACY_PERCENT_KEYS.has(key) && Math.abs(value) > 1 && Math.abs(value) <= 1000) {
+      normalized = value / 100;
+    }
+  }
+  switch (key) {
+    case 'critRate':
+      return clamp(normalized, 0, 0.95);
+    case 'critDamage':
+      return Math.max(1.2, normalized);
+    case 'finalDamageBonus':
+      return clamp(normalized, -0.9, 2);
+    case 'finalDamageReduction':
+      return clamp(normalized, 0, 0.9);
+    case 'lifeSteal':
+      return clamp(normalized, 0, 0.6);
+    case 'healingBonus':
+    case 'healingReduction':
+      return clamp(normalized, -1, 1.5);
+    case 'damageReduction':
+      return clamp(normalized, 0, 0.8);
+    case 'healingReceived':
+      return clamp(normalized, -0.5, 1.5);
+    case 'comboRate':
+    case 'block':
+    case 'counterRate':
+      return clamp(normalized, 0, 1);
+    case 'critResist':
+    case 'controlHit':
+    case 'controlResist':
+    case 'rageGain':
+    case 'controlStrength':
+    case 'shieldPower':
+    case 'summonPower':
+    case 'elementalVulnerability':
+      return normalized;
+    default:
+      return normalized;
+  }
+}
+
+function applyStatSource(target, source, convertLegacyPercentages) {
+  if (!source || typeof source !== 'object') {
+    return;
+  }
+  Object.keys(source).forEach((rawKey) => {
+    const resolvedKey = STAT_ALIASES[rawKey] || rawKey;
+    if (!Object.prototype.hasOwnProperty.call(target, resolvedKey)) {
+      return;
+    }
+    const number = Number(source[rawKey]);
+    if (!Number.isFinite(number)) {
+      return;
+    }
+    target[resolvedKey] = normalizeStatValue(resolvedKey, number, convertLegacyPercentages);
+  });
+}
+
+function resolveCombatStats(summary = {}, options = {}) {
+  const { defaults = DEFAULT_COMBAT_STATS, convertLegacyPercentages = true } = options;
+  const stats = { ...defaults };
+  applyStatSource(stats, summary.finalStats || summary.stats || {}, convertLegacyPercentages);
+  applyStatSource(stats, summary, convertLegacyPercentages);
+  const combatStats = Array.isArray(summary.combatStats) ? summary.combatStats : [];
+  combatStats.forEach((entry) => {
+    if (!entry || typeof entry !== 'object' || !entry.key) {
+      return;
+    }
+    const key = entry.key;
+    const resolvedKey = STAT_ALIASES[key] || key;
+    if (!Object.prototype.hasOwnProperty.call(stats, resolvedKey)) {
+      return;
+    }
+    const value = Number(entry.value);
+    const base = Number(entry.base);
+    if (Number.isFinite(value)) {
+      stats[resolvedKey] = normalizeStatValue(resolvedKey, value, convertLegacyPercentages);
+    } else if (Number.isFinite(base)) {
+      stats[resolvedKey] = normalizeStatValue(resolvedKey, base, convertLegacyPercentages);
+    }
+  });
+  return stats;
+}
+
+function resolveSpecialStats(special = {}, options = {}) {
+  const { defaults = DEFAULT_SPECIAL_STATS, convertLegacyPercentages = true } = options;
+  const resolved = { ...defaults };
+  if (!special || typeof special !== 'object') {
+    return resolved;
+  }
+  Object.keys(resolved).forEach((key) => {
+    if (!Object.prototype.hasOwnProperty.call(special, key)) {
+      return;
+    }
+    const value = Number(special[key]);
+    if (!Number.isFinite(value)) {
+      return;
+    }
+    let normalized = value;
+    if (convertLegacyPercentages && SPECIAL_PERCENT_KEYS.has(key) && Math.abs(value) > 1 && Math.abs(value) <= 1000) {
+      normalized = value / 100;
+    }
+    switch (key) {
+      case 'dodgeChance':
+        resolved[key] = clamp(normalized, 0, 0.8);
+        break;
+      case 'damageReflection':
+        resolved[key] = clamp(normalized, 0, 0.8);
+        break;
+      case 'shield':
+        resolved[key] = Math.max(0, normalized);
+        break;
+      default:
+        resolved[key] = normalized;
+        break;
+    }
+  });
+  return resolved;
+}
+
+function createCombatantFromAttributes(attributes = {}, options = {}) {
+  const stats = resolveCombatStats(
+    { ...attributes, finalStats: attributes.finalStats, combatStats: attributes.combatStats },
+    options
+  );
+  const special = resolveSpecialStats(attributes.skillSummary || attributes.special || {}, options);
+  return { stats, special };
+}
+
+function extractCombatProfile(profile, options = {}) {
+  if (!profile || typeof profile !== 'object') {
+    return {
+      stats: resolveCombatStats({}, options),
+      special: resolveSpecialStats({}, options),
+      combatPower: 0
+    };
+  }
+  const attributeSummary = profile.attributeSummary || profile.attributes || {};
+  const finalStats =
+    attributeSummary.finalStats ||
+    profile.finalStats ||
+    (profile.derivedSummary && profile.derivedSummary.finalStats) ||
+    {};
+  const combatStats = Array.isArray(profile.combatStats) ? profile.combatStats : attributeSummary.combatStats;
+  const stats = resolveCombatStats(
+    {
+      ...attributeSummary,
+      finalStats,
+      combatStats
+    },
+    options
+  );
+  const special = resolveSpecialStats(attributeSummary.skillSummary || profile.skillSummary || {}, options);
+  const combatPower = Number(attributeSummary.combatPower || profile.combatPower || 0);
+  return { stats, special, combatPower: Number.isFinite(combatPower) ? combatPower : 0 };
+}
+
+function executeAttack(attacker, attackerSpecial = {}, defender, defenderSpecial = {}, rng = Math.random) {
+  const random = typeof rng === 'function' ? rng : Math.random;
+  const offensiveSpecial = attackerSpecial || {};
+  const defensiveSpecial = defenderSpecial || {};
+
+  const accuracy = Number(attacker.accuracy || 100) + Number(offensiveSpecial.accuracyBonus || 0);
+  const dodge = Number(defender.dodge || 0);
+  const baseHitChance = clamp(0.85 + (accuracy - dodge) * 0.005, 0.2, 0.99);
+  if (random() > baseHitChance) {
+    return { dodged: true, damage: 0, crit: false, heal: 0, usingMagic: false };
+  }
+  if (random() < clamp(defensiveSpecial.dodgeChance || 0, 0, 0.8)) {
+    return { dodged: true, damage: 0, crit: false, heal: 0, usingMagic: false };
+  }
+
+  const physicalAttack = Math.max(0, Number(attacker.physicalAttack) || 0);
+  const magicAttack = Math.max(0, Number(attacker.magicAttack) || 0);
+  const physicalPenetrationRating = Math.max(0, Number(attacker.physicalPenetration) || 0);
+  const magicPenetrationRating = Math.max(0, Number(attacker.magicPenetration) || 0);
+  const physicalPenetration = clamp(
+    physicalPenetrationRating * 0.005 + Number(offensiveSpecial.physicalPenetrationBonus || 0),
+    0,
+    0.6
+  );
+  const magicPenetration = clamp(
+    magicPenetrationRating * 0.005 + Number(offensiveSpecial.magicPenetrationBonus || 0),
+    0,
+    0.6
+  );
+
+  const physicalDefense = Math.max(0, Number(defender.physicalDefense) || 0);
+  const magicDefense = Math.max(0, Number(defender.magicDefense) || 0);
+  const effectivePhysicalDefense = physicalDefense * (1 - physicalPenetration);
+  const effectiveMagicDefense = magicDefense * (1 - magicPenetration);
+
+  const basePhysical =
+    physicalAttack > 0 ? Math.max(physicalAttack * 0.25, physicalAttack - effectivePhysicalDefense) : 0;
+  const baseMagic = magicAttack > 0 ? Math.max(magicAttack * 0.25, magicAttack - effectiveMagicDefense) : 0;
+  const usingMagic = baseMagic > basePhysical;
+  let damage = usingMagic ? baseMagic : basePhysical;
+  damage *= 0.9 + random() * 0.2;
+
+  const bonusDamage = Number(offensiveSpecial.bonusDamage) || 0;
+  if (bonusDamage) {
+    damage += bonusDamage;
+  }
+
+  const critChance = clamp((Number(attacker.critRate) || 0) - (Number(defender.critResist) || 0), 0.05, 0.95);
+  const crit = random() < critChance;
+  if (crit) {
+    damage *= Math.max(1.2, Number(attacker.critDamage) || 1.5);
+  }
+
+  const finalDamageBonus = Number(attacker.finalDamageBonus) || 0;
+  const finalDamageReduction = clamp(Number(defender.finalDamageReduction) || 0, 0, 0.9);
+  const finalMultiplier = Math.max(0.1, 1 + finalDamageBonus - finalDamageReduction);
+  damage *= finalMultiplier;
+
+  damage = Math.max(1, damage);
+
+  const lifeSteal = clamp(Number(attacker.lifeSteal) || 0, 0, 0.6);
+  const healingBonus = Number(attacker.healingBonus) || 0;
+  const healingReduction = Number(defender.healingReduction) || 0;
+  const healingMultiplier = clamp(1 + healingBonus - healingReduction, 0, 2);
+  let heal = Math.max(0, damage * lifeSteal * healingMultiplier);
+  const healOnHit = Number(offensiveSpecial.healOnHit) || 0;
+  if (healOnHit) {
+    heal += healOnHit;
+  }
+
+  return { damage, crit, dodged: false, heal, usingMagic };
+}
+
+function calculateCombatPower(stats, special = {}) {
+  if (!stats) return 0;
+  const maxHp = toNumber(stats.maxHp);
+  const physicalAttack = toNumber(stats.physicalAttack);
+  const magicAttack = toNumber(stats.magicAttack);
+  const physicalDefense = toNumber(stats.physicalDefense);
+  const magicDefense = toNumber(stats.magicDefense);
+  const speed = toNumber(stats.speed);
+  const accuracy = toNumber(stats.accuracy);
+  const dodge = toNumber(stats.dodge);
+  const critRate = clamp(toNumber(stats.critRate), 0, 0.95);
+  const critDamage = Math.max(1.2, toNumber(stats.critDamage) || 1.5);
+  const critResist = toNumber(stats.critResist);
+  const finalDamageBonus = toNumber(stats.finalDamageBonus);
+  const finalDamageReduction = clamp(toNumber(stats.finalDamageReduction), 0, 0.9);
+  const lifeSteal = clamp(toNumber(stats.lifeSteal), 0, 0.6);
+  const healingBonus = toNumber(stats.healingBonus);
+  const controlHit = toNumber(stats.controlHit);
+  const controlResist = toNumber(stats.controlResist);
+  const physicalPenetration = toNumber(stats.physicalPenetration);
+  const magicPenetration = toNumber(stats.magicPenetration);
+  const comboRate = toNumber(stats.comboRate);
+  const block = toNumber(stats.block);
+  const counterRate = toNumber(stats.counterRate);
+  const damageReduction = toNumber(stats.damageReduction);
+  const healingReceived = toNumber(stats.healingReceived);
+  const rageGain = toNumber(stats.rageGain);
+  const controlStrength = toNumber(stats.controlStrength);
+  const shieldPower = toNumber(stats.shieldPower);
+  const summonPower = toNumber(stats.summonPower);
+  const elementalVulnerability = toNumber(stats.elementalVulnerability);
+  const shield = toNumber(special.shield);
+  const bonusDamage = toNumber(special.bonusDamage);
+  const dodgeChance = toNumber(special.dodgeChance);
+
+  const power =
+    maxHp * 0.35 +
+    (physicalAttack + magicAttack) * 1.8 +
+    (physicalDefense + magicDefense) * 1.45 +
+    speed * 1.2 +
+    accuracy * 0.9 +
+    dodge * 2.5 +
+    critRate * 520 +
+    (critDamage - 1) * 180 +
+    finalDamageBonus * 650 -
+    finalDamageReduction * 480 +
+    critResist * 360 +
+    lifeSteal * 420 +
+    healingBonus * 380 +
+    controlHit * 1.1 +
+    controlResist * 1.1 +
+    physicalPenetration * 2.2 +
+    magicPenetration * 2.2 +
+    comboRate * 520 +
+    block * 380 +
+    counterRate * 480 +
+    damageReduction * 360 +
+    healingReceived * 340 +
+    rageGain * 320 +
+    controlStrength * 300 +
+    shieldPower * 260 +
+    summonPower * 240 +
+    elementalVulnerability * 320 +
+    shield * 0.25 +
+    bonusDamage * 1.4 +
+    dodgeChance * 620;
+  return Math.round(power);
+}
+
+module.exports = {
+  DEFAULT_COMBAT_STATS,
+  DEFAULT_SPECIAL_STATS,
+  clamp,
+  resolveCombatStats,
+  resolveSpecialStats,
+  createCombatantFromAttributes,
+  extractCombatProfile,
+  executeAttack,
+  calculateCombatPower
+};

--- a/docs/pve.md
+++ b/docs/pve.md
@@ -92,6 +92,8 @@
 
 所有动作均会同步写回 `members` 表的 `pveProfile` 字段，并在需要时记录灵石流水（`stoneTransactions`）。【F:cloudfunctions/pve/index.js†L691-L707】【F:cloudfunctions/pve/index.js†L713-L961】
 
+> **数值同步提示**：云函数会在每次更新属性、装备或技能时重新计算 `pveProfile.attributeSummary`，将装备词条、套装效果与技能增益折算为最终战斗属性，供 PVE 战斗与 PVP 竞技场共用。【F:cloudfunctions/pve/index.js†L2836-L2873】【F:cloudfunctions/pve/index.js†L2994-L3072】【F:cloudfunctions/pve/index.js†L3218-L3333】【F:cloudfunctions/pve/index.js†L3377-L3452】【F:cloudfunctions/pve/index.js†L5748-L5796】
+
 ## 部署提示
 
 1. 在云开发控制台创建或更新 `pve` 云函数，上传 `cloudfunctions/pve` 目录并安装依赖。

--- a/docs/pvp.md
+++ b/docs/pvp.md
@@ -44,6 +44,7 @@
 - 赛季自动轮转：当检测到当前赛季结束时会自动创建下一赛季，默认周期 56 天。
 - 段位区间：系统内置青铜→宗师六档，依据积分上下限自动映射段位与奖励。
 - 战斗模拟：基于会员 `pveProfile` 的最终战斗属性进行 15 回合以内的回合制结算，命中、暴击、伤害浮动与减伤均在云端处理。
+- 数值统一：战斗流程直接调用公共模块 `cloudfunctions/nodejs-layer/node_modules/combat-system/index.js`，与 PVE 共用命中、伤害与战力评估公式，确保竞技场与副本的属性口径一致。【F:cloudfunctions/nodejs-layer/node_modules/combat-system/index.js†L1-L210】【F:cloudfunctions/pvp/index.js†L1194-L1294】
 - 防刷机制：邀战会校验过期时间与状态；同一战斗结果生成 MD5 签名返回前端；机器人对战的积分增减有限制，避免刷分。
 
 ## 小程序前端
@@ -58,10 +59,11 @@
 
 ## 部署步骤
 
-1. 在云开发控制台创建上述五个集合，并设置必要索引（建议对 `pvpProfiles.points`、`pvpMatches.seasonId` 建立排序索引）。如在沙盒环境中暂未手动创建，`pvp` 云函数会在首次调用时尝试自动创建缺失集合，但仍建议在正式环境提前完成，以便配置索引与权限。 
+1. 在云开发控制台创建上述五个集合，并设置必要索引（建议对 `pvpProfiles.points`、`pvpMatches.seasonId` 建立排序索引）。如在沙盒环境中暂未手动创建，`pvp` 云函数会在首次调用时尝试自动创建缺失集合，但仍建议在正式环境提前完成，以便配置索引与权限。
 2. 在微信开发者工具中右键上传 `cloudfunctions/pvp` 目录并安装依赖。
-3. 更新小程序前端代码，确保 `miniprogram/services/config.js` 中新增的 `pvp` 云函数名称与实际部署一致。
-4. 若为老项目升级，请手动执行一次 `pvp` 云函数的 `profile` 动作（或让用户进入竞技场页面），以便生成默认档案。
-5. 赛季奖励文案默认内置，可在云数据库的 `pvpSeasons` 文档中按需调整奖励描述或周期。
+3. 若 `cloudfunctions/nodejs-layer/node_modules/combat-system` 有更新，请重新打包 `nodejs-layer` 并在 `pve`、`pvp` 云函数的“层管理”中绑定最新层版本，避免战斗公式不一致。
+4. 更新小程序前端代码，确保 `miniprogram/services/config.js` 中新增的 `pvp` 云函数名称与实际部署一致。
+5. 若为老项目升级，请手动执行一次 `pvp` 云函数的 `profile` 动作（或让用户进入竞技场页面），以便生成默认档案。
+6. 赛季奖励文案默认内置，可在云数据库的 `pvpSeasons` 文档中按需调整奖励描述或周期。
 
 部署完成后，会员即可在“比武”入口体验天梯匹配、好友切磋与邀战分享，实现线上社交裂变与线下消费联动。

--- a/docs/pvp.md
+++ b/docs/pvp.md
@@ -45,6 +45,7 @@
 - 段位区间：系统内置青铜→宗师六档，依据积分上下限自动映射段位与奖励。
 - 战斗模拟：基于会员 `pveProfile` 的最终战斗属性进行 15 回合以内的回合制结算，命中、暴击、伤害浮动与减伤均在云端处理。
 - 数值统一：战斗流程直接调用公共模块 `cloudfunctions/nodejs-layer/node_modules/combat-system/index.js`，与 PVE 共用命中、伤害与战力评估公式，确保竞技场与副本的属性口径一致。【F:cloudfunctions/nodejs-layer/node_modules/combat-system/index.js†L1-L210】【F:cloudfunctions/pvp/index.js†L1194-L1294】
+- 档案快照：`pve` 云函数在写回会员档案时会刷新 `attributeSummary`，竞技场直接读取该字段即可获得包含装备、技能增益的最终战斗属性。【F:cloudfunctions/pve/index.js†L2836-L2873】【F:cloudfunctions/pve/index.js†L3377-L3452】【F:cloudfunctions/pve/index.js†L3738-L3796】【F:cloudfunctions/pvp/index.js†L1198-L1239】
 - 防刷机制：邀战会校验过期时间与状态；同一战斗结果生成 MD5 签名返回前端；机器人对战的积分增减有限制，避免刷分。
 
 ## 小程序前端


### PR DESCRIPTION
## Summary
- introduce a reusable combat-system layer that exposes shared attribute aggregation, attack resolution, and combat power helpers
- refactor the pve and pvp cloud functions to consume the shared module for player/enemy combatants, simulations, and stats snapshots
- refresh documentation to describe the unified formulas and new deployment requirement for the combat-system layer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e218f9b95c8330b03b1591310d3e2f