### PR TITLE
优化外观设置弹窗 tab 布局

### DIFF
--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -224,6 +224,8 @@
     <view class="modal-content modal-content--avatar">
       <view class="modal-header modal-header--appearance">
         <view class="modal-title">外观设置</view>
+        <view class="modal-close" bindtap="handleCloseAvatarPicker">×</view>
+      </view>
         <view class="appearance-tabs">
           <view
             class="appearance-tab {{avatarPicker.activeTab === 'avatar' ? 'appearance-tab--active' : ''}}"
@@ -246,8 +248,6 @@
             bindtap="handleAppearanceTabChange"
           >背景</view>
         </view>
-        <view class="modal-close" bindtap="handleCloseAvatarPicker">×</view>
-      </view>
       <view class="appearance-modal__body-wrapper">
         <scroll-view scroll-y="true" class="modal-body modal-body--scroll appearance-modal__body">
           <view wx:if="{{avatarPicker.activeTab === 'avatar'}}" class="archive-section appearance-section">

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -522,12 +522,22 @@ page {
 }
 
 .modal-header--appearance {
-  align-items: flex-end;
-  gap: 16rpx;
+  align-items: flex-start;
+  flex-wrap: wrap;
 }
 
 .modal-header--appearance .modal-title {
   flex-shrink: 0;
+}
+
+.modal-header--appearance .modal-close {
+  order: 2;
+}
+
+.modal-header--appearance .appearance-tabs {
+  order: 3;
+  width: 100%;
+  margin-top: 16rpx;
 }
 
 .appearance-tabs {


### PR DESCRIPTION
## Summary
- 调整外观设置弹窗头部的布局，让标签行换行排列在标题下方，避免文字折行

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2dcddde3c8330843fc6e80cc2e3e8