### PR TITLE
feat: add media key mapping for storage item icons

### DIFF
--- a/cloudfunctions/member/index.js
+++ b/cloudfunctions/member/index.js
@@ -238,6 +238,39 @@ function applyStorageRewardMetadata(item, rewardType) {
   return item;
 }
 
+function resolveStorageRewardMediaKey(reward) {
+  if (!reward || typeof reward !== 'object') {
+    return '';
+  }
+  if (typeof reward.mediaKey === 'string' && reward.mediaKey.trim()) {
+    return reward.mediaKey.trim();
+  }
+  const type = typeof reward.type === 'string' ? reward.type.trim() : '';
+  if (type === 'background') {
+    return 'item-1';
+  }
+  if (type === 'title') {
+    return 'item-2';
+  }
+  if (type === 'skill') {
+    return 'item-3';
+  }
+  const usageType =
+    reward.usage && typeof reward.usage === 'object' && typeof reward.usage.type === 'string'
+      ? reward.usage.type.trim()
+      : '';
+  if (usageType === 'skillDraw' || usageType === 'skillUnlock' || usageType === 'unlockSkill') {
+    return 'item-3';
+  }
+  if (usageType === 'grantRight' || usageType === 'grantCoupon' || usageType === 'coupon') {
+    return 'item-4';
+  }
+  if (type === 'right' || type === 'voucher' || type === 'coupon') {
+    return 'item-4';
+  }
+  return '';
+}
+
 function createStorageRewardItem(reward, now = new Date()) {
   if (!reward || typeof reward !== 'object') {
     return null;
@@ -265,6 +298,7 @@ function createStorageRewardItem(reward, now = new Date()) {
     storageCategory: reward.storageCategory || defaultCategory,
     slotLabel: reward.slotLabel || resolveStorageCategoryLabel(reward.storageCategory || defaultCategory),
     obtainedAt: now,
+    mediaKey: resolveStorageRewardMediaKey(reward),
     actions:
       Array.isArray(reward.actions) && reward.actions.length
         ? reward.actions.map((action) => ({

--- a/miniprogram/utils/equipment.js
+++ b/miniprogram/utils/equipment.js
@@ -115,6 +115,12 @@ export function buildEquipmentIconPaths(item) {
   if (!item || typeof item !== 'object') {
     return { iconUrl: '', iconFallbackUrl: '' };
   }
+  const mediaKey = typeof item.mediaKey === 'string' ? item.mediaKey.trim() : '';
+  if (mediaKey) {
+    const fileName = /\.[a-z0-9]+$/i.test(mediaKey) ? mediaKey : `${mediaKey}.png`;
+    const mediaUrl = buildCloudAssetUrl('item', fileName);
+    return { iconUrl: mediaUrl, iconFallbackUrl: mediaUrl };
+  }
   const iconId = toPositiveInt(item.iconId);
   const qualityRank = toPositiveInt(item.qualityRank) || resolveEquipmentQualityRank(item.quality);
   if (!qualityRank) {

--- a/miniprogram/utils/equipment.js
+++ b/miniprogram/utils/equipment.js
@@ -111,13 +111,59 @@ function resolveEquipmentQualityRank(quality) {
   return EQUIPMENT_QUALITY_RANK_MAP[key] || 1;
 }
 
+function resolveStorageMediaKey(item) {
+  if (!item || typeof item !== 'object') {
+    return '';
+  }
+  const usageType =
+    item.usage && typeof item.usage === 'object' && typeof item.usage.type === 'string'
+      ? item.usage.type.trim()
+      : '';
+  if (!usageType && typeof item.slotLabel === 'string') {
+    const slotLabel = item.slotLabel.trim();
+    if (slotLabel === '背景') {
+      return 'item-1';
+    }
+    if (slotLabel === '称号') {
+      return 'item-2';
+    }
+  }
+  if (usageType === 'unlockBackground' || usageType === 'backgroundUnlock') {
+    return 'item-1';
+  }
+  if (usageType === 'unlockTitle' || usageType === 'titleUnlock') {
+    return 'item-2';
+  }
+  if (usageType === 'skillDraw' || usageType === 'skillUnlock' || usageType === 'unlockSkill') {
+    return 'item-3';
+  }
+  if (usageType === 'grantRight' || usageType === 'grantCoupon' || usageType === 'coupon') {
+    return 'item-4';
+  }
+  const type = typeof item.type === 'string' ? item.type.trim() : '';
+  if (type === 'background') {
+    return 'item-1';
+  }
+  if (type === 'title') {
+    return 'item-2';
+  }
+  if (type === 'skill') {
+    return 'item-3';
+  }
+  if (type === 'right' || type === 'voucher' || type === 'coupon') {
+    return 'item-4';
+  }
+  return '';
+}
+
 export function buildEquipmentIconPaths(item) {
   if (!item || typeof item !== 'object') {
     return { iconUrl: '', iconFallbackUrl: '' };
   }
-  const mediaKey = typeof item.mediaKey === 'string' ? item.mediaKey.trim() : '';
-  if (mediaKey) {
-    const fileName = /\.[a-z0-9]+$/i.test(mediaKey) ? mediaKey : `${mediaKey}.png`;
+  const directMediaKey = typeof item.mediaKey === 'string' ? item.mediaKey.trim() : '';
+  const inferredMediaKey = directMediaKey || resolveStorageMediaKey(item);
+  if (inferredMediaKey) {
+    const fileName = /\.[a-z0-9]+$/i.test(inferredMediaKey) ? inferredMediaKey : `${inferredMediaKey}.png`;
     const mediaUrl = buildCloudAssetUrl('item', fileName);
     return { iconUrl: mediaUrl, iconFallbackUrl: mediaUrl };
   }


### PR DESCRIPTION
## Summary
- assign media keys to storage rewards based on their type and usage so background, title, skill, and rights items map to the correct icons
- update front-end icon resolution to prefer media keys when building storage item icon URLs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4f90d34a88330840a7f4556dee4fb