### PR TITLE
Add Thanksgiving event admin dashboard

### DIFF
--- a/docs/thanksgiving-pass.md
+++ b/docs/thanksgiving-pass.md
@@ -8,6 +8,10 @@
   例如 ¥998 票价会生成 -99800 的消费记录与 +99800 灵石流水。
 - 会员档案奖励：进入活动页时会检测昵称非空且头像不为默认占位图（`avatar/default.png`），满足条件即可获赠 1 次额外砍价机会并写入 `thanksgivingProfileRewarded` 标记，防止重复发放。
 
+## 管理员监控
+- 管理端新增「感恩节活动管理」页面（管理员中心 → 感恩节活动管理），实时展示下单总数、最近订单明细、库存剩余与 `thanksgiving-pass`
+  权益使用状态分布，便于运营随时跟进购票与权益落地情况。
+
 ## 部署步骤
 1. 重新部署 `cloudfunctions/activities`：确保新建 `bhkBargainStock` 集合权限默认即可，云函数发布后会自动初始化库存文档。
 2. 若此前未发放过权益，请一并部署 `cloudfunctions/member`，以使用 `grantRight` 动作写入感恩节通行证。

--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -66,6 +66,7 @@
         "activities/index",
         "finance-report/index",
         "data-cleanup/index",
+        "thanksgiving/index",
         "system-switches/index"
       ]
     }

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -1397,6 +1397,13 @@ export const AdminService = {
       activityId,
       updates
     });
+  },
+  async getThanksgivingDashboard(options = {}) {
+    const payload = { action: 'getThanksgivingDashboard' };
+    if (options && Number.isFinite(options.limit)) {
+      payload.limit = options.limit;
+    }
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, payload);
   }
 };
 

--- a/miniprogram/subpackages/admin/index.js
+++ b/miniprogram/subpackages/admin/index.js
@@ -32,6 +32,12 @@ const BASE_ACTIONS = [
     url: '/subpackages/admin/activities/index'
   },
   {
+    icon: '🦃',
+    label: '感恩节活动管理',
+    description: '查看感恩节下单、库存与权益',
+    url: '/subpackages/admin/thanksgiving/index'
+  },
+  {
     icon: '🍽️',
     label: '备餐列表',
     description: '查看会员点餐并推送扣费',

--- a/miniprogram/subpackages/admin/thanksgiving/index.js
+++ b/miniprogram/subpackages/admin/thanksgiving/index.js
@@ -1,0 +1,88 @@
+import { AdminService } from '../../../services/api';
+import { formatDateTime } from '../../../utils/format';
+
+function buildRightsSummary(breakdown = []) {
+  const parts = breakdown
+    .filter((item) => item && Number(item.count) > 0)
+    .map((item) => `${item.label} ${item.count}`);
+  return parts.join(' / ');
+}
+
+function normalizeOrders(orders = []) {
+  if (!Array.isArray(orders)) {
+    return [];
+  }
+  return orders.map((item) => ({
+    ...item,
+    displayName: item.displayName || '未命名会员',
+    amountLabel: item.amountLabel || '¥0.00',
+    purchasedAtLabel: item.purchasedAtLabel || formatDateTime(item.purchasedAt) || '—',
+    rightStatusLabel: item.rightStatusLabel || '未发放'
+  }));
+}
+
+Page({
+  data: {
+    loading: true,
+    error: '',
+    summary: {
+      orderCount: 0,
+      orderLimit: 0,
+      stockRemaining: 0,
+      totalStock: 0,
+      sold: 0,
+      rightsTotal: 0,
+      rightsSummary: '',
+      rightsBreakdown: [],
+      updatedAtLabel: ''
+    },
+    orders: []
+  },
+
+  onLoad() {
+    this.loadDashboard();
+  },
+
+  async loadDashboard() {
+    this.setData({ loading: true, error: '' });
+    try {
+      const dashboard = await AdminService.getThanksgivingDashboard();
+      const summary = this.normalizeDashboard(dashboard || {});
+      this.setData({
+        loading: false,
+        summary,
+        orders: normalizeOrders(summary.orders)
+      });
+    } catch (error) {
+      console.error('[admin/thanksgiving] load dashboard failed', error);
+      this.setData({
+        loading: false,
+        error: (error && error.errMsg) || error.message || '加载失败，请稍后重试'
+      });
+    }
+  },
+
+  handleRefresh() {
+    if (this.data.loading) return;
+    this.loadDashboard();
+  },
+
+  normalizeDashboard(payload = {}) {
+    const breakdown = (payload.rights && payload.rights.breakdown) || [];
+    const summaryText = buildRightsSummary(breakdown);
+    const stock = payload.stock || {};
+    const orders = Array.isArray(payload.orders) ? payload.orders : [];
+    return {
+      orderCount: Number(payload.orderCount || 0),
+      orderLimit: Number(payload.orderLimit || orders.length || 0),
+      stockRemaining: Number.isFinite(stock.stockRemaining) ? stock.stockRemaining : 0,
+      totalStock: Number.isFinite(stock.totalStock) ? stock.totalStock : 0,
+      sold: Number.isFinite(stock.sold) ? stock.sold : 0,
+      rightsTotal: (payload.rights && Number(payload.rights.total)) || 0,
+      rightsSummary: summaryText,
+      rightsBreakdown: breakdown,
+      updatedAtLabel: payload.updatedAtLabel || formatDateTime(payload.updatedAt),
+      orders
+    };
+  }
+});

--- a/miniprogram/subpackages/admin/thanksgiving/index.json
+++ b/miniprogram/subpackages/admin/thanksgiving/index.json
@@ -1,0 +1,10 @@
+{
+  "navigationBarTitleText": "感恩节活动管理",
+  "usingComponents": {
+    "custom-nav": "/components/custom-nav/custom-nav",
+    "custom-nav-placeholder": "/components/custom-nav-placeholder/custom-nav-placeholder"
+  },
+  "componentPlaceholder": {
+    "custom-nav": "custom-nav-placeholder"
+  }
+}

--- a/miniprogram/subpackages/admin/thanksgiving/index.wxml
+++ b/miniprogram/subpackages/admin/thanksgiving/index.wxml
@@ -1,0 +1,63 @@
+<custom-nav title="感恩节活动管理" theme="dark"></custom-nav>
+<view class="page">
+  <view class="hero">
+    <view class="hero-text">
+      <view class="hero-title">BHK 感恩节活动监控</view>
+      <view class="hero-subtitle">实时查看下单数、库存与权益发放状态</view>
+      <view wx:if="{{summary.updatedAtLabel}}" class="hero-updated">更新于 {{summary.updatedAtLabel}}</view>
+    </view>
+    <button class="refresh-btn" bindtap="handleRefresh" loading="{{loading}}">{{loading ? '刷新中…' : '刷新数据'}}</button>
+  </view>
+
+  <view class="summary-grid">
+    <view class="summary-card">
+      <view class="summary-label">实时下单数</view>
+      <view class="summary-value">{{summary.orderCount || 0}}</view>
+      <view class="summary-desc">展示最近 {{summary.orderLimit || 0}} 笔下单明细</view>
+    </view>
+    <view class="summary-card">
+      <view class="summary-label">库存</view>
+      <view class="summary-value">{{summary.stockRemaining}} / {{summary.totalStock}}</view>
+      <view class="summary-desc">已售 {{summary.sold}}</view>
+    </view>
+    <view class="summary-card">
+      <view class="summary-label">权益使用</view>
+      <view class="summary-value">{{summary.rightsTotal}}</view>
+      <view class="summary-desc">{{summary.rightsSummary || '未发放'}}</view>
+    </view>
+  </view>
+
+  <view class="section">
+    <view class="section-title">权益使用状态</view>
+    <view wx:if="{{summary.rightsBreakdown.length}}" class="pill-row">
+      <view wx:for="{{summary.rightsBreakdown}}" wx:key="status" class="pill">
+        <text class="pill-count">{{item.count}}</text>
+        <text class="pill-label">{{item.label}}</text>
+      </view>
+    </view>
+    <view wx:else class="empty-text">暂未发放感恩节通行证权益</view>
+  </view>
+
+  <view class="section">
+    <view class="section-title">实时下单明细</view>
+    <view wx:if="{{orders.length}}" class="order-list">
+      <view wx:for="{{orders}}" wx:key="{{item.orderId || item.memberId || index}}" class="order-card">
+        <view class="order-header">
+          <view class="order-member">{{item.displayName}}</view>
+          <view class="order-amount">{{item.amountLabel || '¥0.00'}}</view>
+        </view>
+        <view class="order-meta">会员 ID：{{item.memberId}}</view>
+        <view wx:if="{{item.mobile}}" class="order-meta">手机号：{{item.mobile}}</view>
+        <view class="order-meta">下单时间：{{item.purchasedAtLabel || '—'}}</view>
+        <view class="order-meta">订单号：{{item.orderId || '待补全'}}</view>
+        <view class="order-tags">
+          <view class="tag solid">权益：{{item.rightStatusLabel}}</view>
+          <view class="tag" wx:if="{{item.ticketOwned}}">已落地购票</view>
+        </view>
+      </view>
+    </view>
+    <view wx:else class="empty-text">暂无购票记录，等待新的实时订单。</view>
+  </view>
+
+  <view wx:if="{{error}}" class="error-banner">{{error}}</view>
+</view>

--- a/miniprogram/subpackages/admin/thanksgiving/index.wxss
+++ b/miniprogram/subpackages/admin/thanksgiving/index.wxss
@@ -1,0 +1,192 @@
+.page {
+  padding: 24rpx;
+  background: #0b0c10;
+  min-height: 100vh;
+  color: #f5f7fb;
+}
+
+.hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24rpx;
+  margin-bottom: 24rpx;
+  border-radius: 16rpx;
+  background: linear-gradient(135deg, #1f2833, #0b1d2c);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.hero-text {
+  display: flex;
+  flex-direction: column;
+  gap: 8rpx;
+}
+
+.hero-title {
+  font-size: 34rpx;
+  font-weight: 700;
+}
+
+.hero-subtitle {
+  font-size: 26rpx;
+  color: #9fb3c8;
+}
+
+.hero-updated {
+  font-size: 22rpx;
+  color: #7fd1de;
+}
+
+.refresh-btn {
+  background: #7fd1de;
+  color: #0b0c10;
+  font-weight: 600;
+  border-radius: 12rpx;
+  padding: 12rpx 24rpx;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16rpx;
+  margin-bottom: 24rpx;
+}
+
+.summary-card {
+  background: #121821;
+  padding: 20rpx;
+  border-radius: 16rpx;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.summary-label {
+  font-size: 24rpx;
+  color: #9fb3c8;
+}
+
+.summary-value {
+  margin-top: 8rpx;
+  font-size: 40rpx;
+  font-weight: 700;
+}
+
+.summary-desc {
+  margin-top: 6rpx;
+  font-size: 22rpx;
+  color: #9fb3c8;
+}
+
+.section {
+  background: #121821;
+  border-radius: 16rpx;
+  padding: 20rpx;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  margin-bottom: 24rpx;
+}
+
+.section-title {
+  font-size: 28rpx;
+  font-weight: 700;
+  margin-bottom: 12rpx;
+}
+
+.pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12rpx;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8rpx;
+  padding: 10rpx 14rpx;
+  border-radius: 999rpx;
+  background: rgba(127, 209, 222, 0.12);
+  color: #7fd1de;
+}
+
+.pill-count {
+  font-weight: 700;
+}
+
+.pill-label {
+  font-size: 24rpx;
+}
+
+.order-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16rpx;
+}
+
+.order-card {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12rpx;
+  padding: 16rpx;
+  background: #0f1620;
+}
+
+.order-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8rpx;
+}
+
+.order-member {
+  font-size: 28rpx;
+  font-weight: 700;
+}
+
+.order-amount {
+  font-size: 28rpx;
+  color: #ffd166;
+}
+
+.order-meta {
+  font-size: 24rpx;
+  color: #9fb3c8;
+  margin-top: 6rpx;
+}
+
+.order-tags {
+  display: flex;
+  gap: 10rpx;
+  flex-wrap: wrap;
+  margin-top: 12rpx;
+}
+
+.tag {
+  padding: 8rpx 12rpx;
+  border-radius: 10rpx;
+  background: rgba(255, 255, 255, 0.06);
+  color: #dce4f2;
+  font-size: 22rpx;
+}
+
+.tag.solid {
+  background: linear-gradient(120deg, #7fd1de, #5fb6c4);
+  color: #0b0c10;
+  font-weight: 700;
+}
+
+.empty-text {
+  font-size: 24rpx;
+  color: #9fb3c8;
+}
+
+.error-banner {
+  margin-top: 12rpx;
+  padding: 12rpx 16rpx;
+  border-radius: 12rpx;
+  background: rgba(255, 102, 102, 0.18);
+  color: #ffcdd2;
+  border: 1px solid rgba(255, 102, 102, 0.35);
+}
+
+@media (max-width: 750px) {
+  .summary-grid {
+    grid-template-columns: repeat(1, 1fr);
+  }
+}


### PR DESCRIPTION
## Summary
- add an admin-side Thanksgiving event dashboard with real-time order, stock, and rights visibility
- expose a backend admin action and client API for Thanksgiving monitoring
- document the new admin entry and wire the subpackage page into navigation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929a15f47ac83339ad406938dbba8e1)