### PR TITLE
Allow superadmin role to access admin functions

### DIFF
--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -14,7 +14,7 @@ const db = cloud.database();
 const _ = db.command;
 const $ = db.command.aggregate;
 
-const ADMIN_ROLES = DEFAULT_ADMIN_ROLES;
+const ADMIN_ROLES = [...new Set([...DEFAULT_ADMIN_ROLES, 'superadmin'])];
 const MIN_REPORT_MONTH = new Date(2025, 8, 1);
 const AVATAR_ID_PATTERN = /^(male|female)-([a-z]+)-(\d+)$/;
 const ALLOWED_AVATAR_IDS = new Set(listAvatarIds());

--- a/cloudfunctions/pve/index.js
+++ b/cloudfunctions/pve/index.js
@@ -3969,11 +3969,10 @@ function isAdminMember(member) {
     });
   }
 
-  const adminRoleSet = new Set(
-    Array.isArray(DEFAULT_ADMIN_ROLES)
-      ? DEFAULT_ADMIN_ROLES.map((role) => (typeof role === 'string' ? role.trim().toLowerCase() : '')).filter(Boolean)
-      : []
-  );
+  const defaultRoles = Array.isArray(DEFAULT_ADMIN_ROLES)
+    ? DEFAULT_ADMIN_ROLES.map((role) => (typeof role === 'string' ? role.trim().toLowerCase() : '')).filter(Boolean)
+    : [];
+  const adminRoleSet = new Set([...defaultRoles, 'superadmin']);
 
   return normalizedRoles.some((role) => adminRoleSet.has(role));
 }


### PR DESCRIPTION
## Summary
- allow the superadmin role to pass the admin cloud function permission check by extending the accepted role list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e50bf79dbc83309f28454b08f8d173