### PR TITLE
feat: 显示首页战力数值

### DIFF
--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -58,7 +58,7 @@
         </view>
         <view class="profile-other">
             <text class="profile-meta__text" bindtap="handleLevelTap">境界 {{member ? (member.level ? member.level.name : '练气初期') : '练气初期'}}</text>
-            <text class="profile-meta__text" bindtap="handleStoneTap">战力 </text>
+            <text class="profile-meta__text" bindtap="handleStoneTap">战力 {{memberStats.combatPower}}</text>
             <text class="profile-meta__text" bindtap="handleStoneTap">灵石 {{memberStats.stoneBalance}}</text>
         </view>
       </view>

--- a/miniprogram/utils/format.js
+++ b/miniprogram/utils/format.js
@@ -69,6 +69,20 @@ export const formatStones = (value = 0) => {
   return normalized.toString();
 };
 
+export const formatCombatPower = (value = 0) => {
+  const numeric = coerceToNumber(value);
+  if (!Number.isFinite(numeric)) {
+    return '0';
+  }
+
+  const normalized = Math.max(0, Math.floor(numeric));
+  if (normalized >= 10000) {
+    return normalized.toLocaleString('zh-CN');
+  }
+
+  return normalized.toString();
+};
+
 export const formatStoneChange = (value = 0) => {
   const numeric = coerceToNumber(value);
   if (!Number.isFinite(numeric) || numeric === 0) {


### PR DESCRIPTION
## Summary
- 新增战力数值格式化方法并完善会员统计信息
- 解析会员档案中的战力数据并在首页数据模型中暴露
- 首页头像信息区域展示战力具体数值

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e3405e88208330a691a68c9be99981