### PR TITLE
Add default values to level curve tables

### DIFF
--- a/cloudfunctions/nodejs-layer/node_modules/balance/config/level-curves.md
+++ b/cloudfunctions/nodejs-layer/node_modules/balance/config/level-curves.md
@@ -26,3 +26,101 @@
     - `crit`：提高暴击下限（`min`=0.07）。
 
 > 运行时通过 `getLevelCurveConfig()` 读取，未配置字段会回退到上述默认值，以确保战斗公式具备安全的上下限。配置还会被 combat-system 用于计算属性界限与截断。【F:cloudfunctions/nodejs-layer/node_modules/balance/config-loader.js†L8-L75】【F:cloudfunctions/nodejs-layer/node_modules/combat-system/index.js†L91-L132】
+
+## 主要字段的属性说明
+
+### defaults.combatStats（基础战斗属性）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `maxHp` | 最大生命值上限 | `2860` |
+| `physicalAttack` | 物理攻击强度 | `82` |
+| `magicAttack` | 魔法攻击强度 | `82` |
+| `physicalDefense` | 物理防御力 | `61` |
+| `magicDefense` | 魔法防御力 | `61` |
+| `speed` | 速度（行动条增长率） | `92` |
+| `accuracy` | 命中率 | `112` |
+| `dodge` | 闪避率 | `96` |
+| `critRate` | 暴击率 | `0.062` |
+| `critDamage` | 暴击伤害倍数 | `1.52` |
+| `finalDamageBonus` | 终伤加成系数 | `0` |
+| `finalDamageReduction` | 终伤减免系数 | `0.024` |
+| `lifeSteal` | 吸血比例 | `0` |
+| `healingBonus` | 主动治疗加成 | `0.08` |
+| `healingReduction` | 对目标施加的治疗减免 | `0` |
+| `controlHit` | 控制命中（影响控制类效果命中率） | `11` |
+| `controlResist` | 控制抗性（抵抗控制效果） | `11` |
+| `physicalPenetration` | 物理防御穿透 | `1` |
+| `magicPenetration` | 魔法防御穿透 | `1` |
+| `critResist` | 暴击抵抗率 | `0.0184` |
+| `comboRate` | 连击触发概率 | `0` |
+| `block` | 格挡率 | `0` |
+| `counterRate` | 反击概率 | `0` |
+| `damageReduction` | 减伤率（通用伤害减免） | `0` |
+| `healingReceived` | 受治疗加成 | `0` |
+| `rageGain` | 怒气获取效率 | `0` |
+| `controlStrength` | 控制强度（延长或强化控制效果） | `0` |
+| `shieldPower` | 护盾强度加成 | `0` |
+| `summonPower` | 召唤物强度系数 | `0` |
+| `elementalVulnerability` | 元素易伤系数 | `0` |
+
+### defaults.specialStats（特殊状态初始值）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `shield` | 初始护盾值 | `0` |
+| `bonusDamage` | 额外伤害系数 | `0` |
+| `dodgeChance` | 额外闪避概率 | `0` |
+| `healOnHit` | 攻击命中时回复生命比例 | `0` |
+| `healOnKill` | 击杀后回复生命比例 | `0` |
+| `damageReflection` | 反弹伤害比例 | `0` |
+| `accuracyBonus` | 额外命中加成 | `0` |
+| `speedBonus` | 额外速度加成 | `0` |
+| `physicalPenetrationBonus` | 额外物理穿透 | `0` |
+| `magicPenetrationBonus` | 额外魔法穿透 | `0` |
+
+### baseDamage（基础伤害浮动）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `minAttackRatio` | 伤害计算中攻击力占比的最低阈值 | `0.25` |
+| `randomMin` | 随机浮动区间的起始值 | `0.9` |
+| `randomRange` | 随机浮动幅度 | `0.2` |
+| `minDamage` | 伤害保底值 | `1` |
+
+### finalDamage（终伤截断）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `minMultiplier` | 终伤总乘区的最低倍率 | `0.1` |
+| `bonusClamp.min` | 终伤加成的最小截断值 | `-0.9` |
+| `bonusClamp.max` | 终伤加成的最大截断值 | `2` |
+| `reductionClamp.min` | 终伤减免的最小截断值 | `0` |
+| `reductionClamp.max` | 终伤减免的最大截断值 | `0.9` |
+
+### healing（治疗/吸血限制）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `lifeStealMax` | 吸血比例上限 | `0.6` |
+| `healingBonusClamp.min` | 治疗加成的最小截断值 | `-1` |
+| `healingBonusClamp.max` | 治疗加成的最大截断值 | `1.5` |
+| `healingReductionClamp.min` | 治疗减免的最小截断值 | `-1` |
+| `healingReductionClamp.max` | 治疗减免的最大截断值 | `1.5` |
+| `healingReceivedClamp.min` | 受治疗加成的最小截断值 | `-0.5` |
+| `healingReceivedClamp.max` | 受治疗加成的最大截断值 | `1.5` |
+
+### procCaps（触发类上限）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `comboRateMax` | 连击概率上限 | `1` |
+| `blockMax` | 格挡概率上限 | `1` |
+| `counterRateMax` | 反击概率上限 | `1` |
+
+### specialCaps（特殊效果上限）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `dodgeChanceMax` | 闪避概率上限 | `0.8` |
+| `damageReflectionMax` | 反弹伤害比例上限 | `0.8` |


### PR DESCRIPTION
## Summary
- add default numeric values to the combatStats and specialStats Chinese explanation tables
- document default limits for baseDamage, finalDamage, healing, procCaps, and specialCaps

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c7bf4119c833395b95c94d4a608c6)