### PR TITLE
Improve balance settings versioning and boolean controls

### DIFF
--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -46,6 +46,15 @@ const {
   resolveEquipmentEnhancementFromDocument,
   incrementCacheVersionValue
 } = require('system-settings');
+const { simulatePvpBattle } = require('balance/simulator');
+const {
+  mergeWithDefaults: mergeBalanceWithDefaults,
+  readBalanceConfig,
+  writeBalanceConfig,
+  runWithBalanceConfig,
+  STAGING_DOC_ID,
+  ACTIVE_DOC_ID
+} = require('balance/config-store');
 
 const db = cloud.database();
 const _ = db.command;
@@ -422,6 +431,10 @@ const ACTIONS = {
   UPDATE_GLOBAL_BACKGROUND: 'updateGlobalBackground',
   UPDATE_GLOBAL_BACKGROUND_CATALOG: 'updateGlobalBackgroundCatalog',
   UPDATE_EQUIPMENT_ENHANCEMENT: 'updateEquipmentEnhancement',
+  GET_BALANCE_CONFIG: 'getBalanceConfig',
+  SAVE_BALANCE_DRAFT: 'saveBalanceDraft',
+  APPLY_BALANCE_CONFIG: 'applyBalanceConfig',
+  TEST_BALANCE_CONFIG: 'testBalanceConfig',
   LIST_MEMBER_RIGHTS: 'listMemberRights',
   UPDATE_MEMBER_RIGHT_STATUS: 'updateMemberRightStatus',
   REMOVE_MEMBER_RIGHT: 'removeMemberRight',
@@ -472,6 +485,13 @@ const ACTION_ALIASES = {
   updateequipmentattributes: ACTIONS.UPDATE_EQUIPMENT_ATTRIBUTES,
   updateequipmentenhancement: ACTIONS.UPDATE_EQUIPMENT_ENHANCEMENT,
   equipmentenhancement: ACTIONS.UPDATE_EQUIPMENT_ENHANCEMENT,
+  getbalanceconfig: ACTIONS.GET_BALANCE_CONFIG,
+  balanceconfig: ACTIONS.GET_BALANCE_CONFIG,
+  savebalancedraft: ACTIONS.SAVE_BALANCE_DRAFT,
+  stagedbalance: ACTIONS.SAVE_BALANCE_DRAFT,
+  applybalanceconfig: ACTIONS.APPLY_BALANCE_CONFIG,
+  publishbalanceconfig: ACTIONS.APPLY_BALANCE_CONFIG,
+  testbalanceconfig: ACTIONS.TEST_BALANCE_CONFIG,
   listtradeorders: ACTIONS.LIST_TRADE_ORDERS,
   tradelog: ACTIONS.LIST_TRADE_ORDERS,
   gettradingconfig: ACTIONS.GET_TRADING_CONFIG,
@@ -925,6 +945,12 @@ const ACTION_HANDLERS = {
     updateGlobalBackgroundCatalog(openid, event.catalog || event),
   [ACTIONS.UPDATE_EQUIPMENT_ENHANCEMENT]: (openid, event = {}) =>
     updateEquipmentEnhancementConfig(openid, event.config || event),
+  [ACTIONS.GET_BALANCE_CONFIG]: (openid) => getBalanceConfig(openid),
+  [ACTIONS.SAVE_BALANCE_DRAFT]: (openid, event = {}) =>
+    saveBalanceDraft(openid, event.config || event),
+  [ACTIONS.TEST_BALANCE_CONFIG]: (openid, event = {}) =>
+    testBalanceDraft(openid, event || {}),
+  [ACTIONS.APPLY_BALANCE_CONFIG]: (openid) => applyBalanceConfig(openid),
   [ACTIONS.BUMP_CACHE_VERSION]: (openid, event) => bumpCacheVersion(openid, event || {}),
   [ACTIONS.RESET_IMMORTAL_TOURNAMENT]: (openid, event) =>
     resetImmortalTournament(openid, event || {}),
@@ -1875,6 +1901,203 @@ async function updateGameParameters(openid, updates = {}) {
       gameParameters: cloneGameParameters(DEFAULT_GAME_PARAMETERS),
       rageSettings: cloneRageSettings(DEFAULT_RAGE_SETTINGS)
     }
+  };
+}
+
+async function getBalanceConfig(openid) {
+  await ensureAdmin(openid);
+  await ensureCollectionExists(COLLECTIONS.BALANCE_CONFIGS);
+  const defaults = mergeBalanceWithDefaults({});
+  const staging = await readBalanceConfig(STAGING_DOC_ID).catch(() => ({ exists: false }));
+  const active = await readBalanceConfig(ACTIVE_DOC_ID).catch(() => ({ exists: false }));
+
+  const mergeEntry = (entry) => {
+    if (!entry || !entry.exists) {
+      return { exists: false, config: defaults, metadata: {} };
+    }
+    return {
+      exists: true,
+      config: mergeBalanceWithDefaults(entry.config || {}),
+      metadata: entry.metadata || {}
+    };
+  };
+
+  return {
+    defaults,
+    staging: mergeEntry(staging),
+    active: mergeEntry(active)
+  };
+}
+
+async function saveBalanceDraft(openid, updates = {}) {
+  const admin = await ensureAdmin(openid);
+  await ensureCollectionExists(COLLECTIONS.BALANCE_CONFIGS);
+  if (!updates || typeof updates !== 'object') {
+    throw new Error('请提供需要暂存的平衡性配置');
+  }
+  const payloadConfig = updates.config && typeof updates.config === 'object' ? updates.config : updates;
+  const fieldVersions = updates.fieldVersions && typeof updates.fieldVersions === 'object' ? updates.fieldVersions : {};
+  const merged = mergeBalanceWithDefaults(payloadConfig);
+  const adminName = resolveMemberDisplayName(admin) || '';
+  await writeBalanceConfig(STAGING_DOC_ID, merged, {
+    updatedBy: admin._id,
+    updatedByName: adminName,
+    notes: updates.notes || '',
+    fieldVersions
+  });
+  return {
+    success: true,
+    staging: { config: merged, updatedBy: admin._id, updatedByName: adminName },
+    defaults: mergeBalanceWithDefaults({})
+  };
+}
+
+function buildPkTestCases() {
+  const balanced = {
+    stats: {
+      maxHp: 3600,
+      physicalAttack: 128,
+      magicAttack: 132,
+      physicalDefense: 88,
+      magicDefense: 86,
+      speed: 102,
+      accuracy: 132,
+      dodge: 102,
+      critRate: 0.12,
+      critDamage: 1.62,
+      finalDamageBonus: 0.08,
+      finalDamageReduction: 0.06
+    },
+    special: { healOnHit: 0.02, shield: 0 },
+    skills: []
+  };
+  const burst = {
+    stats: {
+      maxHp: 2800,
+      physicalAttack: 178,
+      magicAttack: 96,
+      physicalDefense: 62,
+      magicDefense: 64,
+      speed: 118,
+      accuracy: 140,
+      dodge: 86,
+      critRate: 0.18,
+      critDamage: 1.8,
+      finalDamageBonus: 0.14,
+      finalDamageReduction: 0.04
+    },
+    special: { bonusDamage: 0.05 },
+    skills: []
+  };
+  const tank = {
+    stats: {
+      maxHp: 4600,
+      physicalAttack: 106,
+      magicAttack: 112,
+      physicalDefense: 118,
+      magicDefense: 122,
+      speed: 88,
+      accuracy: 120,
+      dodge: 92,
+      critRate: 0.08,
+      critDamage: 1.42,
+      finalDamageBonus: 0.02,
+      finalDamageReduction: 0.12
+    },
+    special: { damageReflection: 0.04 },
+    skills: []
+  };
+  return [
+    { playerA: balanced, playerB: burst },
+    { playerA: burst, playerB: tank },
+    { playerA: tank, playerB: balanced }
+  ];
+}
+
+async function testBalanceDraft(openid, options = {}) {
+  await ensureAdmin(openid);
+  await ensureCollectionExists(COLLECTIONS.BALANCE_CONFIGS);
+  const staging = await readBalanceConfig(STAGING_DOC_ID);
+  if (!staging || !staging.exists) {
+    throw new Error('暂无暂存配置，请先暂存后再测试');
+  }
+  const merged = mergeBalanceWithDefaults(staging.config || {});
+  const rounds = Number.isFinite(Number(options.rounds)) ? Math.max(1, Number(options.rounds)) : 12;
+  const seeds = [];
+  const cases = buildPkTestCases();
+  const summary = runWithBalanceConfig(merged, () => {
+    let aWins = 0;
+    let bWins = 0;
+    let draws = 0;
+    let totalRounds = 0;
+    const reports = [];
+    for (let i = 0; i < rounds; i += 1) {
+      const seed = options.seed ? Number(options.seed) + i : Date.now() + i;
+      seeds.push(seed);
+      const testCase = cases[i % cases.length];
+      const result = simulatePvpBattle({
+        playerA: { ...testCase.playerA, id: `player_${i}` },
+        playerB: { ...testCase.playerB, id: `opponent_${i}` },
+        seed,
+        roundLimit: merged.pvp && merged.pvp.roundLimit
+      });
+      totalRounds += result.rounds || 0;
+      let winner = 'draw';
+      if (result.victory) {
+        aWins += 1;
+        winner = 'playerA';
+      } else if (!result.draw) {
+        bWins += 1;
+        winner = 'playerB';
+      } else {
+        draws += 1;
+      }
+      reports.push({
+        seed,
+        winner,
+        rounds: result.rounds,
+        remaining: result.remaining
+      });
+    }
+    const total = rounds || reports.length || 1;
+    return {
+      total,
+      playerAWins: aWins,
+      playerBWins: bWins,
+      draws,
+      averageRounds: Number((totalRounds / total).toFixed(2)),
+      reports
+    };
+  });
+
+  return {
+    success: true,
+    staging: {
+      config: merged,
+      metadata: staging.metadata || {}
+    },
+    report: summary,
+    seeds
+  };
+}
+
+async function applyBalanceConfig(openid) {
+  const admin = await ensureAdmin(openid);
+  await ensureCollectionExists(COLLECTIONS.BALANCE_CONFIGS);
+  const staging = await readBalanceConfig(STAGING_DOC_ID);
+  if (!staging || !staging.exists) {
+    throw new Error('暂无暂存配置，请先暂存后再应用');
+  }
+  const merged = mergeBalanceWithDefaults(staging.config || {});
+  const adminName = resolveMemberDisplayName(admin) || '';
+  await writeBalanceConfig(ACTIVE_DOC_ID, merged, {
+    updatedBy: admin._id,
+    updatedByName: adminName,
+    notes: staging.metadata && staging.metadata.notes
+  });
+  return {
+    success: true,
+    active: { config: merged, updatedBy: admin._id, updatedByName: adminName }
   };
 }
 

--- a/cloudfunctions/nodejs-layer/node_modules/balance/config-loader.js
+++ b/cloudfunctions/nodejs-layer/node_modules/balance/config-loader.js
@@ -298,6 +298,10 @@ function buildGetter(cacheKey, fileName, defaults) {
   getter.__reset = () => {
     cache = null;
   };
+  getter.__set = (value) => {
+    cache = value || null;
+  };
+  getter.__get = () => cache;
   return getter;
 }
 
@@ -329,6 +333,90 @@ function getBalanceVersion() {
   return balanceVersion;
 }
 
+function resolveConfigFromSource(defaults, source) {
+  const fallbackProfile = pickProfile(defaults, defaults.profiles[balanceVersion]).profile;
+  const { profile, version } = pickProfile(source || {}, fallbackProfile);
+  const merged = deepMerge(fallbackProfile, profile || {});
+  merged.version = version || balanceVersion;
+  return merged;
+}
+
+function clone(value) {
+  if (typeof value === 'undefined') {
+    return value;
+  }
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch (error) {
+    return value;
+  }
+}
+
+function getBalanceDefaults() {
+  return {
+    version: DEFAULT_BALANCE_VERSION,
+    level: clone(LEVEL_CURVE_DEFAULTS),
+    equipment: clone(EQUIPMENT_CURVE_DEFAULTS),
+    skill: clone(SKILL_CURVE_DEFAULTS),
+    pve: clone(PVE_CURVE_DEFAULTS),
+    pvp: clone(PVP_CONFIG_DEFAULTS)
+  };
+}
+
+function applyRuntimeBalanceConfig(overrides = {}) {
+  const applied = {};
+  if (overrides && typeof overrides === 'object') {
+    if (overrides.level) {
+      applied.level = resolveConfigFromSource(LEVEL_CURVE_DEFAULTS, overrides.level);
+      getLevelCurveConfig.__set(applied.level);
+    }
+    if (overrides.equipment) {
+      applied.equipment = resolveConfigFromSource(EQUIPMENT_CURVE_DEFAULTS, overrides.equipment);
+      getEquipmentCurveConfig.__set(applied.equipment);
+    }
+    if (overrides.skill) {
+      applied.skill = resolveConfigFromSource(SKILL_CURVE_DEFAULTS, overrides.skill);
+      getSkillCurveConfig.__set(applied.skill);
+    }
+    if (overrides.pve) {
+      applied.pve = resolveConfigFromSource(PVE_CURVE_DEFAULTS, overrides.pve);
+      getPveCurveConfig.__set(applied.pve);
+    }
+    if (overrides.pvp) {
+      applied.pvp = resolveConfigFromSource(PVP_CONFIG_DEFAULTS, overrides.pvp);
+      getPvpConfig.__set(applied.pvp);
+    }
+  }
+  return applied;
+}
+
+function withTemporaryBalanceConfig(overrides = {}, fn) {
+  const previous = {
+    level: getLevelCurveConfig.__get() || getLevelCurveConfig(),
+    equipment: getEquipmentCurveConfig.__get() || getEquipmentCurveConfig(),
+    skill: getSkillCurveConfig.__get() || getSkillCurveConfig(),
+    pve: getPveCurveConfig.__get() || getPveCurveConfig(),
+    pvp: getPvpConfig.__get() || getPvpConfig()
+  };
+  const snapshot = {
+    level: clone(previous.level),
+    equipment: clone(previous.equipment),
+    skill: clone(previous.skill),
+    pve: clone(previous.pve),
+    pvp: clone(previous.pvp)
+  };
+  const applied = applyRuntimeBalanceConfig(overrides);
+  try {
+    return typeof fn === 'function' ? fn(applied) : applied;
+  } finally {
+    getLevelCurveConfig.__set(snapshot.level);
+    getEquipmentCurveConfig.__set(snapshot.equipment);
+    getSkillCurveConfig.__set(snapshot.skill);
+    getPveCurveConfig.__set(snapshot.pve);
+    getPvpConfig.__set(snapshot.pvp);
+  }
+}
+
 module.exports = {
   getLevelCurveConfig,
   getEquipmentCurveConfig,
@@ -338,5 +426,8 @@ module.exports = {
   setBalanceVersion,
   getBalanceVersion,
   __resetBalanceCache: resetCache,
-  DEFAULT_BALANCE_VERSION
+  DEFAULT_BALANCE_VERSION,
+  getBalanceDefaults,
+  applyRuntimeBalanceConfig,
+  withTemporaryBalanceConfig
 };

--- a/cloudfunctions/nodejs-layer/node_modules/balance/config-store.js
+++ b/cloudfunctions/nodejs-layer/node_modules/balance/config-store.js
@@ -1,0 +1,139 @@
+const cloud = require('wx-server-sdk');
+
+const { COLLECTIONS } = require('common-config');
+const {
+  getBalanceDefaults,
+  applyRuntimeBalanceConfig,
+  withTemporaryBalanceConfig
+} = require('balance/config-loader');
+
+const db = cloud.database();
+
+const BALANCE_CONFIG_COLLECTION = COLLECTIONS.BALANCE_CONFIGS || 'balanceConfigs';
+const ACTIVE_DOC_ID = 'active';
+const STAGING_DOC_ID = 'staging';
+const CACHE_TTL_MS = 60 * 1000;
+
+function deepMerge(base = {}, override = {}) {
+  if (Array.isArray(base) || Array.isArray(override)) {
+    return override !== undefined ? override : base;
+  }
+  if (typeof base !== 'object' || typeof override !== 'object' || !override) {
+    return override !== undefined ? override : base;
+  }
+  const result = { ...base };
+  Object.keys(override).forEach((key) => {
+    result[key] = deepMerge(base[key], override[key]);
+  });
+  return result;
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value || {}));
+}
+
+function normalizeBalanceConfig(config = {}) {
+  const source = config && typeof config === 'object' ? config : {};
+  const version = typeof source.version === 'string' && source.version.trim()
+    ? source.version.trim()
+    : getBalanceDefaults().version;
+  return {
+    version,
+    level: source.level || {},
+    equipment: source.equipment || {},
+    skill: source.skill || {},
+    pve: source.pve || {},
+    pvp: source.pvp || {}
+  };
+}
+
+function mergeWithDefaults(config = {}) {
+  const defaults = getBalanceDefaults();
+  const normalized = normalizeBalanceConfig(config);
+  return {
+    version: normalized.version || defaults.version,
+    level: deepMerge(defaults.level, normalized.level),
+    equipment: deepMerge(defaults.equipment, normalized.equipment),
+    skill: deepMerge(defaults.skill, normalized.skill),
+    pve: deepMerge(defaults.pve, normalized.pve),
+    pvp: deepMerge(defaults.pvp, normalized.pvp)
+  };
+}
+
+async function readBalanceConfig(docId = ACTIVE_DOC_ID) {
+  const snapshot = await db.collection(BALANCE_CONFIG_COLLECTION).doc(docId).get().catch(() => null);
+  if (!snapshot || !snapshot.data) {
+    return { exists: false, config: null, metadata: {} };
+  }
+  const { _id, updatedAt, updatedBy, updatedByName, notes, fieldVersions, ...rest } = snapshot.data;
+  return {
+    exists: true,
+    config: normalizeBalanceConfig(rest),
+    metadata: {
+      id: _id || docId,
+      updatedAt: updatedAt || null,
+      updatedBy: updatedBy || '',
+      updatedByName: updatedByName || '',
+      notes: typeof notes === 'string' ? notes : '',
+      fieldVersions: fieldVersions || {}
+    }
+  };
+}
+
+async function writeBalanceConfig(docId, config = {}, metadata = {}) {
+  const now = new Date();
+  const payload = {
+    ...normalizeBalanceConfig(config),
+    updatedAt: metadata.updatedAt || now,
+    updatedBy: metadata.updatedBy || '',
+    updatedByName: metadata.updatedByName || '',
+    notes: metadata.notes || '',
+    fieldVersions: metadata.fieldVersions || {}
+  };
+  await db.collection(BALANCE_CONFIG_COLLECTION).doc(docId).set({ data: payload });
+  return { config: payload, updatedAt: payload.updatedAt };
+}
+
+let cachedActive = null;
+let cachedAt = 0;
+
+async function loadActiveBalanceConfig(options = {}) {
+  const now = Date.now();
+  const force = options && options.force;
+  if (!force && cachedActive && now - cachedAt < CACHE_TTL_MS) {
+    return cachedActive;
+  }
+  const { exists, config, metadata } = await readBalanceConfig(ACTIVE_DOC_ID);
+  const merged = mergeWithDefaults(exists ? config : {});
+  cachedActive = {
+    exists,
+    config: merged,
+    metadata: metadata || {}
+  };
+  cachedAt = now;
+  return cachedActive;
+}
+
+async function ensureActiveRuntimeConfig(options = {}) {
+  const { config } = await loadActiveBalanceConfig(options);
+  applyRuntimeBalanceConfig(config);
+  return config;
+}
+
+function runWithBalanceConfig(overrides = {}, runner) {
+  return withTemporaryBalanceConfig(mergeWithDefaults(overrides), runner);
+}
+
+module.exports = {
+  ACTIVE_DOC_ID,
+  STAGING_DOC_ID,
+  BALANCE_CONFIG_COLLECTION,
+  deepMerge,
+  mergeWithDefaults,
+  normalizeBalanceConfig,
+  readBalanceConfig,
+  writeBalanceConfig,
+  loadActiveBalanceConfig,
+  ensureActiveRuntimeConfig,
+  runWithBalanceConfig
+};

--- a/cloudfunctions/nodejs-layer/node_modules/common-config/index.js
+++ b/cloudfunctions/nodejs-layer/node_modules/common-config/index.js
@@ -71,7 +71,8 @@ const COLLECTIONS = Object.freeze({
   TRADE_ORDERS: 'tradeOrders',
   TRADE_BIDS: 'tradeBids',
   TRADE_METRICS: 'tradeMetrics',
-  TRADE_SETTINGS: 'tradeSettings'
+  TRADE_SETTINGS: 'tradeSettings',
+  BALANCE_CONFIGS: 'balanceConfigs'
 });
 
 const TRADING_CONFIG = Object.freeze({

--- a/docs/balance-settings-deployment.md
+++ b/docs/balance-settings-deployment.md
@@ -1,0 +1,23 @@
+# 平衡性配置后台与部署说明
+
+本次新增「平衡性设定」管理员页面，用于管理 `cloudfunctions/nodejs-layer/node_modules/balance` 下的所有数值字段，支持暂存、测试与全局应用。
+
+## 新增能力
+- **后台入口**：管理员中心新增「平衡性设定」，可逐字段编辑等级曲线、装备成长、技能资源、PVE/PVP 参数，并展示默认值提示。
+- **暂存与测试**：点击「暂存配置」写入 `balanceConfigs` 集合的 `staging` 文档，不影响线上；「测试暂存配置」基于暂存数据跑多轮 PVP PK，生成胜率/回合数报告。
+- **应用到全局**：对测试结果满意后点击「应用到全局」，将 `staging` 复制到 `active` 并实时加载到 PVE/PVP 云函数的运行时缓存中。
+
+## 部署步骤
+1. **创建集合**：在云开发数据库中新建 `balanceConfigs` 集合，默认文档 ID 建议使用 `active`、`staging`（云函数会自动创建/写入）。
+2. **上传云函数**：重新部署以下云函数以加载新能力：
+   - `cloudfunctions/admin`
+   - `cloudfunctions/pvp`
+   - `cloudfunctions/pve`
+3. **上传公共模块**：若使用了独立云托管层，请确保 `cloudfunctions/nodejs-layer` 一并发布，使新的 `balance/config-loader` 与 `balance/config-store` 生效。
+4. **更新小程序**：构建并上传小程序，包含新增页面 `subpackages/admin/balance-settings` 与首页入口。
+
+## 使用指引
+1. 管理员进入「平衡性设定」，按字段编辑后点击 **暂存配置**。当前值与默认值并行显示，便于比对。
+2. 点击 **测试暂存配置**，系统会用暂存参数运行多轮 PVP 模拟，页面展示胜率、平局数、平均回合等指标。
+3. 确认无误后点击 **应用到全局**，新配置将写入 `balanceConfigs/active`，并在 PVE/PVP 云函数请求入口实时刷新缓存，立刻生效。
+4. 如需回退，可再次编辑后暂存并应用，或清空暂存配置再应用即可恢复默认。

--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -66,7 +66,8 @@
         "activities/index",
         "finance-report/index",
         "data-cleanup/index",
-        "system-switches/index"
+        "system-switches/index",
+        "balance-settings/index"
       ]
     }
   ],

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -1275,6 +1275,23 @@ export const AdminService = {
       config
     });
   },
+  async getBalanceConfig() {
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, { action: 'getBalanceConfig' });
+  },
+  async saveBalanceDraft(payload = {}) {
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, { action: 'saveBalanceDraft', ...payload });
+  },
+  async testBalanceDraft(options = {}) {
+    const payload = { action: 'testBalanceConfig' };
+    if (options && typeof options === 'object') {
+      if (options.rounds) payload.rounds = options.rounds;
+      if (options.seed) payload.seed = options.seed;
+    }
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, payload);
+  },
+  async applyBalanceConfig() {
+    return callCloud(CLOUD_FUNCTIONS.ADMIN, { action: 'applyBalanceConfig' });
+  },
   async bumpCacheVersion(scope) {
     const payload = {
       action: 'bumpCacheVersion'

--- a/miniprogram/subpackages/admin/balance-settings/index.js
+++ b/miniprogram/subpackages/admin/balance-settings/index.js
@@ -1,0 +1,702 @@
+import { AdminService } from '../../../services/api';
+
+const SECTION_LABELS = {
+  level: '等级成长/属性曲线',
+  equipment: '装备强化成长',
+  skill: '技能资源与控制',
+  pve: 'PVE 秘境与怪物',
+  pvp: 'PVP 赛季与匹配'
+};
+
+const FIELD_GROUP_META = [
+  {
+    section: 'level',
+    prefix: 'profiles.v1.defaults.combatStats.',
+    map: {
+      maxHp: { label: '最大生命值上限', description: '角色生命值基线，用于计算血量与容错。' },
+      physicalAttack: { label: '物理攻击强度', description: '物理输出基线，决定物攻伤害起点。' },
+      magicAttack: { label: '魔法攻击强度', description: '魔法输出基线，决定法术伤害起点。' },
+      physicalDefense: { label: '物理防御力', description: '物理减伤基线，抵御物理伤害。' },
+      magicDefense: { label: '魔法防御力', description: '魔法减伤基线，抵御法术伤害。' },
+      speed: { label: '速度（行动条）', description: '影响行动条增长与出手顺序的基线。' },
+      accuracy: { label: '命中率', description: '命中初始属性，决定命中公式基础。' },
+      dodge: { label: '闪避率', description: '闪避初始属性，为命中公式留出空间。' },
+      critRate: { label: '暴击率', description: '暴击触发起点。' },
+      critDamage: { label: '暴击伤害倍数', description: '暴击倍率起点。' },
+      finalDamageBonus: { label: '终伤加成系数', description: '终伤增益基线。' },
+      finalDamageReduction: { label: '终伤减免系数', description: '终伤减益基线，抵消伤害。' },
+      lifeSteal: { label: '吸血比例', description: '攻击回血起点，影响续航。' },
+      healingBonus: { label: '主动治疗加成', description: '治疗输出基线。' },
+      healingReduction: { label: '治疗减免', description: '对目标施加的治疗衰减起点。' },
+      controlHit: { label: '控制命中', description: '控制类效果命中率基线。' },
+      controlResist: { label: '控制抗性', description: '抵抗控制的基线。' },
+      physicalPenetration: { label: '物理穿透', description: '物防穿透起点。' },
+      magicPenetration: { label: '魔法穿透', description: '魔防穿透起点。' },
+      critResist: { label: '暴击抵抗率', description: '抑制被暴击的起点。' },
+      comboRate: { label: '连击概率', description: '触发类概率基线。' },
+      block: { label: '格挡率', description: '格挡触发基线。' },
+      counterRate: { label: '反击概率', description: '反击触发基线。' },
+      damageReduction: { label: '通用减伤率', description: '固定减伤基线。' },
+      healingReceived: { label: '受治疗加成', description: '被治疗收益基线。' },
+      rageGain: { label: '怒气获取效率', description: '资源获取效率基线。' },
+      controlStrength: { label: '控制强度', description: '控制效果时长/强度基线。' },
+      shieldPower: { label: '护盾强度加成', description: '护盾效率基线。' },
+      summonPower: { label: '召唤物强度', description: '召唤物属性加成起点。' },
+      elementalVulnerability: { label: '元素易伤系数', description: '元素伤害易伤基线。' }
+    }
+  },
+  {
+    section: 'level',
+    prefix: 'profiles.v1.defaults.specialStats.',
+    map: {
+      shield: { label: '初始护盾值', description: '角色创建时自带护盾。' },
+      bonusDamage: { label: '额外伤害系数', description: '触发额外伤害的倍率基线。' },
+      dodgeChance: { label: '额外闪避概率', description: '触发型闪避概率基线。' },
+      healOnHit: { label: '命中回复生命比例', description: '每次命中触发的自恢复。' },
+      healOnKill: { label: '击杀回复生命比例', description: '击杀触发的自恢复。' },
+      damageReflection: { label: '反弹伤害比例', description: '反伤系数基线。' },
+      accuracyBonus: { label: '额外命中加成', description: '额外命中修正基线。' },
+      speedBonus: { label: '额外速度加成', description: '临时速度增益基线。' },
+      physicalPenetrationBonus: { label: '额外物理穿透', description: '额外物防穿透修正。' },
+      magicPenetrationBonus: { label: '额外魔法穿透', description: '额外魔防穿透修正。' }
+    }
+  },
+  {
+    section: 'level',
+    prefix: 'profiles.v1.hitFormula.',
+    map: {
+      base: { label: '命中公式基础命中率', description: '命中概率的基础值。' },
+      slope: { label: '命中成长斜率', description: '命中随属性或等级提升的斜率。' },
+      min: { label: '命中下限', description: '命中概率的最小截断值。' },
+      max: { label: '命中上限', description: '命中概率的最大截断值。' }
+    }
+  },
+  {
+    section: 'level',
+    prefix: 'profiles.v1.penetration.',
+    map: {
+      scale: { label: '穿透系数比例', description: '穿透属性转化为减防效果的比例。' },
+      max: { label: '减防率上限', description: '穿透减防的封顶值。' }
+    }
+  },
+  {
+    section: 'level',
+    prefix: 'profiles.v1.baseDamage.',
+    map: {
+      minAttackRatio: { label: '攻击占比最低阈值', description: '伤害公式中攻击力占比的下限。' },
+      randomMin: { label: '伤害随机浮动下限', description: '基础伤害随机区间的起点。' },
+      randomRange: { label: '伤害随机浮动幅度', description: '基础伤害的随机波动范围。' },
+      minDamage: { label: '伤害保底值', description: '极端情况下的最小伤害。' }
+    }
+  },
+  {
+    section: 'level',
+    prefix: 'profiles.v1.crit.',
+    map: {
+      min: { label: '暴击率下限', description: '暴击触发概率最小值。' },
+      max: { label: '暴击率上限', description: '暴击触发概率最大值。' },
+      damageMin: { label: '暴击伤害下限', description: '暴击伤害倍率的下限。' }
+    }
+  },
+  {
+    section: 'level',
+    prefix: 'profiles.v1.finalDamage.',
+    map: {
+      minMultiplier: { label: '终伤总乘最低倍率', description: '终伤乘区的最低值。' },
+      'bonusClamp.min': { label: '终伤加成最小截断', description: '终伤加成的最低截断值。' },
+      'bonusClamp.max': { label: '终伤加成最大截断', description: '终伤加成的最高截断值。' },
+      'reductionClamp.min': { label: '终伤减免最小截断', description: '终伤减免的最低截断值。' },
+      'reductionClamp.max': { label: '终伤减免最大截断', description: '终伤减免的最高截断值。' }
+    }
+  },
+  {
+    section: 'level',
+    prefix: 'profiles.v1.healing.',
+    map: {
+      lifeStealMax: { label: '吸血比例上限', description: '吸血系数封顶，防止无限续航。' },
+      'healingBonusClamp.min': { label: '治疗加成最小截断', description: '治疗增益允许的最低值。' },
+      'healingBonusClamp.max': { label: '治疗加成最大截断', description: '治疗增益允许的最高值。' },
+      'healingReductionClamp.min': { label: '治疗减免最小截断', description: '治疗减免允许的最低值。' },
+      'healingReductionClamp.max': { label: '治疗减免最大截断', description: '治疗减免允许的最高值。' },
+      'healingReceivedClamp.min': { label: '受治疗加成最小截断', description: '受治疗系数的下限。' },
+      'healingReceivedClamp.max': { label: '受治疗加成最大截断', description: '受治疗系数的上限。' }
+    }
+  },
+  {
+    section: 'level',
+    prefix: 'profiles.v1.mitigation.',
+    map: {
+      damageReductionMax: { label: '减伤率上限', description: '通用减伤的封顶值。' }
+    }
+  },
+  {
+    section: 'level',
+    prefix: 'profiles.v1.procCaps.',
+    map: {
+      comboRateMax: { label: '连击概率上限', description: '触发概率最高 100%。' },
+      blockMax: { label: '格挡概率上限', description: '格挡概率封顶。' },
+      counterRateMax: { label: '反击概率上限', description: '反击概率封顶。' }
+    }
+  },
+  {
+    section: 'level',
+    prefix: 'profiles.v1.specialCaps.',
+    map: {
+      dodgeChanceMax: { label: '闪避概率上限', description: '附加闪避的封顶值。' },
+      damageReflectionMax: { label: '反弹伤害比例上限', description: '反伤比例封顶。' }
+    }
+  },
+  {
+    section: 'level',
+    prefix: 'profiles.v1.statFloors.',
+    map: {
+      critDamageMin: { label: '暴击伤害下限', description: '暴击伤害倍率的最低值。' }
+    }
+  },
+  {
+    section: 'level',
+    prefix: 'profiles.v2.',
+    map: {
+      'hitFormula.base': { label: 'V2 命中基础值', description: '在 v2 中提升命中基础率。' },
+      'baseDamage.randomMin': { label: 'V2 伤害浮动下限', description: 'v2 的基础伤害随机下限。' },
+      'baseDamage.randomRange': { label: 'V2 伤害浮动幅度', description: 'v2 的基础伤害浮动范围。' },
+      'crit.min': { label: 'V2 暴击率下限', description: 'v2 的暴击触发下限。' }
+    }
+  },
+  {
+    section: 'equipment',
+    prefix: 'profiles.v1.',
+    map: {
+      slots: { label: '可强化装备槽位', description: '允许强化的装备槽列表。' },
+      'enhancement.base': { label: '强化基础倍率', description: '装备强化计算使用的基础系数。' }
+    }
+  },
+  {
+    section: 'skill',
+    prefix: 'profiles.v1.resource.defaults.',
+    map: {
+      type: { label: '资源类型', description: '技能资源的代号，如怒气/真气。' },
+      baseMax: { label: '资源上限', description: '技能资源槽的最大值。' },
+      startFraction: { label: '开局资源百分比', description: '按最大值比例给予的起手资源。' },
+      startValue: { label: '开局固定资源', description: '开局额外的固定资源值。' },
+      turnGain: { label: '每回合自然回复', description: '回合结束自动恢复的资源量。' },
+      basicAttackGain: { label: '普攻获得资源', description: '普攻后获得的资源。' },
+      damageTakenGain: { label: '受伤资源系数', description: '按伤害量乘系数获得资源。' },
+      critGain: { label: '暴击奖励资源', description: '造成暴击时额外获得的资源。' },
+      critTakenGain: { label: '被暴击补偿资源', description: '被暴击时额外获得的资源。' }
+    }
+  },
+  {
+    section: 'skill',
+    prefix: 'profiles.v1.controlEffects.stun.',
+    map: {
+      summary: { label: '眩晕描述', description: '状态描述文案。' },
+      skip: { label: '眩晕跳过回合', description: '是否整回合跳过。' },
+      disableBasic: { label: '眩晕禁用普攻', description: '眩晕时是否禁止普攻。' },
+      disableActive: { label: '眩晕禁用主动技能', description: '眩晕时是否禁止主动技能。' },
+      disableDodge: { label: '眩晕禁用闪避', description: '眩晕时是否禁止闪避。' }
+    }
+  },
+  {
+    section: 'skill',
+    prefix: 'profiles.v1.controlEffects.silence.',
+    map: {
+      summary: { label: '沉默描述', description: '状态描述文案。' },
+      skip: { label: '沉默跳过回合', description: '沉默时是否跳过回合。' },
+      disableBasic: { label: '沉默禁用普攻', description: '沉默时是否禁止普攻。' },
+      disableActive: { label: '沉默禁用主动技能', description: '沉默时是否禁止主动技能。' },
+      disableDodge: { label: '沉默禁用闪避', description: '沉默时是否禁止闪避。' }
+    }
+  },
+  {
+    section: 'skill',
+    prefix: 'profiles.v1.controlEffects.freeze.',
+    map: {
+      summary: { label: '冰冻描述', description: '状态描述文案。' },
+      skip: { label: '冰冻跳过回合', description: '冰冻时是否跳过回合。' },
+      disableBasic: { label: '冰冻禁用普攻', description: '冰冻时是否禁止普攻。' },
+      disableActive: { label: '冰冻禁用主动技能', description: '冰冻时是否禁止主动技能。' },
+      disableDodge: { label: '冰冻禁用闪避', description: '冰冻时是否禁止闪避。' },
+      breakOnFire: { label: '火属性解除冰冻', description: '受到火属性伤害是否解除。' },
+      fireDamageMultiplier: { label: '火克制额外伤害', description: '火属性克制下的额外伤害系数。' }
+    }
+  },
+  {
+    section: 'skill',
+    prefix: 'profiles.v1.controlEffects.sleep.',
+    map: {
+      summary: { label: '沉睡描述', description: '状态描述文案。' },
+      skip: { label: '沉睡跳过回合', description: '沉睡时是否跳过回合。' },
+      disableBasic: { label: '沉睡禁用普攻', description: '沉睡时是否禁止普攻。' },
+      disableActive: { label: '沉睡禁用主动技能', description: '沉睡时是否禁止主动技能。' },
+      disableDodge: { label: '沉睡禁用闪避', description: '沉睡时是否禁止闪避。' },
+      wakeOnDamage: { label: '受击立即醒来', description: '受伤后是否立即解除沉睡。' },
+      turnResourceGain: { label: '沉睡回合被动回能', description: '沉睡状态下每回合被动回复的资源量。' }
+    }
+  },
+  {
+    section: 'skill',
+    prefix: 'profiles.v2.resource.defaults.',
+    map: {
+      turnGain: { label: 'V2 每回合回能', description: 'v2 版本的自然回复量。' },
+      basicAttackGain: { label: 'V2 普攻回能', description: 'v2 版本的普攻资源获取。' },
+      damageTakenGain: { label: 'V2 受伤回能系数', description: 'v2 受伤获得资源的系数。' },
+      startFraction: { label: 'V2 开局资源比例', description: 'v2 版本的起手资源比例。' },
+      'controlEffects.sleep.turnResourceGain': { label: 'V2 沉睡回能', description: 'v2 中沉睡状态的回能值。' }
+    }
+  },
+  {
+    section: 'skill',
+    prefix: 'profiles.v2.controlEffects.sleep.',
+    map: {
+      turnResourceGain: { label: 'V2 沉睡回能', description: 'v2 中沉睡状态的回能值。' }
+    }
+  },
+  {
+    section: 'pve',
+    prefix: 'profiles.v1.',
+    map: {
+      maxLevel: { label: 'PVE 等级上限', description: '秘境与剧情的等级封顶。' },
+      roundLimit: { label: 'PVE 最大回合数', description: 'PVE 战斗超出回合即判和局。' },
+      cooldownMs: { label: 'PVE 冷却时间(毫秒)', description: '限制重复开战的冷却时间。' },
+      cooldownMessage: { label: 'PVE 冷却提示', description: '冷却期间展示给玩家的提示文案。' }
+    }
+  },
+  {
+    section: 'pve',
+    prefix: 'profiles.v1.secretRealm.baseStats.',
+    map: {
+      maxHp: { label: '敌方生命基线', description: '秘境敌人的基础生命值。' },
+      physicalAttack: { label: '敌方物攻基线', description: '秘境敌人的物理攻击力基线。' },
+      magicAttack: { label: '敌方法攻基线', description: '秘境敌人的魔法攻击力基线。' },
+      physicalDefense: { label: '敌方物防基线', description: '秘境敌人的物理防御。' },
+      magicDefense: { label: '敌方魔防基线', description: '秘境敌人的魔法防御。' },
+      speed: { label: '敌方速度', description: '秘境敌人的速度基线。' },
+      accuracy: { label: '敌方命中', description: '秘境敌人的命中基线。' },
+      dodge: { label: '敌方闪避', description: '秘境敌人的闪避基线。' },
+      critRate: { label: '敌方暴击率', description: '秘境敌人的暴击概率。' },
+      critDamage: { label: '敌方暴击伤害', description: '秘境敌人的暴击伤害倍率。' },
+      finalDamageBonus: { label: '敌方终伤加成', description: '秘境敌人的终伤增益。' },
+      finalDamageReduction: { label: '敌方终伤减免', description: '秘境敌人的终伤减免。' },
+      lifeSteal: { label: '敌方吸血', description: '秘境敌人的吸血比例。' },
+      controlHit: { label: '敌方控制命中', description: '秘境敌人的控制命中基线。' },
+      controlResist: { label: '敌方控制抗性', description: '秘境敌人的控制抗性基线。' },
+      physicalPenetration: { label: '敌方物穿', description: '秘境敌人的物理穿透。' },
+      magicPenetration: { label: '敌方法穿', description: '秘境敌人的魔法穿透。' }
+    }
+  },
+  {
+    section: 'pve',
+    prefix: 'profiles.v1.secretRealm.tuning.',
+    map: {
+      baseMultiplier: { label: '楼层基础倍率', description: '秘境楼层数值的起始乘数。' },
+      floorGrowth: { label: '每层递增倍率', description: '每层增加的综合系数。' },
+      realmGrowth: { label: '每章递增倍率', description: '每个秘境章节额外增幅。' },
+      'normal.base': { label: '普通怪基础倍率', description: '普通怪在非克制下的基准倍率。' },
+      'normal.primary': { label: '普通怪主属性倍率', description: '普通怪主属性的强化倍率。' },
+      'normal.secondary': { label: '普通怪副属性倍率', description: '普通怪副属性的加成。' },
+      'normal.off': { label: '普通怪非针对倍率', description: '普通怪在非克制关系下的倍率。' },
+      'normal.weak': { label: '普通怪被克制衰减', description: '普通怪被克制时的衰减倍率。' },
+      'boss.base': { label: '首领基础倍率', description: '首领敌人的基础倍率。' },
+      'boss.primary': { label: '首领主属性倍率', description: '首领主属性加成。' },
+      'boss.secondary': { label: '首领副属性倍率', description: '首领副属性加成。' },
+      'boss.tertiary': { label: '首领次要属性倍率', description: '首领次要属性加成。' },
+      'boss.off': { label: '首领非针对倍率', description: '首领在非克制时的倍率。' },
+      'boss.weak': { label: '首领被克制衰减', description: '首领被克制时的衰减倍率。' },
+      'special.base': { label: '特殊怪基础倍率', description: '特殊怪初始加成。' },
+      'special.growth': { label: '特殊怪每层增幅', description: '特殊怪随楼层提升的增幅。' },
+      'special.boss': { label: '特殊首领额外倍率', description: '特殊首领额外提升系数。' },
+      'limits.critRate': { label: '暴击率上限', description: '秘境敌人暴击率封顶。' },
+      'limits.critDamage': { label: '暴击伤害上限', description: '秘境敌人暴击伤害封顶。' },
+      'limits.finalDamageBonus': { label: '终伤加成上限', description: '秘境敌人终伤增益上限。' },
+      'limits.finalDamageReduction': { label: '终伤减免上限', description: '秘境敌人终伤减免上限。' },
+      'limits.lifeSteal': { label: '吸血上限', description: '秘境敌人吸血比例上限。' },
+      'limits.accuracy': { label: '命中属性上限', description: '秘境敌人命中数值上限。' },
+      'limits.dodge': { label: '闪避属性上限', description: '秘境敌人闪避数值上限。' }
+    }
+  },
+  {
+    section: 'pve',
+    prefix: 'profiles.v2.',
+    map: {
+      roundLimit: { label: 'V2 PVE 最大回合数', description: 'v2 调整后的 PVE 回合上限。' },
+      'secretRealm.tuning.normal.primary': { label: 'V2 普通怪主属性倍率', description: 'v2 下调的普通怪主属性倍率。' },
+      'secretRealm.tuning.limits.finalDamageReduction': { label: 'V2 终伤减免上限', description: 'v2 调整后的终伤减免上限。' }
+    }
+  },
+  {
+    section: 'pvp',
+    prefix: 'profiles.v1.',
+    map: {
+      roundLimit: { label: 'PVP 最大回合数', description: 'PVP 战斗的最大回合数。' },
+      cooldownMs: { label: '匹配冷却时间(毫秒)', description: '同一玩家发起战斗的冷却时间。' },
+      cooldownMessage: { label: '冷却提示文案', description: '冷却期间显示的提示。' },
+      seasonLengthDays: { label: '赛季时长(天)', description: '赛季重置周期。' },
+      leaderboardCacheSize: { label: '排行榜缓存上限', description: '排行榜缓存条数上限。' },
+      leaderboardSchemaVersion: { label: '排行榜数据版本', description: '排行榜数据结构版本号。' },
+      recentMatchLimit: { label: '最近对局保留数', description: '用于匹配冷却或展示的记录数。' },
+      defaultRating: { label: '新玩家初始分', description: '新手 Elo/天梯起始分。' },
+      tiers: { label: '段位区间列表', description: '从青铜到宗师的分数范围定义。' },
+      'tierRewards.bronze.stones': { label: '青铜奖励-货币', description: '青铜段位的奖励货币数量。' },
+      'tierRewards.bronze.title': { label: '青铜奖励-称号', description: '青铜段位称号。' },
+      'tierRewards.bronze.coupon': { label: '青铜奖励-优惠券', description: '青铜段位券 ID（可为空）。' },
+      'tierRewards.silver.stones': { label: '白银奖励-货币', description: '白银段位奖励货币。' },
+      'tierRewards.silver.title': { label: '白银奖励-称号', description: '白银段位称号。' },
+      'tierRewards.silver.coupon': { label: '白银奖励-优惠券', description: '白银段位券 ID。' },
+      'tierRewards.gold.stones': { label: '黄金奖励-货币', description: '黄金段位奖励货币。' },
+      'tierRewards.gold.title': { label: '黄金奖励-称号', description: '黄金段位称号。' },
+      'tierRewards.gold.coupon': { label: '黄金奖励-优惠券', description: '黄金段位券 ID。' },
+      'tierRewards.platinum.stones': { label: '白金奖励-货币', description: '白金段位奖励货币。' },
+      'tierRewards.platinum.title': { label: '白金奖励-称号', description: '白金段位称号。' },
+      'tierRewards.platinum.coupon': { label: '白金奖励-优惠券', description: '白金段位券 ID。' },
+      'tierRewards.diamond.stones': { label: '钻石奖励-货币', description: '钻石段位奖励货币。' },
+      'tierRewards.diamond.title': { label: '钻石奖励-称号', description: '钻石段位称号。' },
+      'tierRewards.diamond.coupon': { label: '钻石奖励-优惠券', description: '钻石段位券 ID。' },
+      'tierRewards.master.stones': { label: '宗师奖励-货币', description: '宗师段位奖励货币。' },
+      'tierRewards.master.title': { label: '宗师奖励-称号', description: '宗师段位称号。' },
+      'tierRewards.master.coupon': { label: '宗师奖励-优惠券', description: '宗师段位券 ID。' }
+    }
+  },
+  {
+    section: 'pvp',
+    prefix: 'profiles.v2.',
+    map: {
+      roundLimit: { label: 'V2 PVP 最大回合数', description: 'v2 调整后的 PVP 回合上限。' }
+    }
+  }
+];
+
+const FIELD_FALLBACKS = {
+  version: { label: '配置版本', description: '用于选择当前生效的数值版本。' }
+};
+
+function clone(value) {
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch (error) {
+    return value;
+  }
+}
+
+function getValueByPath(obj, path) {
+  if (!obj || !path) return undefined;
+  const segments = path.split('.');
+  let current = obj;
+  for (let i = 0; i < segments.length; i += 1) {
+    if (!current || typeof current !== 'object') return undefined;
+    current = current[segments[i]];
+  }
+  return current;
+}
+
+function setValueByPath(obj, path, value) {
+  const segments = path.split('.');
+  let target = obj;
+  for (let i = 0; i < segments.length; i += 1) {
+    const key = segments[i];
+    if (i === segments.length - 1) {
+      target[key] = value;
+      return;
+    }
+    if (!target[key] || typeof target[key] !== 'object') {
+      target[key] = {};
+    }
+    target[key] = { ...target[key] };
+    Object.setPrototypeOf(target[key], Object.prototype);
+    target = target[key];
+  }
+}
+
+function flattenConfig(source = {}, prefix = '') {
+  const fields = [];
+  const walk = (value, path) => {
+    const currentPath = path;
+    if (Array.isArray(value)) {
+      fields.push({ path: currentPath, type: 'json', defaultValue: value });
+      return;
+    }
+    if (typeof value === 'boolean') {
+      fields.push({ path: currentPath, type: 'boolean', defaultValue: value });
+      return;
+    }
+    if (value && typeof value === 'object') {
+      Object.keys(value).forEach((key) => {
+        walk(value[key], currentPath ? `${currentPath}.${key}` : key);
+      });
+      return;
+    }
+    fields.push({
+      path: currentPath,
+      type: typeof value === 'number' ? 'number' : 'text',
+      defaultValue: value
+    });
+  };
+  walk(source, prefix);
+  return fields;
+}
+
+function resolveFieldMeta(sectionKey, path) {
+  const directKey = `${sectionKey}.${path}`;
+  if (FIELD_FALLBACKS[directKey]) return FIELD_FALLBACKS[directKey];
+  if (FIELD_FALLBACKS[path]) return FIELD_FALLBACKS[path];
+  const group = FIELD_GROUP_META.find((item) => item.section === sectionKey && path.startsWith(item.prefix));
+  if (group) {
+    const suffix = path.replace(group.prefix, '');
+    if (group.map[suffix]) return group.map[suffix];
+  }
+  return { label: '自定义字段', description: '请根据需要填写。' };
+}
+
+function parseVersionedPath(path = '') {
+  const match = path.match(/^(.*)\.v(\d+)\.(.+)$/);
+  if (!match) return { basePath: path, version: null };
+  return { basePath: `${match[1]}.${match[3]}`, version: Number(match[2]) };
+}
+
+function buildSections(defaults = {}, staging = {}, versions = {}) {
+  return Object.keys(SECTION_LABELS).map((key) => {
+    const base = defaults[key] || {};
+    const fields = flattenConfig(base);
+    const latestByPath = {};
+    fields.forEach((field) => {
+      const version = (versions[key] && versions[key][field.path]) || parseVersionedPath(field.path).version;
+      const basePath = parseVersionedPath(field.path).basePath || field.path;
+      const current = latestByPath[basePath];
+      if (!current || (Number.isFinite(version) && version > (current.version || 0))) {
+        latestByPath[basePath] = { field, version: Number.isFinite(version) ? version : null };
+      }
+    });
+    const dedupedFields = Object.values(latestByPath).map(({ field, version }) => {
+      const defaultText =
+        field.defaultValue === undefined
+          ? '无'
+          : typeof field.defaultValue === 'object'
+            ? JSON.stringify(field.defaultValue)
+            : field.defaultValue;
+      const versionHint = Number.isFinite(version) ? ` 当前版本:v${version}` : '';
+      return {
+        ...field,
+        ...resolveFieldMeta(key, field.path),
+        defaultHint: `默认值：${defaultText}${versionHint}`,
+        value: getValueByPath(staging[key] || {}, field.path),
+        displayValue:
+          field.type === 'json'
+            ? (() => {
+                const current = getValueByPath(staging[key] || {}, field.path);
+                if (!current) return '';
+                try {
+                  return JSON.stringify(current, null, 2);
+                } catch (error) {
+                  return '';
+                }
+              })()
+            : undefined
+      };
+    });
+      return {
+        key,
+        title: SECTION_LABELS[key] || key,
+        fields: dedupedFields
+      };
+    });
+}
+
+Page({
+  data: {
+    loading: true,
+    saving: false,
+    testing: false,
+    applying: false,
+    sections: [],
+    activeTab: '',
+    stagingConfig: {},
+    activeConfig: {},
+    defaults: {},
+    activeMetadata: {},
+    stagingMetadata: {},
+    fieldVersions: {},
+    baselineConfig: {},
+    testReport: null,
+    testRounds: 12
+  },
+
+  onLoad() {
+    this.loadConfig();
+  },
+
+  async loadConfig() {
+    this.setData({ loading: true });
+    try {
+      const result = await AdminService.getBalanceConfig();
+      const defaults = result && result.defaults ? result.defaults : {};
+      const stagingConfig = (result && result.staging && result.staging.config) || defaults;
+      const fieldVersions = (result && result.staging && result.staging.metadata && result.staging.metadata.fieldVersions) || {};
+      const sections = buildSections(defaults, stagingConfig, fieldVersions);
+      const activeTab = this.data.activeTab || (sections[0] && sections[0].key) || '';
+      this.setData({
+        sections,
+        activeTab,
+        defaults,
+        stagingConfig,
+        baselineConfig: stagingConfig,
+        fieldVersions,
+        activeConfig: (result && result.active && result.active.config) || defaults,
+        activeMetadata: (result && result.active && result.active.metadata) || {},
+        stagingMetadata: (result && result.staging && result.staging.metadata) || {},
+        loading: false
+      });
+    } catch (error) {
+      console.error('load balance config failed', error);
+      wx.showToast({ title: '加载配置失败', icon: 'none' });
+      this.setData({ loading: false });
+    }
+  },
+
+  handleRoundsChange(event) {
+    const value = Number(event.detail.value);
+    this.setData({ testRounds: Number.isFinite(value) ? value : this.data.testRounds });
+  },
+
+  handleFieldChange(event) {
+    const { section, path, type } = event.currentTarget.dataset;
+    const rawValue = event.detail.value;
+    const nextConfig = clone(this.data.stagingConfig || {});
+    const sectionConfig = clone(nextConfig[section] || {});
+    let value = rawValue;
+    if (type === 'number') {
+      const numeric = Number(rawValue);
+      value = Number.isFinite(numeric) ? numeric : rawValue;
+    } else if (type === 'boolean') {
+      value = !!rawValue;
+    } else if (type === 'json') {
+      try {
+        value = rawValue ? JSON.parse(rawValue) : {};
+      } catch (error) {
+        wx.showToast({ title: 'JSON 解析失败', icon: 'none' });
+        return;
+      }
+    }
+    setValueByPath(sectionConfig, path, value);
+    nextConfig[section] = sectionConfig;
+    const sections = this.data.sections.map((item) => {
+      if (item.key !== section) return item;
+      return {
+        ...item,
+        fields: item.fields.map((field) =>
+          field.path === path
+            ? {
+                ...field,
+                value: type === 'json' ? value : value,
+                displayValue: type === 'json' ? rawValue : field.displayValue
+              }
+            : field
+        )
+      };
+    });
+    this.setData({ stagingConfig: nextConfig, sections });
+  },
+
+  handleTabChange(event) {
+    const { key } = event.currentTarget.dataset;
+    if (!key || key === this.data.activeTab) return;
+    this.setData({ activeTab: key });
+  },
+
+  computeNextVersions() {
+    const flattenValues = (obj = {}, prefix = '') => {
+      const result = {};
+      const walk = (value, path) => {
+        if (Array.isArray(value) || typeof value !== 'object' || value === null) {
+          result[path] = value;
+          return;
+        }
+        Object.keys(value).forEach((key) => {
+          const nextPath = path ? `${path}.${key}` : key;
+          walk(value[key], nextPath);
+        });
+      };
+      walk(obj, prefix);
+      return result;
+    };
+
+    const currentFlat = flattenValues(this.data.stagingConfig || {});
+    const baselineFlat = flattenValues(this.data.baselineConfig || {});
+    const nextVersions = clone(this.data.fieldVersions || {});
+
+    Object.keys(currentFlat).forEach((fullPath) => {
+      const baseValue = baselineFlat[fullPath];
+      const currentValue = currentFlat[fullPath];
+      const changed = JSON.stringify(baseValue) !== JSON.stringify(currentValue);
+      const [section, ...rest] = fullPath.split('.');
+      const path = rest.join('.');
+      if (!section || !path) return;
+      if (changed) {
+        const sectionVersions = nextVersions[section] || {};
+        sectionVersions[path] = (sectionVersions[path] || 0) + 1;
+        nextVersions[section] = sectionVersions;
+      }
+    });
+
+    return nextVersions;
+  },
+
+  async handleSaveDraft() {
+    this.setData({ saving: true });
+    try {
+      const nextVersions = this.computeNextVersions();
+      const response = await AdminService.saveBalanceDraft({
+        config: this.data.stagingConfig || {},
+        fieldVersions: nextVersions
+      });
+      wx.showToast({ title: '已暂存', icon: 'success' });
+      const stagingMetadata = {
+        updatedBy: response.staging && response.staging.updatedBy,
+        updatedByName: response.staging && response.staging.updatedByName,
+        updatedAt: new Date(),
+        fieldVersions: nextVersions
+      };
+      const sections = buildSections(this.data.defaults, this.data.stagingConfig, nextVersions);
+      this.setData({ stagingMetadata, fieldVersions: nextVersions, baselineConfig: this.data.stagingConfig, sections });
+    } catch (error) {
+      console.error('save balance draft failed', error);
+      wx.showToast({ title: error.message || '暂存失败', icon: 'none' });
+    } finally {
+      this.setData({ saving: false });
+    }
+  },
+
+  async handleTestDraft() {
+    this.setData({ testing: true, testReport: null });
+    try {
+      const report = await AdminService.testBalanceDraft({ rounds: this.data.testRounds });
+      const seedText = report && Array.isArray(report.seeds) ? report.seeds.join(', ') : '';
+      this.setData({ testReport: { ...report, seedText } });
+    } catch (error) {
+      console.error('test balance draft failed', error);
+      wx.showToast({ title: error.message || '测试失败', icon: 'none' });
+    } finally {
+      this.setData({ testing: false });
+    }
+  },
+
+  async handleApplyGlobal() {
+    wx.showModal({
+      title: '应用到全局',
+      content: '确定将暂存的平衡性配置应用到全局吗？',
+      success: async (res) => {
+        if (!res.confirm) return;
+        this.setData({ applying: true });
+        try {
+          await AdminService.applyBalanceConfig();
+          wx.showToast({ title: '已应用到全局', icon: 'success' });
+          this.loadConfig();
+        } catch (error) {
+          console.error('apply balance config failed', error);
+          wx.showToast({ title: error.message || '应用失败', icon: 'none' });
+        } finally {
+          this.setData({ applying: false });
+        }
+      }
+    });
+  }
+});

--- a/miniprogram/subpackages/admin/balance-settings/index.js
+++ b/miniprogram/subpackages/admin/balance-settings/index.js
@@ -477,15 +477,39 @@ function toSlotItems(list = []) {
 }
 
 function normalizeTiers(list = []) {
+  const unwrapValue = (value) => {
+    if (value === undefined || value === null) return '';
+    if (typeof value === 'object') {
+      if ('value' in value) return value.value;
+      if ('current' in value) return value.current;
+      return '';
+    }
+    return value;
+  };
+
+  const normalizeNumber = (value) => {
+    if (value === 'Infinity') return Infinity;
+    const num = Number(value);
+    return Number.isFinite(num) ? num : value;
+  };
+
   if (!Array.isArray(list)) return [];
-  return list.map((item) => ({
-    id: item && item.id ? item.id : '',
-    name: item && item.name ? item.name : '',
-    min: item && item.min !== undefined ? item.min : '',
-    max: item && item.max !== undefined ? item.max : '',
-    color: item && item.color ? item.color : '',
-    rewardKey: item && item.rewardKey ? item.rewardKey : ''
-  }));
+  return list.map((item) => {
+    const id = unwrapValue(item && item.id);
+    const name = unwrapValue(item && item.name);
+    const min = normalizeNumber(unwrapValue(item && item.min));
+    const max = normalizeNumber(unwrapValue(item && item.max));
+    const color = unwrapValue(item && item.color);
+    const rewardKey = unwrapValue(item && item.rewardKey);
+    return {
+      id: id || '',
+      name: name || '',
+      min: min === undefined ? '' : min,
+      max: max === undefined ? '' : max,
+      color: color || '',
+      rewardKey: rewardKey || ''
+    };
+  });
 }
 
 function toTierItems(list = []) {

--- a/miniprogram/subpackages/admin/balance-settings/index.json
+++ b/miniprogram/subpackages/admin/balance-settings/index.json
@@ -1,0 +1,10 @@
+{
+  "navigationBarTitleText": "平衡性设定",
+  "usingComponents": {
+    "custom-nav": "/components/custom-nav/custom-nav",
+    "custom-nav-placeholder": "/components/custom-nav-placeholder/custom-nav-placeholder"
+  },
+  "componentPlaceholder": {
+    "custom-nav": "custom-nav-placeholder"
+  }
+}

--- a/miniprogram/subpackages/admin/balance-settings/index.wxml
+++ b/miniprogram/subpackages/admin/balance-settings/index.wxml
@@ -56,7 +56,7 @@
             <view class="field-desc" wx:if="{{field.description}}">{{field.description}}</view>
             <view class="field-default">{{field.defaultHint}}</view>
           </view>
-          <view class="field-control" wx:if="{{field.type !== 'json' && field.type !== 'boolean' && field.type !== 'slots'}}">
+          <view class="field-control" wx:if="{{field.type !== 'json' && field.type !== 'boolean' && field.type !== 'slots' && field.type !== 'tiers'}}">
             <input
               class="field-input"
               type="{{field.type === 'number' ? 'number' : 'text'}}"
@@ -84,12 +84,12 @@
                 <view class="tier-row-header">
                   <view class="tier-title">{{tier.title}}</view>
                   <button
-                    class="ghost-button mini-button"
+                    class="ghost-button mini-button tier-remove"
                     data-section="{{section.key}}"
                     data-path="{{field.path}}"
                     data-index="{{idx}}"
                     bindtap="handleTierRemove"
-                  >删除段位</button>
+                  >删除</button>
                 </view>
                 <view class="tier-fields">
                   <block wx:for="{{['id','name','min','max','color','rewardKey']}}" wx:key="item">

--- a/miniprogram/subpackages/admin/balance-settings/index.wxml
+++ b/miniprogram/subpackages/admin/balance-settings/index.wxml
@@ -56,7 +56,7 @@
             <view class="field-desc" wx:if="{{field.description}}">{{field.description}}</view>
             <view class="field-default">{{field.defaultHint}}</view>
           </view>
-          <view class="field-control" wx:if="{{field.type !== 'json' && field.type !== 'boolean'}}">
+          <view class="field-control" wx:if="{{field.type !== 'json' && field.type !== 'boolean' && field.type !== 'slots'}}">
             <input
               class="field-input"
               type="{{field.type === 'number' ? 'number' : 'text'}}"
@@ -77,6 +77,38 @@
               data-type="boolean"
               bindchange="handleFieldChange"
             />
+          </view>
+          <view class="field-control slots-control" wx:if="{{field.type === 'slots'}}">
+            <view class="slot-list">
+              <view class="slot-row" wx:for="{{field.items}}" wx:key="index" wx:for-index="idx" wx:for-item="item">
+                <view class="slot-info">
+                  <view class="slot-name">{{item.label}}</view>
+                  <view class="slot-hint">{{item.hint}}</view>
+                </view>
+                <input
+                  class="slot-input"
+                  type="text"
+                  value="{{item.value}}"
+                  data-section="{{section.key}}"
+                  data-path="{{field.path}}"
+                  data-index="{{idx}}"
+                  bindinput="handleSlotValueChange"
+                />
+                <button
+                  class="ghost-button mini-button"
+                  data-section="{{section.key}}"
+                  data-path="{{field.path}}"
+                  data-index="{{idx}}"
+                  bindtap="handleSlotRemove"
+                >删除</button>
+              </view>
+              <button
+                class="ghost-button add-slot"
+                data-section="{{section.key}}"
+                data-path="{{field.path}}"
+                bindtap="handleSlotAdd"
+              >新增槽位</button>
+            </view>
           </view>
           <view class="field-control full" wx:if="{{field.type === 'json'}}">
             <textarea

--- a/miniprogram/subpackages/admin/balance-settings/index.wxml
+++ b/miniprogram/subpackages/admin/balance-settings/index.wxml
@@ -1,0 +1,96 @@
+<custom-nav title="平衡性设定" theme="dark"></custom-nav>
+<view class="page container balance-settings-page">
+  <view class="card" wx:if="{{loading}}">
+    <text class="hint">正在加载平衡性配置...</text>
+  </view>
+
+  <view class="card summary-card" wx:if="{{!loading}}">
+    <view class="card-title">当前全局配置</view>
+    <view class="meta">最近更新时间：{{activeMetadata.updatedAt || '未设置'}}</view>
+    <view class="meta">操作人：{{activeMetadata.updatedByName || '未知'}} {{activeMetadata.updatedBy || ''}}</view>
+  </view>
+
+  <view class="card actions-card" wx:if="{{!loading}}">
+    <view class="action-row">
+      <view class="label">测试轮次</view>
+      <input class="field-input" type="number" value="{{testRounds}}" data-section="pvp" data-path="rounds" bindinput="handleRoundsChange" />
+    </view>
+    <view class="buttons">
+      <button class="primary-button" loading="{{saving}}" bindtap="handleSaveDraft">暂存配置</button>
+      <button class="ghost-button" loading="{{testing}}" bindtap="handleTestDraft">测试暂存配置</button>
+      <button class="danger-button" loading="{{applying}}" bindtap="handleApplyGlobal">应用到全局</button>
+    </view>
+  </view>
+
+  <view class="card" wx:if="{{testReport && !loading}}">
+    <view class="card-title">测试报告</view>
+    <view class="meta">对局次数：{{testReport.report.total}}</view>
+    <view class="meta">玩家胜场：{{testReport.report.playerAWins}} · 对手胜场：{{testReport.report.playerBWins}} · 平局：{{testReport.report.draws}}</view>
+    <view class="meta">平均回合：{{testReport.report.averageRounds}}</view>
+    <view class="seed-list" wx:if="{{testReport.seedText}}">
+      <text class="hint">种子：{{testReport.seedText}}</text>
+    </view>
+  </view>
+
+  <view class="card tabs-card" wx:if="{{!loading}}">
+    <view class="tabs">
+      <block wx:for="{{sections}}" wx:key="key" wx:for-item="tab">
+        <view
+          class="tab-item {{tab.key === activeTab ? 'active' : ''}}"
+          data-key="{{tab.key}}"
+          bindtap="handleTabChange"
+        >
+          {{tab.title}}
+        </view>
+      </block>
+    </view>
+  </view>
+
+  <block wx:for="{{sections}}" wx:key="key" wx:for-item="section">
+    <view class="card section-card" wx:if="{{section.key === activeTab}}">
+      <view class="card-title">{{section.title}}</view>
+      <block wx:for="{{section.fields}}" wx:key="path" wx:for-item="field">
+        <view class="field {{field.type === 'json' ? 'json-field' : ''}}">
+          <view class="field-info">
+            <view class="field-name">{{field.label}}</view>
+            <view class="field-desc" wx:if="{{field.description}}">{{field.description}}</view>
+            <view class="field-default">{{field.defaultHint}}</view>
+          </view>
+          <view class="field-control" wx:if="{{field.type !== 'json' && field.type !== 'boolean'}}">
+            <input
+              class="field-input"
+              type="{{field.type === 'number' ? 'number' : 'text'}}"
+              placeholder="{{field.defaultHint}}"
+              value="{{field.value}}"
+              data-section="{{section.key}}"
+              data-path="{{field.path}}"
+              data-type="{{field.type}}"
+              bindinput="handleFieldChange"
+            />
+          </view>
+          <view class="field-control" wx:if="{{field.type === 'boolean'}}">
+            <switch
+              class="field-switch"
+              checked="{{!!field.value}}"
+              data-section="{{section.key}}"
+              data-path="{{field.path}}"
+              data-type="boolean"
+              bindchange="handleFieldChange"
+            />
+          </view>
+          <view class="field-control full" wx:if="{{field.type === 'json'}}">
+            <textarea
+              class="textarea"
+              placeholder="请输入 JSON 配置"
+              value="{{field.displayValue || ''}}"
+              data-section="{{section.key}}"
+              data-path="{{field.path}}"
+              data-type="json"
+              bindinput="handleFieldChange"
+            />
+          </view>
+        </view>
+      </block>
+    </view>
+  </block>
+</view>

--- a/miniprogram/subpackages/admin/balance-settings/index.wxml
+++ b/miniprogram/subpackages/admin/balance-settings/index.wxml
@@ -50,7 +50,7 @@
     <view class="card section-card" wx:if="{{section.key === activeTab}}">
       <view class="card-title">{{section.title}}</view>
       <block wx:for="{{section.fields}}" wx:key="path" wx:for-item="field">
-        <view class="field {{field.type === 'json' ? 'json-field' : ''}}">
+        <view class="{{field.type === 'slots' ? 'slot-field' : ('field ' + (field.type === 'json' ? 'json-field' : ''))}}">
           <view class="field-info">
             <view class="field-name">{{field.label}}</view>
             <view class="field-desc" wx:if="{{field.description}}">{{field.description}}</view>

--- a/miniprogram/subpackages/admin/balance-settings/index.wxml
+++ b/miniprogram/subpackages/admin/balance-settings/index.wxml
@@ -50,7 +50,7 @@
     <view class="card section-card" wx:if="{{section.key === activeTab}}">
       <view class="card-title">{{section.title}}</view>
       <block wx:for="{{section.fields}}" wx:key="path" wx:for-item="field">
-        <view class="{{field.type === 'slots' ? 'slot-field' : ('field ' + (field.type === 'json' ? 'json-field' : ''))}}">
+        <view class="{{field.type === 'slots' ? 'slot-field' : field.type === 'tiers' ? 'tier-field' : ('field ' + (field.type === 'json' ? 'json-field' : ''))}}">
           <view class="field-info">
             <view class="field-name">{{field.label}}</view>
             <view class="field-desc" wx:if="{{field.description}}">{{field.description}}</view>
@@ -77,6 +77,47 @@
               data-type="boolean"
               bindchange="handleFieldChange"
             />
+          </view>
+          <view class="field-control tiers-control" wx:if="{{field.type === 'tiers'}}">
+            <view class="tier-list">
+              <view class="tier-row" wx:for="{{field.items}}" wx:key="key" wx:for-item="tier" wx:for-index="idx">
+                <view class="tier-row-header">
+                  <view class="tier-title">{{tier.title}}</view>
+                  <button
+                    class="ghost-button mini-button"
+                    data-section="{{section.key}}"
+                    data-path="{{field.path}}"
+                    data-index="{{idx}}"
+                    bindtap="handleTierRemove"
+                  >删除段位</button>
+                </view>
+                <view class="tier-fields">
+                  <block wx:for="{{['id','name','min','max','color','rewardKey']}}" wx:key="item">
+                    <view class="tier-field">
+                      <view class="tier-field-label">{{tierFieldMeta[item].label}}</view>
+                      <view class="tier-field-desc">{{tierFieldMeta[item].description}}</view>
+                      <input
+                        class="tier-input"
+                        type="{{item === 'min' || item === 'max' ? 'number' : 'text'}}"
+                        placeholder="{{tierFieldMeta[item].label}}"
+                        value="{{item === 'max' && tier[item] === Infinity ? 'Infinity' : tier[item]}}"
+                        data-section="{{section.key}}"
+                        data-path="{{field.path}}"
+                        data-index="{{idx}}"
+                        data-key="{{item}}"
+                        bindinput="handleTierFieldChange"
+                      />
+                    </view>
+                  </block>
+                </view>
+              </view>
+              <button
+                class="ghost-button add-tier"
+                data-section="{{section.key}}"
+                data-path="{{field.path}}"
+                bindtap="handleTierAdd"
+              >新增段位</button>
+            </view>
           </view>
           <view class="field-control slots-control" wx:if="{{field.type === 'slots'}}">
             <view class="slot-list">

--- a/miniprogram/subpackages/admin/balance-settings/index.wxss
+++ b/miniprogram/subpackages/admin/balance-settings/index.wxss
@@ -150,6 +150,68 @@
   transform: scale(0.92);
 }
 
+.slots-control {
+  width: 100%;
+}
+
+.slot-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12rpx;
+  width: 100%;
+}
+
+.slot-row {
+  display: flex;
+  align-items: center;
+  gap: 12rpx;
+}
+
+.slot-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4rpx;
+}
+
+.slot-name {
+  font-size: 28rpx;
+  color: #e7ecff;
+  font-weight: 600;
+}
+
+.slot-hint {
+  font-size: 22rpx;
+  color: rgba(206, 216, 255, 0.68);
+  line-height: 1.4;
+}
+
+.slot-input {
+  width: 200rpx;
+  padding: 10rpx 14rpx;
+  border-radius: 12rpx;
+  border: 1rpx solid rgba(118, 134, 214, 0.4);
+  background: rgba(13, 19, 49, 0.8);
+  color: #e7ecff;
+  text-align: left;
+  font-size: 26rpx;
+}
+
+.mini-button {
+  min-width: 120rpx;
+  padding: 10rpx 20rpx;
+  font-size: 24rpx;
+  border-radius: 14rpx;
+}
+
+.add-slot {
+  align-self: flex-start;
+  padding: 10rpx 20rpx;
+  font-size: 24rpx;
+  border-radius: 14rpx;
+}
+
 .field-control.full {
   width: 100%;
 }

--- a/miniprogram/subpackages/admin/balance-settings/index.wxss
+++ b/miniprogram/subpackages/admin/balance-settings/index.wxss
@@ -252,6 +252,8 @@
   font-size: 22rpx;
   color: rgba(206, 216, 255, 0.7);
   line-height: 1.5;
+  height: 66rpx;
+  overflow: hidden;
 }
 
 .tier-input {
@@ -262,6 +264,10 @@
   background: rgba(255, 255, 255, 0.05);
   color: #f1f4ff;
   font-size: 26rpx;
+}
+
+.tier-remove {
+  margin-left: auto;
 }
 
 .add-tier {

--- a/miniprogram/subpackages/admin/balance-settings/index.wxss
+++ b/miniprogram/subpackages/admin/balance-settings/index.wxss
@@ -48,6 +48,13 @@
   white-space: nowrap;
 }
 
+.ghost-button.mini-button {
+  width: 100rpx;
+  min-width: 100rpx;
+  padding-left: 0;
+  padding-right: 0;
+}
+
 .primary-button {
   background: linear-gradient(135deg, #5c7cfa, #7f8cff);
   color: #fff;
@@ -112,6 +119,15 @@
 }
 
 .field:last-child {
+  border-bottom: none;
+}
+
+.slot-field {
+  padding: 16rpx 0;
+  border-bottom: 1rpx solid rgba(255, 255, 255, 0.04);
+}
+
+.slot-field:last-child {
   border-bottom: none;
 }
 

--- a/miniprogram/subpackages/admin/balance-settings/index.wxss
+++ b/miniprogram/subpackages/admin/balance-settings/index.wxss
@@ -131,6 +131,21 @@
   border-bottom: none;
 }
 
+.tier-field {
+  padding: 16rpx 0;
+  border-bottom: 1rpx solid rgba(255, 255, 255, 0.04);
+}
+
+.tier-field:last-child {
+  border-bottom: none;
+}
+
+.tier-field .field-info,
+.tier-field .field-control {
+  width: 100%;
+  flex: unset;
+}
+
 .field-info {
   flex: 1;
   min-width: 0;
@@ -170,6 +185,10 @@
   width: 100%;
 }
 
+.tiers-control {
+  width: 100%;
+}
+
 .slot-list {
   display: flex;
   flex-direction: column;
@@ -181,6 +200,73 @@
   display: flex;
   align-items: center;
   gap: 12rpx;
+}
+
+.tier-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14rpx;
+  width: 100%;
+}
+
+.tier-row {
+  padding: 12rpx;
+  border: 1rpx solid rgba(255, 255, 255, 0.08);
+  border-radius: 12rpx;
+  background: rgba(255, 255, 255, 0.02);
+  display: flex;
+  flex-direction: column;
+  gap: 12rpx;
+}
+
+.tier-row-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.tier-title {
+  font-size: 28rpx;
+  font-weight: 600;
+  color: #f1f4ff;
+}
+
+.tier-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260rpx, 1fr));
+  gap: 12rpx;
+}
+
+.tier-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6rpx;
+}
+
+.tier-field-label {
+  font-size: 26rpx;
+  color: #e5e9ff;
+}
+
+.tier-field-desc {
+  font-size: 22rpx;
+  color: rgba(206, 216, 255, 0.7);
+  line-height: 1.5;
+}
+
+.tier-input {
+  height: 64rpx;
+  padding: 0 16rpx;
+  border-radius: 10rpx;
+  border: 1rpx solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.05);
+  color: #f1f4ff;
+  font-size: 26rpx;
+}
+
+.add-tier {
+  margin-top: 4rpx;
+  align-self: flex-start;
 }
 
 .slot-info {

--- a/miniprogram/subpackages/admin/balance-settings/index.wxss
+++ b/miniprogram/subpackages/admin/balance-settings/index.wxss
@@ -1,0 +1,198 @@
+.balance-settings-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24rpx;
+  background: #050921;
+  min-height: 100vh;
+}
+
+.summary-card .meta {
+  font-size: 24rpx;
+  color: rgba(206, 216, 255, 0.78);
+}
+
+.actions-card {
+  display: flex;
+  flex-direction: column;
+  gap: 20rpx;
+}
+
+.actions-card .action-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20rpx;
+}
+
+.actions-card .label {
+  font-size: 28rpx;
+  color: #e6ebff;
+}
+
+.buttons {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 12rpx;
+  justify-content: flex-end;
+}
+
+.primary-button,
+.ghost-button,
+.danger-button {
+  min-width: 180rpx;
+  padding: 14rpx 28rpx;
+  border-radius: 999rpx;
+  font-size: 26rpx;
+  font-weight: 600;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, #5c7cfa, #7f8cff);
+  color: #fff;
+  border: none;
+}
+
+.ghost-button {
+  background: transparent;
+  border: 1rpx solid rgba(118, 134, 214, 0.56);
+  color: #d7e0ff;
+}
+
+.danger-button {
+  background: rgba(255, 110, 110, 0.18);
+  border: 1rpx solid rgba(255, 150, 150, 0.4);
+  color: #ffbcbc;
+}
+
+.section-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12rpx;
+}
+
+.tabs-card {
+  padding: 0;
+  background: transparent;
+  box-shadow: none;
+  border: none;
+}
+
+.tabs {
+  display: flex;
+  flex-wrap: wrap;
+  overflow: visible;
+  padding: 12rpx 20rpx;
+  gap: 16rpx 12rpx;
+}
+
+.tab-item {
+  padding: 16rpx 24rpx;
+  border-radius: 999rpx;
+  background: rgba(118, 134, 214, 0.12);
+  color: #d7e0ff;
+  font-size: 26rpx;
+  white-space: nowrap;
+  border: 1rpx solid rgba(118, 134, 214, 0.3);
+}
+
+.tab-item.active {
+  background: linear-gradient(135deg, #5c7cfa, #7f8cff);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 6rpx 18rpx rgba(92, 124, 250, 0.35);
+}
+
+.field {
+  display: flex;
+  gap: 20rpx;
+  padding: 16rpx 0;
+  border-bottom: 1rpx solid rgba(255, 255, 255, 0.04);
+}
+
+.field:last-child {
+  border-bottom: none;
+}
+
+.field-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6rpx;
+}
+
+.field-name {
+  font-size: 30rpx;
+  font-weight: 600;
+  color: #f1f4ff;
+}
+
+.field-desc {
+  font-size: 24rpx;
+  color: rgba(206, 216, 255, 0.85);
+  line-height: 1.6;
+}
+
+.field-default {
+  font-size: 22rpx;
+  color: rgba(206, 216, 255, 0.65);
+}
+
+.field-control {
+  flex-shrink: 0;
+  display: flex;
+  align-items: flex-start;
+}
+
+.field-switch {
+  transform: scale(0.92);
+}
+
+.field-control.full {
+  width: 100%;
+}
+
+.field-input {
+  width: 200rpx;
+  padding: 12rpx 16rpx;
+  border-radius: 14rpx;
+  border: 1rpx solid rgba(118, 134, 214, 0.4);
+  background: rgba(13, 19, 49, 0.8);
+  color: #e7ecff;
+  text-align: right;
+  font-size: 28rpx;
+}
+
+.textarea {
+  width: 100%;
+  min-height: 200rpx;
+  border-radius: 16rpx;
+  border: 1rpx solid rgba(118, 134, 214, 0.35);
+  background: rgba(13, 19, 49, 0.8);
+  color: #e7ecff;
+  padding: 16rpx;
+  box-sizing: border-box;
+  font-size: 26rpx;
+}
+
+.json-field {
+  flex-direction: column;
+}
+
+.json-field .field-control {
+  width: 100%;
+  margin-top: 12rpx;
+}
+
+.meta,
+.hint,
+.seed-list {
+  font-size: 24rpx;
+  color: rgba(206, 216, 255, 0.78);
+}
+
+.seed-list {
+  margin-top: 8rpx;
+}

--- a/miniprogram/subpackages/admin/index.js
+++ b/miniprogram/subpackages/admin/index.js
@@ -78,6 +78,12 @@ const BASE_ACTIONS = [
     label: '系统设置',
     description: '系统全局配置功能',
     url: '/subpackages/admin/system-switches/index'
+  },
+  {
+    icon: '⚖️',
+    label: '平衡性设定',
+    description: '维护战斗平衡配置并测试',
+    url: '/subpackages/admin/balance-settings/index'
   }
 ];
 


### PR DESCRIPTION
## Summary
- deduplicate versioned balance fields by showing the latest version with inline version hints and per-field change tracking
- add automatic field version increments on save plus metadata persistence for staging configs
- switch boolean balance inputs to toggles while keeping action layout and section tabs intact

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d6268f62083339c5e6752c4ab726d)