### PR TITLE
Document defaults across balance config docs

### DIFF
--- a/cloudfunctions/nodejs-layer/node_modules/balance/config/equipment-curves.md
+++ b/cloudfunctions/nodejs-layer/node_modules/balance/config/equipment-curves.md
@@ -10,3 +10,21 @@
       - `base`：所有装备强化的基础倍率。`v1` 为 `1`，`v2` 为 `1.05`，后者比前者整体提升 5%。此值会在装备强化数值计算中作为基准倍率。
 
 > 运行时通过 `getEquipmentCurveConfig()` 读取，若运行时未找到对应版本或字段缺失，会自动回退到上述默认结构。【F:cloudfunctions/nodejs-layer/node_modules/balance/config-loader.js†L77-L89】【F:cloudfunctions/nodejs-layer/node_modules/balance/config/equipment-curves.json†L1-L13】
+
+## 主要字段的属性说明
+
+### slots（可强化装备槽位）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `weapon` | 武器槽位是否允许强化 | ✅ 包含于列表 |
+| `armor` | 防具槽位是否允许强化 | ✅ 包含于列表 |
+| `accessory` | 饰品槽位是否允许强化 | ✅ 包含于列表 |
+
+> 默认列表取自 `v1`，`v2` 同样保留三类槽位。
+
+### enhancement（强化基础系数）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `base` | 强化计算使用的基础倍率 | `1`（`v2` 提升到 `1.05`） |

--- a/cloudfunctions/nodejs-layer/node_modules/balance/config/level-curves.md
+++ b/cloudfunctions/nodejs-layer/node_modules/balance/config/level-curves.md
@@ -26,3 +26,101 @@
     - `crit`：提高暴击下限（`min`=0.07）。
 
 > 运行时通过 `getLevelCurveConfig()` 读取，未配置字段会回退到上述默认值，以确保战斗公式具备安全的上下限。配置还会被 combat-system 用于计算属性界限与截断。【F:cloudfunctions/nodejs-layer/node_modules/balance/config-loader.js†L8-L75】【F:cloudfunctions/nodejs-layer/node_modules/combat-system/index.js†L91-L132】
+
+## 主要字段的属性说明
+
+### defaults.combatStats（基础战斗属性）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `maxHp` | 最大生命值上限 | `2860` |
+| `physicalAttack` | 物理攻击强度 | `82` |
+| `magicAttack` | 魔法攻击强度 | `82` |
+| `physicalDefense` | 物理防御力 | `61` |
+| `magicDefense` | 魔法防御力 | `61` |
+| `speed` | 速度（行动条增长率） | `92` |
+| `accuracy` | 命中率 | `112` |
+| `dodge` | 闪避率 | `96` |
+| `critRate` | 暴击率 | `0.062` |
+| `critDamage` | 暴击伤害倍数 | `1.52` |
+| `finalDamageBonus` | 终伤加成系数 | `0` |
+| `finalDamageReduction` | 终伤减免系数 | `0.024` |
+| `lifeSteal` | 吸血比例 | `0` |
+| `healingBonus` | 主动治疗加成 | `0.08` |
+| `healingReduction` | 对目标施加的治疗减免 | `0` |
+| `controlHit` | 控制命中（影响控制类效果命中率） | `11` |
+| `controlResist` | 控制抗性（抵抗控制效果） | `11` |
+| `physicalPenetration` | 物理防御穿透 | `1` |
+| `magicPenetration` | 魔法防御穿透 | `1` |
+| `critResist` | 暴击抵抗率 | `0.0184` |
+| `comboRate` | 连击触发概率 | `0` |
+| `block` | 格挡率 | `0` |
+| `counterRate` | 反击概率 | `0` |
+| `damageReduction` | 减伤率（通用伤害减免） | `0` |
+| `healingReceived` | 受治疗加成 | `0` |
+| `rageGain` | 怒气获取效率 | `0` |
+| `controlStrength` | 控制强度（延长或强化控制效果） | `0` |
+| `shieldPower` | 护盾强度加成 | `0` |
+| `summonPower` | 召唤物强度系数 | `0` |
+| `elementalVulnerability` | 元素易伤系数 | `0` |
+
+### defaults.specialStats（特殊状态初始值）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `shield` | 初始护盾值 | `0` |
+| `bonusDamage` | 额外伤害系数 | `0` |
+| `dodgeChance` | 额外闪避概率 | `0` |
+| `healOnHit` | 攻击命中时回复生命比例 | `0` |
+| `healOnKill` | 击杀后回复生命比例 | `0` |
+| `damageReflection` | 反弹伤害比例 | `0` |
+| `accuracyBonus` | 额外命中加成 | `0` |
+| `speedBonus` | 额外速度加成 | `0` |
+| `physicalPenetrationBonus` | 额外物理穿透 | `0` |
+| `magicPenetrationBonus` | 额外魔法穿透 | `0` |
+
+### baseDamage（基础伤害浮动）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `minAttackRatio` | 伤害计算中攻击力占比的最低阈值 | `0.25` |
+| `randomMin` | 随机浮动区间的起始值 | `0.9` |
+| `randomRange` | 随机浮动幅度 | `0.2` |
+| `minDamage` | 伤害保底值 | `1` |
+
+### finalDamage（终伤截断）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `minMultiplier` | 终伤总乘区的最低倍率 | `0.1` |
+| `bonusClamp.min` | 终伤加成的最小截断值 | `-0.9` |
+| `bonusClamp.max` | 终伤加成的最大截断值 | `2` |
+| `reductionClamp.min` | 终伤减免的最小截断值 | `0` |
+| `reductionClamp.max` | 终伤减免的最大截断值 | `0.9` |
+
+### healing（治疗/吸血限制）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `lifeStealMax` | 吸血比例上限 | `0.6` |
+| `healingBonusClamp.min` | 治疗加成的最小截断值 | `-1` |
+| `healingBonusClamp.max` | 治疗加成的最大截断值 | `1.5` |
+| `healingReductionClamp.min` | 治疗减免的最小截断值 | `-1` |
+| `healingReductionClamp.max` | 治疗减免的最大截断值 | `1.5` |
+| `healingReceivedClamp.min` | 受治疗加成的最小截断值 | `-0.5` |
+| `healingReceivedClamp.max` | 受治疗加成的最大截断值 | `1.5` |
+
+### procCaps（触发类上限）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `comboRateMax` | 连击概率上限 | `1` |
+| `blockMax` | 格挡概率上限 | `1` |
+| `counterRateMax` | 反击概率上限 | `1` |
+
+### specialCaps（特殊效果上限）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `dodgeChanceMax` | 闪避概率上限 | `0.8` |
+| `damageReflectionMax` | 反弹伤害比例上限 | `0.8` |

--- a/cloudfunctions/nodejs-layer/node_modules/balance/config/pve-curves.md
+++ b/cloudfunctions/nodejs-layer/node_modules/balance/config/pve-curves.md
@@ -26,3 +26,85 @@
     - `secretRealm.tuning.limits.finalDamageReduction`：终伤减免上限降至 0.5。
 
 > 运行时通过 `getPveCurveConfig()` 读取，战斗模拟与秘境敌人生成都会引用上述字段，缺失部分会沿用 `v1` 默认值。【F:cloudfunctions/nodejs-layer/node_modules/balance/config-loader.js†L114-L184】【F:cloudfunctions/nodejs-layer/node_modules/balance/simulator.js†L37-L59】
+
+## 主要字段的属性说明
+
+### v1 顶层参数
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `maxLevel` | PVE 等级上限 | `100` |
+| `roundLimit` | 最大回合数 | `20`（`v2` 下调为 `18`） |
+| `cooldownMs` | 战斗冷却时间（毫秒） | `10000` |
+| `cooldownMessage` | 冷却提示文案 | `"您的上一场战斗还没结束，请稍后再战"` |
+
+### secretRealm.baseStats（秘境敌人基线属性）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `maxHp` | 最大生命值 | `920` |
+| `physicalAttack` | 物理攻击力 | `120` |
+| `magicAttack` | 魔法攻击力 | `120` |
+| `physicalDefense` | 物理防御力 | `68` |
+| `magicDefense` | 魔法防御力 | `65` |
+| `speed` | 速度 | `82` |
+| `accuracy` | 命中 | `118` |
+| `dodge` | 闪避 | `88` |
+| `critRate` | 暴击率 | `0.06` |
+| `critDamage` | 暴击伤害 | `1.52` |
+| `finalDamageBonus` | 终伤加成 | `0.025` |
+| `finalDamageReduction` | 终伤减免 | `0.035` |
+| `lifeSteal` | 吸血 | `0.015` |
+| `controlHit` | 控制命中 | `26` |
+| `controlResist` | 控制抗性 | `18` |
+| `physicalPenetration` | 物理穿透 | `9` |
+| `magicPenetration` | 魔法穿透 | `9` |
+
+### secretRealm.tuning（秘境数值调节）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `baseMultiplier` | 楼层数值整体倍率基础值 | `1` |
+| `floorGrowth` | 每层递增倍率 | `0.08` |
+| `realmGrowth` | 每章递增倍率 | `0.34` |
+
+### secretRealm.tuning.normal（普通怪物多属性系数）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `base` | 基础倍率 | `1` |
+| `primary` | 主属性倍率 | `1.35`（`v2` 为 `1.25`） |
+| `secondary` | 副属性倍率 | `1.15` |
+| `off` | 非针对属性倍率 | `0.98` |
+| `weak` | 克制衰减倍率 | `0.85` |
+
+### secretRealm.tuning.boss（首领怪物多属性系数）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `base` | 基础倍率 | `1.22` |
+| `primary` | 主属性倍率 | `1.68` |
+| `secondary` | 副属性倍率 | `1.34` |
+| `tertiary` | 次要属性倍率 | `1.15` |
+| `off` | 非针对属性倍率 | `1` |
+| `weak` | 克制衰减倍率 | `0.88` |
+
+### secretRealm.tuning.special（特殊怪物增益）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `base` | 特殊怪基础倍率 | `1` |
+| `growth` | 每层增幅 | `0.07` |
+| `boss` | 特殊首领额外倍率 | `1.5` |
+
+### secretRealm.tuning.limits（秘境敌人属性上限）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `critRate` | 暴击率上限 | `0.45` |
+| `critDamage` | 暴击伤害上限 | `2.15` |
+| `finalDamageBonus` | 终伤加成上限 | `0.4` |
+| `finalDamageReduction` | 终伤减免上限 | `0.55`（`v2` 下调为 `0.5`） |
+| `lifeSteal` | 吸血上限 | `0.18` |
+| `accuracy` | 命中属性上限 | `520` |
+| `dodge` | 闪避属性上限 | `420` |

--- a/cloudfunctions/nodejs-layer/node_modules/balance/config/pvp-config.md
+++ b/cloudfunctions/nodejs-layer/node_modules/balance/config/pvp-config.md
@@ -23,3 +23,40 @@
     - `defaultRating`：新手初始分提高到 1250；其余字段沿用 v1。
 
 > 运行时通过 `getPvpConfig()` 读取，缺失字段都会从 v1 默认配置回填，保证匹配、排行榜和奖励逻辑的参数完整性。【F:cloudfunctions/nodejs-layer/node_modules/balance/config-loader.js†L185-L250】【F:cloudfunctions/nodejs-layer/node_modules/balance/simulator.js†L61-L76】
+
+## 主要字段的属性说明
+
+### v1 顶层参数
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `roundLimit` | PVP 最大回合数 | `15`（`v2` 为 `13`） |
+| `cooldownMs` | 战斗冷却时间（毫秒） | `10000` |
+| `cooldownMessage` | 冷却提示文案 | `"您的上一场战斗还没结束，请稍后再战"` |
+| `seasonLengthDays` | 赛季时长（天） | `56` |
+| `leaderboardCacheSize` | 排行榜缓存条数上限 | `100` |
+| `leaderboardSchemaVersion` | 排行榜数据版本 | `2` |
+| `recentMatchLimit` | 最近对局记录保留数量 | `10` |
+| `defaultRating` | 新玩家初始分 | `1200`（`v2` 为 `1250`） |
+
+### tiers（段位区间定义）
+
+| 段位 id | 名称 | 分数下限 | 分数上限 | 颜色 | 奖励 key |
+| --- | --- | --- | --- | --- | --- |
+| `bronze` | 青铜 | `0` | `999` | `#c4723a` | `bronze` |
+| `silver` | 白银 | `1000` | `1499` | `#c0c0c0` | `silver` |
+| `gold` | 黄金 | `1500` | `1999` | `#d4af37` | `gold` |
+| `platinum` | 白金 | `2000` | `2399` | `#e5f0ff` | `platinum` |
+| `diamond` | 钻石 | `2400` | `2799` | `#7dd3fc` | `diamond` |
+| `master` | 宗师 | `2800` | `99999`（视为 Infinity） | `#f472b6` | `master` |
+
+### tierRewards（赛季奖励）
+
+| 奖励 key | 货币 `stones` | 称号 `title` | 优惠券 `coupon` |
+| --- | --- | --- | --- |
+| `bronze` | `50` | `"青铜试剑者"` | `null` |
+| `silver` | `80` | `"白银破阵者"` | `"coupon_pvp_silver"` |
+| `gold` | `120` | `"黄金斗剑士"` | `"coupon_pvp_gold"` |
+| `platinum` | `160` | `"白金灵刃"` | `"coupon_pvp_platinum"` |
+| `diamond` | `220` | `"钻石星耀者"` | `"coupon_pvp_diamond"` |
+| `master` | `320` | `"宗师武曲星"` | `"coupon_pvp_master"` |

--- a/cloudfunctions/nodejs-layer/node_modules/balance/config/skill-curves.md
+++ b/cloudfunctions/nodejs-layer/node_modules/balance/config/skill-curves.md
@@ -26,3 +26,48 @@
     - `controlEffects.sleep.turnResourceGain`：沉睡状态下的被动回复提升到 14。
 
 > `createActorRuntime` 在构建角色时会引用这些资源与控制效果定义，确保技能、沉睡/冰冻等状态与配置保持一致。缺失字段会按 `v1` 补全。【F:cloudfunctions/nodejs-layer/node_modules/balance/config-loader.js†L40-L113】【F:cloudfunctions/nodejs-layer/node_modules/balance/config/skill-curves.json†L1-L38】
+
+## 主要字段的属性说明
+
+### resource.defaults（技能资源基线）
+
+| 属性名 | 中文含义 | 默认值 |
+| --- | --- | --- |
+| `type` | 资源类型标识 | `"qi"` |
+| `baseMax` | 最大资源值 | `100` |
+| `startFraction` | 开局按最大值比例获得的资源 | `0`（`v2` 为 `0.1`） |
+| `startValue` | 开局固定资源值 | `0` |
+| `turnGain` | 每回合自然回复 | `20`（`v2` 为 `24`） |
+| `basicAttackGain` | 普攻后获得的资源 | `10`（`v2` 为 `12`） |
+| `damageTakenGain` | 受伤获得资源系数 | `1.5`（`v2` 为 `1.8`） |
+| `critGain` | 造成暴击时额外获得的资源 | `1` |
+| `critTakenGain` | 被暴击时额外获得的资源 | `1` |
+
+### controlEffects（控制效果行为）
+
+| 控制效果 | 字段 | 中文含义 | 默认值 |
+| --- | --- | --- | --- |
+| `stun` | `summary` | 状态描述 | `"眩晕"` |
+| `stun` | `skip` | 是否跳过整回合 | `true` |
+| `stun` | `disableBasic` | 禁用普攻 | `true` |
+| `stun` | `disableActive` | 禁用主动技能 | `true` |
+| `stun` | `disableDodge` | 禁用闪避 | `true` |
+| `silence` | `summary` | 状态描述 | `"沉默"` |
+| `silence` | `skip` | 是否跳过整回合 | `false` |
+| `silence` | `disableBasic` | 禁用普攻 | `false` |
+| `silence` | `disableActive` | 禁用主动技能 | `true` |
+| `silence` | `disableDodge` | 禁用闪避 | `false` |
+| `freeze` | `summary` | 状态描述 | `"冰冻"` |
+| `freeze` | `skip` | 是否跳过整回合 | `true` |
+| `freeze` | `disableBasic` | 禁用普攻 | `true` |
+| `freeze` | `disableActive` | 禁用主动技能 | `true` |
+| `freeze` | `disableDodge` | 禁用闪避 | `true` |
+| `freeze` | `breakOnFire` | 受到火属性伤害是否解除 | `true` |
+| `freeze` | `fireDamageMultiplier` | 火属性克制时的额外伤害系数 | `0.1` |
+| `sleep` | `summary` | 状态描述 | `"陷入沉睡"` |
+| `sleep` | `skip` | 是否跳过整回合 | `true` |
+| `sleep` | `disableBasic` | 禁用普攻 | `true` |
+| `sleep` | `disableActive` | 禁用主动技能 | `true` |
+| `sleep` | `disableDodge` | 禁用闪避 | `true` |
+| `sleep` | `wakeOnDamage` | 受击是否立即醒来 | `true` |
+| `sleep` | `turnResourceGain` | 睡眠回合仍然被动回复的资源量 | `10`（`v2` 为 `14`） |


### PR DESCRIPTION
## Summary
- add tables to equipment, pve, pvp, and skill curve docs that list English field names with Chinese meanings and default values
- capture per-version default differences (v2 overrides) where applicable

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c7bf4119c833395b95c94d4a608c6)