### PR TITLE
Add balance config field documentation

### DIFF
--- a/cloudfunctions/nodejs-layer/node_modules/balance/config/equipment-curves.md
+++ b/cloudfunctions/nodejs-layer/node_modules/balance/config/equipment-curves.md
@@ -1,0 +1,12 @@
+# equipment-curves.json 字段说明
+
+此文件定义装备强化相关的数值档位。`config-loader` 会读取 `profiles` 中与当前 `balanceVersion` 对应的配置；未覆盖的字段会回退到默认值 `v1`。结构如下：
+
+- `version`：默认版本标识（字符串）。`config-loader` 会把它作为优先选择的 profile key。
+- `profiles`：按版本分组的配置集合。
+  - `v1`、`v2` 等：具体版本配置对象。
+    - `slots`：可强化的装备槽位列表。默认包含 `weapon`、`armor`、`accessory`，用于校验/生成装备数据时允许的槽位集合。
+    - `enhancement`：强化基础系数配置。
+      - `base`：所有装备强化的基础倍率。`v1` 为 `1`，`v2` 为 `1.05`，后者比前者整体提升 5%。此值会在装备强化数值计算中作为基准倍率。
+
+> 运行时通过 `getEquipmentCurveConfig()` 读取，若运行时未找到对应版本或字段缺失，会自动回退到上述默认结构。【F:cloudfunctions/nodejs-layer/node_modules/balance/config-loader.js†L77-L89】【F:cloudfunctions/nodejs-layer/node_modules/balance/config/equipment-curves.json†L1-L13】

--- a/cloudfunctions/nodejs-layer/node_modules/balance/config/level-curves.md
+++ b/cloudfunctions/nodejs-layer/node_modules/balance/config/level-curves.md
@@ -1,0 +1,28 @@
+# level-curves.json 字段说明
+
+此文件定义基础战斗属性的默认值与若干公式边界。`config-loader` 会先读取对应 `profile`，缺失字段自动回退到默认 `v1`。主要结构：
+
+- `version`：默认使用的版本标识。
+- `profiles`：各版本配置。
+  - `v1`（默认完整配置）
+    - `defaults`
+      - `combatStats`：角色基础战斗属性的初始值，缺省时 combat-system 会使用它们作为新角色属性基线并支持别名映射。【F:cloudfunctions/nodejs-layer/node_modules/combat-system/index.js†L4-L89】
+        - 包含 `maxHp`、`physicalAttack`、`magicAttack`、`physicalDefense`、`magicDefense`、`speed`、`accuracy`、`dodge`、`critRate`、`critDamage`、`finalDamageBonus`、`finalDamageReduction`、`lifeSteal`、`healingBonus`、`healingReduction`、`controlHit`、`controlResist`、`physicalPenetration`、`magicPenetration`、`critResist`、`comboRate`、`block`、`counterRate`、`damageReduction`、`healingReceived`、`rageGain`、`controlStrength`、`shieldPower`、`summonPower`、`elementalVulnerability` 等所有基础数值，各字段含义与战斗公式同名参数一致。
+      - `specialStats`：特殊状态类属性默认值，供角色初始化使用，字段包括 `shield`、`bonusDamage`、`dodgeChance`、`healOnHit`、`healOnKill`、`damageReflection`、`accuracyBonus`、`speedBonus`、`physicalPenetrationBonus`、`magicPenetrationBonus`。
+    - `hitFormula`：命中概率公式参数，提供 `base`（基础命中率）、`slope`（命中随等级或命中属性的增长斜率）、`min`、`max`（结果上下限）。
+    - `penetration`：穿透系数控制，`scale` 为穿透属性对减防效果的转化比例，`max` 为减防率上限。
+    - `baseDamage`：基础伤害浮动控制，`minAttackRatio` 为最低攻击占比，`randomMin` 与 `randomRange` 控制随机浮动区间，`minDamage` 为保底伤害。
+    - `crit`：暴击率与暴击伤害的边界，`min`/`max` 为暴击触发概率范围，`damageMin` 为暴击伤害倍率下限。
+    - `finalDamage`：终伤加成/减免相关的截断配置，`minMultiplier` 为终伤下限，`bonusClamp`/`reductionClamp` 分别定义终伤加成与减免的最小/最大值。
+    - `healing`：治疗与吸血相关限制，`lifeStealMax` 为吸血上限，`healingBonusClamp`、`healingReductionClamp`、`healingReceivedClamp` 控制各项治疗系数的上下限。
+    - `mitigation`：减伤率上限，字段 `damageReductionMax`。
+    - `procCaps`：触发类属性上限，包含 `comboRateMax`、`blockMax`、`counterRateMax`。
+    - `specialCaps`：特殊效果上限，如 `dodgeChanceMax`、`damageReflectionMax`。
+    - `statFloors`：关键属性的下限设置，目前包含 `critDamageMin`（暴击伤害下限），供战斗公式截断使用。【F:cloudfunctions/nodejs-layer/node_modules/combat-system/index.js†L67-L130】
+  - `v2`（相对 v1 的增量覆盖）
+    - `defaults`：空对象，表示沿用 v1 默认属性。
+    - `hitFormula`：仅覆盖 `base`，将基础命中率提升至 0.87。
+    - `baseDamage`：调整伤害浮动范围（`randomMin`=0.95，`randomRange`=0.22）。
+    - `crit`：提高暴击下限（`min`=0.07）。
+
+> 运行时通过 `getLevelCurveConfig()` 读取，未配置字段会回退到上述默认值，以确保战斗公式具备安全的上下限。配置还会被 combat-system 用于计算属性界限与截断。【F:cloudfunctions/nodejs-layer/node_modules/balance/config-loader.js†L8-L75】【F:cloudfunctions/nodejs-layer/node_modules/combat-system/index.js†L91-L132】

--- a/cloudfunctions/nodejs-layer/node_modules/balance/config/pve-curves.md
+++ b/cloudfunctions/nodejs-layer/node_modules/balance/config/pve-curves.md
@@ -1,0 +1,28 @@
+# pve-curves.json 字段说明
+
+此文件控制 PVE（含秘境）战斗的全局节奏与敌人基线数值。`config-loader` 依据 `balanceVersion` 选择对应 profile，并与默认 `v1` 递归合并。
+
+- `version`：默认版本标识。
+- `profiles`：按版本定义的配置集合。
+  - `v1`（完整默认配置）
+    - `maxLevel`：PVE 角色/敌人的等级上限。
+    - `roundLimit`：PVE 战斗最大回合数，超出后按平局处理。`simulator.js` 读取此值控制对战循环。【F:cloudfunctions/nodejs-layer/node_modules/balance/simulator.js†L37-L59】
+    - `cooldownMs`：服务器判定战斗冷却时间（毫秒）。用于限制重复开战频率，相关提示文案见 `cooldownMessage`。
+    - `cooldownMessage`：冷却期间向玩家展示的提示文案。
+    - `secretRealm`：秘境模式专用配置。
+      - `baseStats`：敌方基础属性模板（生命、攻击、防御、速度、命中/闪避、暴击、终伤、吸血、控制相关等），构造秘境敌人时以此为基线。
+      - `tuning`：秘境难度调节参数。
+        - `baseMultiplier`：楼层数值总体倍率基础值。
+        - `floorGrowth`：每层递增的数值倍率（线性增长部分）。
+        - `realmGrowth`：每个秘境章节（realm）提升的额外增幅。
+        - `normal`：普通怪物的多属性系数，对应不同抗性/属性类型的倍率：
+          - `base`：基础倍率；`primary`/`secondary`/`tertiary`：主、副、次要属性的加成；`off`：非针对属性；`weak`：克制下的衰减。
+        - `boss`：首领怪系数，字段与 `normal` 类似但包含 `tertiary`。
+        - `special`：特殊怪增益，`base` 为基础倍率、`growth` 为每层增幅、`boss` 为首领额外倍率。
+        - `limits`：秘境敌人属性上限（暴击率、暴击伤害、终伤加成/减免、吸血、命中、闪避），生成敌人时需截断到此范围内。
+  - `v2`（增量覆盖）
+    - `roundLimit`：将最大回合数调低至 18。
+    - `secretRealm.tuning.normal.primary`：普通怪主属性倍率降至 1.25，以降低前期强度。
+    - `secretRealm.tuning.limits.finalDamageReduction`：终伤减免上限降至 0.5。
+
+> 运行时通过 `getPveCurveConfig()` 读取，战斗模拟与秘境敌人生成都会引用上述字段，缺失部分会沿用 `v1` 默认值。【F:cloudfunctions/nodejs-layer/node_modules/balance/config-loader.js†L114-L184】【F:cloudfunctions/nodejs-layer/node_modules/balance/simulator.js†L37-L59】

--- a/cloudfunctions/nodejs-layer/node_modules/balance/config/pvp-config.md
+++ b/cloudfunctions/nodejs-layer/node_modules/balance/config/pvp-config.md
@@ -1,0 +1,25 @@
+# pvp-config.json 字段说明
+
+此文件定义 PVP 排位/匹配相关的全局参数。`config-loader` 会按 `balanceVersion` 选择 profile，与默认 `v1` 合并。
+
+- `version`：默认版本标识。
+- `profiles`：各版本配置集合。
+  - `v1`（完整默认配置）
+    - `roundLimit`：PVP 战斗的最大回合数。`simulatePvpBattle` 使用该值控制对战循环。【F:cloudfunctions/nodejs-layer/node_modules/balance/simulator.js†L61-L76】
+    - `cooldownMs`：同一玩家发起 PVP 战斗的冷却时间（毫秒）。
+    - `cooldownMessage`：处于冷却状态时返回给玩家的提示文案。
+    - `seasonLengthDays`：赛季时长（天），用于服务器重置排行/发放奖励的周期。
+    - `leaderboardCacheSize`：排行榜缓存数量上限，用于限制内存占用及接口返回条数。
+    - `leaderboardSchemaVersion`：排行榜数据结构版本号，便于迁移或兼容处理。
+    - `recentMatchLimit`：保留最近对局记录的数量，用于匹配冷却或展示。
+    - `defaultRating`：新玩家的 Elo/天梯初始分数。
+    - `tiers`：段位区间列表，按从低到高定义。
+      - 每个段位项包含：`id`（标识）、`name`（名称）、`min`/`max`（分数范围；`master` 最大值为 Infinity）、`color`（显示用颜色）、`rewardKey`（对应奖励表的 key）。
+    - `tierRewards`：各段位赛季奖励定义。
+      - 以 `rewardKey` 为键，值包含 `stones`（货币数量）、`title`（称号字符串）、`coupon`（可为空的券 ID）。
+  - `v2`（增量覆盖）
+    - `roundLimit`：下调至 13 回合以加快节奏。
+    - `cooldownMs`：保持 10 秒。
+    - `defaultRating`：新手初始分提高到 1250；其余字段沿用 v1。
+
+> 运行时通过 `getPvpConfig()` 读取，缺失字段都会从 v1 默认配置回填，保证匹配、排行榜和奖励逻辑的参数完整性。【F:cloudfunctions/nodejs-layer/node_modules/balance/config-loader.js†L185-L250】【F:cloudfunctions/nodejs-layer/node_modules/balance/simulator.js†L61-L76】

--- a/cloudfunctions/nodejs-layer/node_modules/balance/config/skill-curves.md
+++ b/cloudfunctions/nodejs-layer/node_modules/balance/config/skill-curves.md
@@ -1,0 +1,28 @@
+# skill-curves.json 字段说明
+
+此文件描述技能资源与控制效果的默认机制。`config-loader` 会按版本读取并与 `v1` 合并，供 skill-engine 创建角色运行时使用。
+
+- `version`：默认版本标识。
+- `profiles`：各版本配置集合。
+  - `v1`（完整默认配置）
+    - `resource`
+      - `defaults`：技能资源（如怒气/真气）基础规则。
+        - `type`：资源类型标识，默认 `qi`。
+        - `baseMax`：资源槽最大值。
+        - `startFraction`：开局按最大值的百分比获得的资源比例。
+        - `startValue`：开局的资源固定值（与 `startFraction` 叠加）。
+        - `turnGain`：每个回合自然回复的资源量。
+        - `basicAttackGain`：普攻后获得的资源量。
+        - `damageTakenGain`：受到伤害时的资源系数（乘以伤害量）。
+        - `critGain`：造成暴击时额外获得的资源量。
+        - `critTakenGain`：被暴击时额外获得的资源量。
+    - `controlEffects`：各类控制效果的行为定义，skill-engine 会据此决定回合是否跳过、哪些动作被禁用等。
+      - `stun`：眩晕。`summary`=描述文本；`skip`=true（整回合跳过）；`disableBasic`/`disableActive`/`disableDodge`=true，表示普攻、主动技能与闪避均被禁用。
+      - `silence`：沉默。只禁止主动技能（`disableActive`=true），其他动作保留。
+      - `freeze`：冰冻。与眩晕类似会跳过回合并禁用所有动作，附加 `breakOnFire`=true 表示受到火属性伤害会解除；`fireDamageMultiplier`=0.1 表示被火属性克制时伤害加成系数。
+      - `sleep`：沉睡。跳过回合且禁用所有动作；`wakeOnDamage`=true 表示受击立即唤醒；`turnResourceGain`=10 表示沉睡回合仍会被动回复的资源量。
+  - `v2`（增量覆盖）
+    - `resource.defaults`：提升资源获取与初始资源比例（`turnGain`=24、`basicAttackGain`=12、`damageTakenGain`=1.8、`startFraction`=0.1）。
+    - `controlEffects.sleep.turnResourceGain`：沉睡状态下的被动回复提升到 14。
+
+> `createActorRuntime` 在构建角色时会引用这些资源与控制效果定义，确保技能、沉睡/冰冻等状态与配置保持一致。缺失字段会按 `v1` 补全。【F:cloudfunctions/nodejs-layer/node_modules/balance/config-loader.js†L40-L113】【F:cloudfunctions/nodejs-layer/node_modules/balance/config/skill-curves.json†L1-L38】


### PR DESCRIPTION
## Summary
- add Chinese markdown documentation for each balance config JSON file
- describe every field and version fallback behavior based on config-loader logic

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c4e849c648333ab1d2ccc28b9154d)