### PR TITLE
Fix skill unequip slot handling

### DIFF
--- a/cloudfunctions/pve/index.js
+++ b/cloudfunctions/pve/index.js
@@ -2287,7 +2287,20 @@ async function equipSkill(actorId, event) {
     }
   }
 
-  let resolvedSlot = typeof slot === 'number' && slot >= 0 && slot < MAX_SKILL_SLOTS ? slot : null;
+  let resolvedSlot = null;
+  if (typeof slot === 'number') {
+    if (slot >= 0 && slot < MAX_SKILL_SLOTS) {
+      resolvedSlot = slot;
+    }
+  } else if (typeof slot === 'string') {
+    const parsedSlot = Number(slot);
+    if (Number.isFinite(parsedSlot)) {
+      const normalizedSlot = Math.floor(parsedSlot);
+      if (normalizedSlot >= 0 && normalizedSlot < MAX_SKILL_SLOTS) {
+        resolvedSlot = normalizedSlot;
+      }
+    }
+  }
 
   if (resolvedSlot !== null) {
     if (normalizedSkillId) {

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -276,6 +276,11 @@ export const PveService = {
     const payload = { action: 'equipSkill', skillId: skillId || '' };
     if (typeof slot === 'number') {
       payload.slot = slot;
+    } else if (typeof slot === 'string' && slot.trim()) {
+      const parsedSlot = Number(slot);
+      if (Number.isFinite(parsedSlot)) {
+        payload.slot = Math.floor(parsedSlot);
+      }
     }
     return callCloud(CLOUD_FUNCTIONS.PVE, payload);
   },


### PR DESCRIPTION
## Summary
- normalize the skill slot argument on the client before calling the equipSkill cloud function
- accept numeric strings for the slot parameter on the equipSkill cloud handler so unequip requests persist

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e248cbe47883308877afb8324332a3