### PR TITLE
Add Chinese tables for level curve attributes

### DIFF
--- a/cloudfunctions/nodejs-layer/node_modules/balance/config/level-curves.md
+++ b/cloudfunctions/nodejs-layer/node_modules/balance/config/level-curves.md
@@ -26,3 +26,101 @@
     - `crit`：提高暴击下限（`min`=0.07）。
 
 > 运行时通过 `getLevelCurveConfig()` 读取，未配置字段会回退到上述默认值，以确保战斗公式具备安全的上下限。配置还会被 combat-system 用于计算属性界限与截断。【F:cloudfunctions/nodejs-layer/node_modules/balance/config-loader.js†L8-L75】【F:cloudfunctions/nodejs-layer/node_modules/combat-system/index.js†L91-L132】
+
+## 主要字段的属性说明
+
+### defaults.combatStats（基础战斗属性）
+
+| 属性名 | 中文含义 |
+| --- | --- |
+| `maxHp` | 最大生命值上限 |
+| `physicalAttack` | 物理攻击强度 |
+| `magicAttack` | 魔法攻击强度 |
+| `physicalDefense` | 物理防御力 |
+| `magicDefense` | 魔法防御力 |
+| `speed` | 速度（行动条增长率） |
+| `accuracy` | 命中率 |
+| `dodge` | 闪避率 |
+| `critRate` | 暴击率 |
+| `critDamage` | 暴击伤害倍数 |
+| `finalDamageBonus` | 终伤加成系数 |
+| `finalDamageReduction` | 终伤减免系数 |
+| `lifeSteal` | 吸血比例 |
+| `healingBonus` | 主动治疗加成 |
+| `healingReduction` | 对目标施加的治疗减免 |
+| `controlHit` | 控制命中（影响控制类效果命中率） |
+| `controlResist` | 控制抗性（抵抗控制效果） |
+| `physicalPenetration` | 物理防御穿透 |
+| `magicPenetration` | 魔法防御穿透 |
+| `critResist` | 暴击抵抗率 |
+| `comboRate` | 连击触发概率 |
+| `block` | 格挡率 |
+| `counterRate` | 反击概率 |
+| `damageReduction` | 减伤率（通用伤害减免） |
+| `healingReceived` | 受治疗加成 |
+| `rageGain` | 怒气获取效率 |
+| `controlStrength` | 控制强度（延长或强化控制效果） |
+| `shieldPower` | 护盾强度加成 |
+| `summonPower` | 召唤物强度系数 |
+| `elementalVulnerability` | 元素易伤系数 |
+
+### defaults.specialStats（特殊状态初始值）
+
+| 属性名 | 中文含义 |
+| --- | --- |
+| `shield` | 初始护盾值 |
+| `bonusDamage` | 额外伤害系数 |
+| `dodgeChance` | 额外闪避概率 |
+| `healOnHit` | 攻击命中时回复生命比例 |
+| `healOnKill` | 击杀后回复生命比例 |
+| `damageReflection` | 反弹伤害比例 |
+| `accuracyBonus` | 额外命中加成 |
+| `speedBonus` | 额外速度加成 |
+| `physicalPenetrationBonus` | 额外物理穿透 |
+| `magicPenetrationBonus` | 额外魔法穿透 |
+
+### baseDamage（基础伤害浮动）
+
+| 属性名 | 中文含义 |
+| --- | --- |
+| `minAttackRatio` | 伤害计算中攻击力占比的最低阈值 |
+| `randomMin` | 随机浮动区间的起始值 |
+| `randomRange` | 随机浮动幅度 |
+| `minDamage` | 伤害保底值 |
+
+### finalDamage（终伤截断）
+
+| 属性名 | 中文含义 |
+| --- | --- |
+| `minMultiplier` | 终伤总乘区的最低倍率 |
+| `bonusClamp.min` | 终伤加成的最小截断值 |
+| `bonusClamp.max` | 终伤加成的最大截断值 |
+| `reductionClamp.min` | 终伤减免的最小截断值 |
+| `reductionClamp.max` | 终伤减免的最大截断值 |
+
+### healing（治疗/吸血限制）
+
+| 属性名 | 中文含义 |
+| --- | --- |
+| `lifeStealMax` | 吸血比例上限 |
+| `healingBonusClamp.min` | 治疗加成的最小截断值 |
+| `healingBonusClamp.max` | 治疗加成的最大截断值 |
+| `healingReductionClamp.min` | 治疗减免的最小截断值 |
+| `healingReductionClamp.max` | 治疗减免的最大截断值 |
+| `healingReceivedClamp.min` | 受治疗加成的最小截断值 |
+| `healingReceivedClamp.max` | 受治疗加成的最大截断值 |
+
+### procCaps（触发类上限）
+
+| 属性名 | 中文含义 |
+| --- | --- |
+| `comboRateMax` | 连击概率上限 |
+| `blockMax` | 格挡概率上限 |
+| `counterRateMax` | 反击概率上限 |
+
+### specialCaps（特殊效果上限）
+
+| 属性名 | 中文含义 |
+| --- | --- |
+| `dodgeChanceMax` | 闪避概率上限 |
+| `damageReflectionMax` | 反弹伤害比例上限 |


### PR DESCRIPTION
## Summary
- add tables explaining combatStats, specialStats, and other level-curve attributes in Chinese

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c7bf4119c833395b95c94d4a608c6)