### PR TITLE
feat: 将砍价8项配置迁移到活动管理并支持概率

### DIFF
--- a/cloudfunctions/activities/index.js
+++ b/cloudfunctions/activities/index.js
@@ -216,7 +216,16 @@ function buildBhkBargainConfig() {
     floorPrice: 998,
     baseAttempts: 3,
     vipBonuses: buildRealmBonusConfig(),
-    segments: [120, 180, 200, 260, 320, 500, 0],
+    items: [
+      { amount: 120, probability: 1 },
+      { amount: 160, probability: 1 },
+      { amount: 200, probability: 1 },
+      { amount: 240, probability: 1 },
+      { amount: 280, probability: 1 },
+      { amount: 320, probability: 1 },
+      { amount: 400, probability: 1 },
+      { amount: 500, probability: 1 }
+    ],
     assistRewardRange: { min: 60, max: 180 },
     assistAttemptCap: null,
     stock: 15,
@@ -248,6 +257,7 @@ async function resolveBargainActivityRuntime(event = {}) {
     const config = buildBhkBargainConfig();
     config.startPrice = Number.isFinite(settings.startPrice) ? settings.startPrice : config.startPrice;
     config.floorPrice = Number.isFinite(settings.floorPrice) ? settings.floorPrice : config.floorPrice;
+    config.items = normalizeBargainItems(settings.items, settings.segments);
     config.heroImage = doc.coverImage || config.heroImage;
     config.endsAt = doc.endTime || config.endsAt;
     return { activityId, activityDoc: doc, config };
@@ -527,9 +537,33 @@ function normalizeSegments(segments = []) {
     .filter((value) => Number.isFinite(value));
 }
 
+function normalizeBargainItems(items = [], fallbackSegments = []) {
+  const source = Array.isArray(items) && items.length ? items : fallbackSegments;
+  return source
+    .map((item) => {
+      if (item && typeof item === 'object') {
+        const amount = Number(item.amount);
+        const probability = Number(item.probability);
+        if (!Number.isFinite(amount)) {
+          return null;
+        }
+        return {
+          amount: Math.max(0, Math.floor(amount)),
+          probability: Number.isFinite(probability) ? Math.max(0, probability) : 1
+        };
+      }
+      const amount = Number(item);
+      if (!Number.isFinite(amount)) {
+        return null;
+      }
+      return { amount: Math.max(0, Math.floor(amount)), probability: 1 };
+    })
+    .filter(Boolean);
+}
+
 function buildDisplaySegments(segments = [], mysteryLabel = '???') {
-  const normalized = normalizeSegments(segments);
-  const display = normalized.map((amount) => ({ amount, label: `-¥${amount}` }));
+  const normalized = normalizeBargainItems(segments);
+  const display = normalized.map((item) => ({ amount: item.amount, label: `-¥${item.amount}` }));
   display.push({ amount: null, label: mysteryLabel || '???', isMystery: true });
   return display;
 }
@@ -1044,7 +1078,7 @@ async function buildShareContext(config, targetOpenId, viewerOpenId, viewerProfi
 }
 
 function buildBargainPayload(config, session, overrides = {}) {
-  const displaySegments = buildDisplaySegments(config.segments, config.mysteryLabel);
+  const displaySegments = buildDisplaySegments(config.items || config.segments, config.mysteryLabel);
   const floorReached = (session.currentPrice || 0) <= config.floorPrice;
   const totalStock = Number.isFinite(overrides.totalStock) ? overrides.totalStock : config.stock;
   const publicConfig = { ...config, stock: totalStock, displaySegments };
@@ -1119,14 +1153,14 @@ async function getBhkBargainStatus(event = {}) {
 
 async function spinBhkBargain(event = {}) {
   const { activityId, config, activityDoc } = await resolveBargainActivityRuntime(event);
-  const displaySegments = buildDisplaySegments(config.segments, config.mysteryLabel);
+  const displaySegments = buildDisplaySegments(config.items || config.segments, config.mysteryLabel);
   const stockState = await getBargainStock(config, activityId);
   const { memberBoost, realmName, openid, profile, profileComplete } = await resolveMemberBoost(config);
   const docId = `${activityId}_${openid}`;
   const now = typeof db.serverDate === 'function' ? db.serverDate() : new Date();
-  const segments = normalizeSegments(config.segments);
+  const items = normalizeBargainItems(config.items, config.segments);
 
-  if (!segments.length) {
+  if (!items.length) {
     throw new Error('暂无抽奖配置');
   }
 
@@ -1152,8 +1186,21 @@ async function spinBhkBargain(event = {}) {
       throw new Error('抽奖次数不足');
     }
 
-    const sliceIndex = Math.floor(Math.random() * segments.length);
-    const slice = segments[sliceIndex] || 0;
+    const totalWeight = items.reduce((sum, item) => sum + (Number.isFinite(item.probability) ? Math.max(0, item.probability) : 0), 0);
+    let sliceIndex = 0;
+    if (totalWeight > 0) {
+      let cursor = Math.random() * totalWeight;
+      for (let index = 0; index < items.length; index += 1) {
+        cursor -= Math.max(0, Number(items[index].probability) || 0);
+        if (cursor <= 0) {
+          sliceIndex = index;
+          break;
+        }
+      }
+    } else {
+      sliceIndex = Math.floor(Math.random() * items.length);
+    }
+    const slice = Number(items[sliceIndex] && items[sliceIndex].amount) || 0;
     const availableCut = Math.max(0, record.currentPrice - config.floorPrice);
     const rawCut = Math.max(0, slice);
     const cut = Math.min(rawCut, availableCut);

--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -9462,6 +9462,30 @@ function normalizeBargainSettings(settings = {}, activityType = 'standard') {
     shareRewardAttempts: Number.isFinite(shareRewardAttempts) ? Math.max(0, Math.floor(shareRewardAttempts)) : 1,
     ticketingMode: 'paid-ticket'
   };
+  const defaultItems = [120, 160, 200, 240, 280, 320, 400, 500].map((amount) => ({ amount, probability: 1 }));
+  const itemSource = Array.isArray(source.items) ? source.items : Array.isArray(source.segments) ? source.segments : [];
+  const normalizedItems = itemSource
+    .map((item) => {
+      if (item && typeof item === 'object') {
+        const amountNum = Number(item.amount);
+        const probabilityNum = Number(item.probability);
+        if (!Number.isFinite(amountNum)) {
+          return null;
+        }
+        return {
+          amount: Math.max(0, Math.floor(amountNum)),
+          probability: Number.isFinite(probabilityNum) ? Math.max(0, probabilityNum) : 1
+        };
+      }
+      const amountNum = Number(item);
+      if (!Number.isFinite(amountNum)) {
+        return null;
+      }
+      return { amount: Math.max(0, Math.floor(amountNum)), probability: 1 };
+    })
+    .filter(Boolean)
+    .slice(0, 8);
+  value.items = normalizedItems.length ? normalizedItems : defaultItems;
   if (value.floorPrice > value.startPrice) {
     value.floorPrice = value.startPrice;
   }

--- a/miniprogram/subpackages/admin/activities/index.js
+++ b/miniprogram/subpackages/admin/activities/index.js
@@ -160,6 +160,11 @@ function decorateActivity(activity) {
 }
 
 function buildEditorForm(activity) {
+  const bargainItems =
+    activity && activity.bargainSettings && Array.isArray(activity.bargainSettings.items)
+      ? activity.bargainSettings.items.slice(0, 8)
+      : [];
+  const defaultBargainAmounts = [120, 160, 200, 240, 280, 320, 400, 500];
   if (!activity) {
     return {
       title: '',
@@ -181,6 +186,11 @@ function buildEditorForm(activity) {
       bargainStartPrice: '1500',
       bargainFloorPrice: '998',
       shareRewardAttempts: '1',
+      bargainItems: defaultBargainAmounts.map((amount, index) => ({
+        key: `${index}`,
+        amount: `${amount}`,
+        probability: '1'
+      })),
       coverImage: '',
       sortOrder: '0'
     };
@@ -214,6 +224,14 @@ function buildEditorForm(activity) {
       activity.bargainSettings && Number.isFinite(activity.bargainSettings.shareRewardAttempts)
         ? `${activity.bargainSettings.shareRewardAttempts}`
         : '1',
+    bargainItems: defaultBargainAmounts.map((amount, index) => {
+      const item = bargainItems[index] || {};
+      return {
+        key: `${index}`,
+        amount: Number.isFinite(Number(item.amount)) ? `${Number(item.amount)}` : `${amount}`,
+        probability: Number.isFinite(Number(item.probability)) ? `${Number(item.probability)}` : '1'
+      };
+    }),
     coverImage: activity.coverImage || '',
     sortOrder: `${Number(activity.sortOrder || 0)}`
   };
@@ -334,6 +352,13 @@ Page({
     const value = event.detail && typeof event.detail.value === 'string' ? event.detail.value : '';
     this.setData({ [`editorForm.${field}`]: value });
   },
+  handleBargainItemInput(event) {
+    const { index, field } = event.currentTarget.dataset || {};
+    const idx = Number(index);
+    if (Number.isNaN(idx) || !field) return;
+    const value = event.detail && typeof event.detail.value === 'string' ? event.detail.value : '';
+    this.setData({ [`editorForm.bargainItems[${idx}].${field}`]: value });
+  },
 
   handleEditorTextArea(event) {
     const { field } = event.currentTarget.dataset || {};
@@ -419,7 +444,13 @@ Page({
       payload.bargainSettings = {
         startPrice: Number(form.bargainStartPrice || 1500),
         floorPrice: Number(form.bargainFloorPrice || 998),
-        shareRewardAttempts: Number(form.shareRewardAttempts || 1)
+        shareRewardAttempts: Number(form.shareRewardAttempts || 1),
+        items: (Array.isArray(form.bargainItems) ? form.bargainItems : [])
+          .map((item) => ({
+            amount: Number(item.amount || 0),
+            probability: Number(item.probability || 0)
+          }))
+          .filter((item) => Number.isFinite(item.amount))
       };
     } else {
       payload.bargainSettings = null;

--- a/miniprogram/subpackages/admin/activities/index.wxml
+++ b/miniprogram/subpackages/admin/activities/index.wxml
@@ -244,6 +244,19 @@
         <text class="form-label">分享奖励次数</text>
         <input class="form-input" type="number" value="{{editorForm.shareRewardAttempts}}" data-field="shareRewardAttempts" bindinput="handleEditorInput" />
       </view>
+      <view wx:if="{{editorForm.activityType === 'bargain'}}" class="form-row form-row--full">
+        <text class="form-label">砍价项配置</text>
+        <view class="bargain-items">
+          <view class="bargain-items__header">
+            <text>序号</text><text>金额(元)</text><text>概率权重</text>
+          </view>
+          <view wx:for="{{editorForm.bargainItems}}" wx:key="key" wx:for-index="idx" class="bargain-items__row">
+            <text class="bargain-items__index">{{idx + 1}}</text>
+            <input class="bargain-items__input" type="digit" value="{{item.amount}}" data-index="{{idx}}" data-field="amount" bindinput="handleBargainItemInput" />
+            <input class="bargain-items__input" type="digit" value="{{item.probability}}" data-index="{{idx}}" data-field="probability" bindinput="handleBargainItemInput" />
+          </view>
+        </view>
+      </view>
       <view class="form-row">
         <text class="form-label">发布状态</text>
         <picker

--- a/miniprogram/subpackages/admin/activities/index.wxss
+++ b/miniprogram/subpackages/admin/activities/index.wxss
@@ -265,6 +265,43 @@ page {
   justify-content: flex-end;
   margin-top: 8rpx;
 }
+.bargain-items {
+  flex: 1;
+  padding: 12rpx;
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  border-radius: 12rpx;
+  background: rgba(15, 23, 42, 0.55);
+}
+.bargain-items__header,
+.bargain-items__row {
+  display: grid;
+  grid-template-columns: 72rpx 1fr 1fr;
+  gap: 10rpx;
+  align-items: center;
+}
+.bargain-items__header {
+  font-size: 22rpx;
+  color: rgba(203, 213, 225, 0.78);
+  padding: 4rpx 6rpx 10rpx;
+}
+.bargain-items__row {
+  margin-bottom: 8rpx;
+}
+.bargain-items__index {
+  text-align: center;
+  font-size: 24rpx;
+  color: rgba(226, 232, 240, 0.9);
+}
+.bargain-items__input {
+  min-height: 64rpx;
+  background: rgba(30, 41, 59, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 10rpx;
+  padding: 10rpx 16rpx;
+  color: #e2e8f0;
+  font-size: 24rpx;
+  box-sizing: border-box;
+}
 
 .submit-btn {
   flex: none;


### PR DESCRIPTION
### Motivation

- 将原来硬编码在砍价业务里的 8 个砍价项抽出到活动管理中以便运营可配置金额与概率权重，提升可维护性与多活动复用能力。 

### Description

- 管理端：在活动编辑表单新增“砍价项配置”紧凑三列编辑区（序号 / 金额 / 概率权重），并在 `miniprogram/subpackages/admin/activities/index.js` / `.wxml` / `.wxss` 中增加表单域、事件处理与样式，提交时将 `bargainSettings.items` 一并写入活动。 
- 后端管理接口：在 `cloudfunctions/admin/index.js` 中增强 `normalizeBargainSettings`，兼容旧的 `segments` 或数字数组格式，标准化并限制最多 8 项，若无配置则补默认项。 
- 活动云函数：在 `cloudfunctions/activities/index.js` 中引入 `items` + `probability` 支持，新增 `normalizeBargainItems` 与基于权重的抽取逻辑，调整 `buildDisplaySegments` / `resolveBargainActivityRuntime` / `spinBhkBargain`，同时保留对旧 `segments` 的回退兼容。 

### Testing

- 运行了单测：`npm test -- --runInBand __tests__/activities/bargain.test.js`，该测试文件中的所有用例均通过。 
- 注意：CI 的全仓库 coverage 阈值策略触发了 coverage 检查导致测试命令以非 0 退出（与本次功能逻辑无关）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a116e242718832c80c102a817cee967)