### PR TITLE
feat: support appearance titles

### DIFF
--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -51,6 +51,9 @@
         <view class="profile-info">
           <view class="profile-name" bindtap="handleProfileTap">{{member ? (member.nickName || '无名仙友') : '无名仙友'}}</view>
           <view class="profile-meta">
+            <view wx:if="{{activeTitleImage}}" class="profile-meta__title">
+              <image class="profile-meta__title-image" src="{{activeTitleImage}}" mode="heightFix"></image>
+            </view>
             <text class="profile-meta__text" bindtap="handleLevelTap">境界 {{member ? (member.level ? member.level.name : '练气初期') : '练气初期'}}</text>
             <text class="profile-meta__text" bindtap="handleStoneTap">灵石 {{memberStats.stoneBalance}}</text>
             <text class="profile-meta__text" bindtap="handleExperienceTap">修为 {{memberStats.experience}}</text>
@@ -234,6 +237,11 @@
             bindtap="handleAppearanceTabChange"
           >相框</view>
           <view
+            class="appearance-tab {{avatarPicker.activeTab === 'title' ? 'appearance-tab--active' : ''}}"
+            data-tab="title"
+            bindtap="handleAppearanceTabChange"
+          >称号</view>
+          <view
             class="appearance-tab {{avatarPicker.activeTab === 'background' ? 'appearance-tab--active' : ''}}"
             data-tab="background"
             bindtap="handleAppearanceTabChange"
@@ -280,6 +288,28 @@
                   ></image>
                 </view>
                 <view class="avatar-frame-option__label">{{item.name}}</view>
+              </view>
+            </view>
+          </view>
+          <view wx:elif="{{avatarPicker.activeTab === 'title'}}" class="archive-section appearance-section">
+            <view class="appearance-title-grid">
+              <view
+                class="appearance-title-option {{avatarPicker.appearanceTitle === item.id ? 'appearance-title-option--active' : ''}}"
+                wx:for="{{avatarPicker.titleOptions}}"
+                wx:key="id"
+                data-id="{{item.id}}"
+                bindtap="handleTitleSelect"
+              >
+                <view class="appearance-title-option__preview">
+                  <image
+                    wx:if="{{item.image}}"
+                    class="appearance-title-option__image"
+                    src="{{item.image}}"
+                    mode="widthFix"
+                  ></image>
+                  <view wx:else class="appearance-title-option__placeholder">无称号</view>
+                </view>
+                <view class="appearance-title-option__label">{{item.name}}</view>
               </view>
             </view>
           </view>

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -177,6 +177,19 @@ page {
   color: rgba(220, 230, 255, 0.8);
 }
 
+.profile-meta__title {
+  display: flex;
+  align-items: center;
+  min-height: 40rpx;
+}
+
+.profile-meta__title-image {
+  height: 40rpx;
+  max-width: 260rpx;
+  width: auto;
+  display: block;
+}
+
 .profile-meta__text {
   display: block;
   white-space: nowrap;
@@ -757,6 +770,58 @@ page {
   width: 100%;
   height: 100%;
   border-radius: 50%;
+}
+
+.appearance-title-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 24rpx;
+  margin: 12rpx 0 24rpx;
+  justify-items: center;
+}
+
+.appearance-title-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12rpx;
+}
+
+.appearance-title-option__preview {
+  width: 160rpx;
+  min-height: 72rpx;
+  padding: 16rpx;
+  border-radius: 20rpx;
+  background: rgba(30, 42, 102, 0.6);
+  border: 4rpx solid transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.appearance-title-option--active .appearance-title-option__preview {
+  border-color: rgba(156, 178, 255, 0.85);
+  transform: translateY(-4rpx);
+  box-shadow: 0 0 0 8rpx rgba(156, 178, 255, 0.2);
+}
+
+.appearance-title-option__image {
+  width: 100%;
+  height: auto;
+}
+
+.appearance-title-option__placeholder {
+  font-size: 24rpx;
+  color: rgba(220, 230, 255, 0.85);
+  text-align: center;
+}
+
+.appearance-title-option__label {
+  font-size: 22rpx;
+  color: rgba(220, 230, 255, 0.85);
+  text-align: center;
 }
 
 .appearance-section {

--- a/miniprogram/shared/asset-paths.js
+++ b/miniprogram/shared/asset-paths.js
@@ -11,11 +11,13 @@ function buildCloudAssetUrl(...segments) {
 const BACKGROUND_IMAGE_BASE_PATH = buildCloudAssetUrl('background');
 const BACKGROUND_VIDEO_BASE_PATH = buildCloudAssetUrl('background');
 const CHARACTER_IMAGE_BASE_PATH = buildCloudAssetUrl('character');
+const TITLE_IMAGE_BASE_PATH = buildCloudAssetUrl('title');
 
 module.exports = {
   CLOUD_ASSET_BASE_PATH,
   BACKGROUND_IMAGE_BASE_PATH,
   BACKGROUND_VIDEO_BASE_PATH,
   CHARACTER_IMAGE_BASE_PATH,
+  TITLE_IMAGE_BASE_PATH,
   buildCloudAssetUrl
 };

--- a/miniprogram/shared/titles.js
+++ b/miniprogram/shared/titles.js
@@ -1,0 +1,66 @@
+const { TITLE_IMAGE_BASE_PATH } = require('./asset-paths.js');
+
+const RAW_TITLES = [
+  { id: 'title_refining_rookie', name: '炼气新人' }
+];
+
+function normalizeTitleId(id) {
+  if (typeof id !== 'string') {
+    return '';
+  }
+  return id.trim();
+}
+
+function buildTitleImageUrl(id) {
+  const normalized = normalizeTitleId(id);
+  if (!normalized) {
+    return '';
+  }
+  return `${TITLE_IMAGE_BASE_PATH}/${normalized}.png`;
+}
+
+function decorateTitle(definition) {
+  if (!definition || !definition.id) {
+    return null;
+  }
+  const normalized = normalizeTitleId(definition.id);
+  if (!normalized) {
+    return null;
+  }
+  return {
+    ...definition,
+    id: normalized,
+    image: buildTitleImageUrl(normalized)
+  };
+}
+
+const TITLES = RAW_TITLES.map((item) => decorateTitle(item)).filter(Boolean);
+const TITLE_MAP = new Map(TITLES.map((item) => [item.id, item]));
+
+function listTitles() {
+  return TITLES.map((title) => ({ ...title }));
+}
+
+function resolveTitleById(id) {
+  const normalized = normalizeTitleId(id);
+  if (!normalized) {
+    return null;
+  }
+  if (TITLE_MAP.has(normalized)) {
+    const matched = TITLE_MAP.get(normalized);
+    return matched ? { ...matched } : null;
+  }
+  return {
+    id: normalized,
+    name: '神秘称号',
+    image: buildTitleImageUrl(normalized)
+  };
+}
+
+module.exports = {
+  listTitles,
+  resolveTitleById,
+  buildTitleImageUrl,
+  normalizeTitleId,
+  TITLE_IMAGE_BASE_PATH
+};


### PR DESCRIPTION
## Summary
- add a title tab to the appearance picker, persist the selected title, and surface the active badge next to the profile avatar
- provide shared helpers for title assets so the mini program can list unlocked options
- update the member archive cloud function to validate and store appearance titles alongside existing appearance fields

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2d1cb6c10833099c7fcf92ca0d700