### PR TITLE
Fix foundation background auto unlock configuration

### DIFF
--- a/cloudfunctions/member/shared/backgrounds.js
+++ b/cloudfunctions/member/shared/backgrounds.js
@@ -2,7 +2,7 @@ const RAW_BACKGROUNDS = [
   { id: 'realm_refining', realmOrder: 1, realmName: '炼气期', name: '炼气之地', unlockType: 'realm' },
   { id: 'trial_spirit_test', realmOrder: 1, realmName: '炼气期', name: '灵根测试', unlockType: 'manual' },
   { id: 'realm_foundation', realmOrder: 2, realmName: '筑基期', name: '筑基之地', unlockType: 'realm' },
-  { id: 'reward_foundation', realmOrder: 2, realmName: '筑基期', name: '筑基背景', unlockType: 'manual' },
+  { id: 'reward_foundation', realmOrder: 2, realmName: '筑基期', name: '筑基背景', unlockType: 'realm' },
   { id: 'realm_core', realmOrder: 3, realmName: '金丹期', name: '金丹之地', unlockType: 'realm' },
   { id: 'realm_nascent', realmOrder: 4, realmName: '元婴期', name: '元婴之地', unlockType: 'realm' },
   { id: 'realm_divine', realmOrder: 5, realmName: '化神期', name: '化神之地', unlockType: 'realm' },

--- a/miniprogram/shared/backgrounds.js
+++ b/miniprogram/shared/backgrounds.js
@@ -4,7 +4,7 @@ const RAW_BACKGROUNDS = [
   { id: 'realm_refining', realmOrder: 1, realmName: '炼气期', name: '炼气之地', unlockType: 'realm' },
   { id: 'trial_spirit_test', realmOrder: 1, realmName: '炼气期', name: '灵根测试', unlockType: 'manual', mediaKey: '1' },
   { id: 'realm_foundation', realmOrder: 2, realmName: '筑基期', name: '筑基之地', unlockType: 'realm' },
-  { id: 'reward_foundation', realmOrder: 2, realmName: '筑基期', name: '筑基背景', unlockType: 'manual', mediaKey: '2' },
+  { id: 'reward_foundation', realmOrder: 2, realmName: '筑基期', name: '筑基背景', unlockType: 'realm', mediaKey: '2' },
   { id: 'realm_core', realmOrder: 3, realmName: '金丹期', name: '金丹之地', unlockType: 'realm' },
   { id: 'realm_nascent', realmOrder: 4, realmName: '元婴期', name: '元婴之地', unlockType: 'realm' },
   { id: 'realm_divine', realmOrder: 5, realmName: '化神期', name: '化神之地', unlockType: 'realm' },


### PR DESCRIPTION
## Summary
- align the筑基背景 configuration with the auto unlock flow by marking it as realm unlocked in both cloud functions and miniprogram

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2c86e52b08330a2b4701ef84b3df6