### PR TITLE
Fix default background fallback ordering

### DIFF
--- a/miniprogram/shared/backgrounds.js
+++ b/miniprogram/shared/backgrounds.js
@@ -103,7 +103,9 @@ function resolveHighestUnlockedBackgroundByRealmOrder(realmOrder) {
   if (!Number.isFinite(numericRealmOrder)) {
     return cloneBackground(BACKGROUNDS[0]);
   }
-  const unlocked = BACKGROUNDS.filter((background) => numericRealmOrder >= background.realmOrder);
+  const unlocked = BACKGROUNDS.filter(
+    (background) => background.unlockType !== 'manual' && numericRealmOrder >= background.realmOrder
+  );
   const target = unlocked.length ? unlocked[unlocked.length - 1] : BACKGROUNDS[0];
   return cloneBackground(target);
 }


### PR DESCRIPTION
## Summary
- ensure the highest unlocked background fallback ignores manual backgrounds so the default stays on realm backgrounds
- keep the initial load from briefly showing the manual bg-free-1 image before the member's chosen background is applied

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4ec7d41fc833099cce738417cb83f