### PR TITLE
支持音乐会砍价头图高度与云存储路径配置

### DIFF
--- a/cloudfunctions/activities/index.js
+++ b/cloudfunctions/activities/index.js
@@ -232,6 +232,7 @@ function buildBhkBargainConfig() {
     stock: 15,
     endsAt: '2025-12-01T16:00:00.000Z',
     heroImage: buildCloudAssetUrl('background', 'cover-20251126.jpg'),
+    heroHeightRpx: 1000,
     mysteryLabel: '???',
     perks: [
         '基础砍价：3次',
@@ -304,7 +305,13 @@ async function resolveBargainActivityRuntime(event = {}) {
         config.segments = config.bargainItems.map((item) => item.amount);
       }
     }
-    config.heroImage = doc.coverImage || config.heroImage;
+    const heroImagePath = typeof settings.heroImagePath === 'string' ? settings.heroImagePath.trim() : '';
+    if (heroImagePath) {
+      config.heroImage = buildCloudAssetUrl(heroImagePath.replace(/^\/+/, ''));
+    } else {
+      config.heroImage = doc.coverImage || config.heroImage;
+    }
+    config.heroHeightRpx = Number.isFinite(settings.heroHeightRpx) ? Math.max(420, Math.floor(settings.heroHeightRpx)) : 1000;
     config.endsAt = doc.endTime || config.endsAt;
     return { activityId, activityDoc: doc, config };
   }

--- a/cloudfunctions/activities/index.js
+++ b/cloudfunctions/activities/index.js
@@ -263,6 +263,18 @@ function normalizeBargainItems(items = []) {
     });
 }
 
+
+function normalizeCloudAssetRelativePath(path = '') {
+  if (typeof path !== 'string') {
+    return '';
+  }
+  const trimmed = path.trim().replace(/\\/g, '/').replace(/^\/+/, '');
+  if (!trimmed) {
+    return '';
+  }
+  return trimmed.replace(/^assets\//i, '');
+}
+
 function pickBargainItemByProbability(items = []) {
   const normalized = normalizeBargainItems(items);
   if (!normalized.length) {
@@ -307,7 +319,8 @@ async function resolveBargainActivityRuntime(event = {}) {
     }
     const heroImagePath = typeof settings.heroImagePath === 'string' ? settings.heroImagePath.trim() : '';
     if (heroImagePath) {
-      config.heroImage = buildCloudAssetUrl(heroImagePath.replace(/^\/+/, ''));
+      const normalizedHeroImagePath = normalizeCloudAssetRelativePath(heroImagePath);
+      config.heroImage = normalizedHeroImagePath ? buildCloudAssetUrl(normalizedHeroImagePath) : config.heroImage;
     } else {
       config.heroImage = doc.coverImage || config.heroImage;
     }

--- a/cloudfunctions/activities/index.js
+++ b/cloudfunctions/activities/index.js
@@ -233,6 +233,8 @@ function buildBhkBargainConfig() {
     endsAt: '2025-12-01T16:00:00.000Z',
     heroImage: buildCloudAssetUrl('background', 'cover-20251126.jpg'),
     heroHeightRpx: 1000,
+    pageBackgroundColor: '#050814',
+    cardBackgroundColor: 'rgba(13, 18, 35, 0.9)',
     mysteryLabel: '???',
     perks: [
         '基础砍价：3次',
@@ -325,6 +327,12 @@ async function resolveBargainActivityRuntime(event = {}) {
       config.heroImage = doc.coverImage || config.heroImage;
     }
     config.heroHeightRpx = Number.isFinite(settings.heroHeightRpx) ? Math.max(420, Math.floor(settings.heroHeightRpx)) : 1000;
+    config.pageBackgroundColor = typeof settings.pageBackgroundColor === 'string' && settings.pageBackgroundColor.trim()
+      ? settings.pageBackgroundColor.trim()
+      : config.pageBackgroundColor;
+    config.cardBackgroundColor = typeof settings.cardBackgroundColor === 'string' && settings.cardBackgroundColor.trim()
+      ? settings.cardBackgroundColor.trim()
+      : config.cardBackgroundColor;
     config.endsAt = doc.endTime || config.endsAt;
     return { activityId, activityDoc: doc, config };
   }

--- a/cloudfunctions/activities/index.js
+++ b/cloudfunctions/activities/index.js
@@ -235,6 +235,7 @@ function buildBhkBargainConfig() {
     heroHeightRpx: 1000,
     pageBackgroundColor: '#050814',
     cardBackgroundColor: 'rgba(13, 18, 35, 0.9)',
+    heroMaskEnabled: true,
     mysteryLabel: '???',
     perks: [
         '基础砍价：3次',
@@ -333,6 +334,7 @@ async function resolveBargainActivityRuntime(event = {}) {
     config.cardBackgroundColor = typeof settings.cardBackgroundColor === 'string' && settings.cardBackgroundColor.trim()
       ? settings.cardBackgroundColor.trim()
       : config.cardBackgroundColor;
+    config.heroMaskEnabled = typeof settings.heroMaskEnabled === 'boolean' ? settings.heroMaskEnabled : config.heroMaskEnabled;
     config.endsAt = doc.endTime || config.endsAt;
     return { activityId, activityDoc: doc, config };
   }

--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -9465,6 +9465,7 @@ function normalizeBargainSettings(settings = {}, activityType = 'standard') {
     : '/assets/background/articalday.jpg';
   const pageBackgroundColor = trimToString(source.pageBackgroundColor) || '#050814';
   const cardBackgroundColor = trimToString(source.cardBackgroundColor) || 'rgba(13, 18, 35, 0.9)';
+  const heroMaskEnabled = typeof source.heroMaskEnabled === 'boolean' ? source.heroMaskEnabled : source.heroMaskEnabled !== 'false';
   const value = {
     startPrice: Number.isFinite(startPrice) ? Math.max(0, Math.floor(startPrice)) : 1500,
     floorPrice: Number.isFinite(floorPrice) ? Math.max(0, Math.floor(floorPrice)) : 998,
@@ -9474,6 +9475,7 @@ function normalizeBargainSettings(settings = {}, activityType = 'standard') {
     heroHeightRpx: Number.isFinite(heroHeightRpx) ? Math.max(420, Math.floor(heroHeightRpx)) : 1000,
     pageBackgroundColor,
     cardBackgroundColor,
+    heroMaskEnabled,
     ticketingMode: 'paid-ticket'
   };
   const defaultItems = [

--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -9463,6 +9463,8 @@ function normalizeBargainSettings(settings = {}, activityType = 'standard') {
   const heroImagePath = normalizedHeroImagePath
     ? `/${normalizedHeroImagePath.replace(/^\/+/, '')}`
     : '/assets/background/articalday.jpg';
+  const pageBackgroundColor = trimToString(source.pageBackgroundColor) || '#050814';
+  const cardBackgroundColor = trimToString(source.cardBackgroundColor) || 'rgba(13, 18, 35, 0.9)';
   const value = {
     startPrice: Number.isFinite(startPrice) ? Math.max(0, Math.floor(startPrice)) : 1500,
     floorPrice: Number.isFinite(floorPrice) ? Math.max(0, Math.floor(floorPrice)) : 998,
@@ -9470,6 +9472,8 @@ function normalizeBargainSettings(settings = {}, activityType = 'standard') {
     stock: Number.isFinite(stock) ? Math.max(0, Math.floor(stock)) : 15,
     heroImagePath,
     heroHeightRpx: Number.isFinite(heroHeightRpx) ? Math.max(420, Math.floor(heroHeightRpx)) : 1000,
+    pageBackgroundColor,
+    cardBackgroundColor,
     ticketingMode: 'paid-ticket'
   };
   const defaultItems = [

--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -9457,11 +9457,19 @@ function normalizeBargainSettings(settings = {}, activityType = 'standard') {
   const floorPrice = Number(source.floorPrice);
   const shareRewardAttempts = Number(source.shareRewardAttempts);
   const stock = Number(source.stock);
+  const heroHeightRpx = Number(source.heroHeightRpx);
+  const rawHeroImagePath = trimToString(source.heroImagePath);
+  const normalizedHeroImagePath = rawHeroImagePath.replace(/\\/g, '/').trim();
+  const heroImagePath = normalizedHeroImagePath
+    ? `/${normalizedHeroImagePath.replace(/^\/+/, '')}`
+    : '/assets/background/articalday.jpg';
   const value = {
     startPrice: Number.isFinite(startPrice) ? Math.max(0, Math.floor(startPrice)) : 1500,
     floorPrice: Number.isFinite(floorPrice) ? Math.max(0, Math.floor(floorPrice)) : 998,
     shareRewardAttempts: Number.isFinite(shareRewardAttempts) ? Math.max(0, Math.floor(shareRewardAttempts)) : 1,
     stock: Number.isFinite(stock) ? Math.max(0, Math.floor(stock)) : 15,
+    heroImagePath,
+    heroHeightRpx: Number.isFinite(heroHeightRpx) ? Math.max(420, Math.floor(heroHeightRpx)) : 1000,
     ticketingMode: 'paid-ticket'
   };
   const defaultItems = [

--- a/docs/activity-bargain-template-design.md
+++ b/docs/activity-bargain-template-design.md
@@ -154,3 +154,25 @@
    - 新建/编辑音乐会活动，确认 `activityType=bargain`、`activityTemplate=concert-bargain`、`1500/998/1` 已保存。
    - 前台活动列表进入该活动后，检查标题、头图、价格初始值、最低价是否与音乐会配置一致。
    - 数据库检查 `bhkBargainRecords` 新增记录键是否为 `${音乐会活动ID}_${openid}`，`bhkBargainStock` 是否使用音乐会活动 ID 作为文档键。
+
+
+## 问题复盘（2026-05-23）：音乐会头图路径配置未生效
+
+### 现象
+- 后台活动管理已填写 `bargainSettings.heroImagePath=/assets/background/articalday.jpg`，但前台仍显示旧图：`.../assets/background/cover-20251126.jpg`。
+
+### 根因
+1. 后台管理端表单虽然新增了 `heroImagePath/heroHeightRpx` 并提交到 `payload.bargainSettings`；
+2. 但 `cloudfunctions/admin` 的 `normalizeBargainSettings` 白名单未包含这两个字段，保存时被规范化逻辑丢弃；
+3. `cloudfunctions/activities` 读取活动配置时拿不到 `heroImagePath`，只能回退到 `doc.coverImage` 或默认 `cover-20251126.jpg`。
+
+### 修复
+- 在 `cloudfunctions/admin/index.js` 的 `normalizeBargainSettings` 中补充：
+  - `heroImagePath`：标准化为以 `/` 开头的云存储相对路径，默认 `/assets/background/articalday.jpg`；
+  - `heroHeightRpx`：最小值保护 420，默认 1000。
+- 保持 `cloudfunctions/activities` 现有读取逻辑：优先 `heroImagePath`，再回退 `coverImage`。
+
+### 回归建议
+1. 管理后台编辑音乐会砍价活动并保存；
+2. 云开发数据库检查活动文档 `bargainSettings.heroImagePath` 是否已落库；
+3. 前台打开活动页，确认头图 URL 为 `/assets/background/articalday.jpg` 对应云地址。

--- a/miniprogram/pages/activities/bhk-bargain/index.js
+++ b/miniprogram/pages/activities/bhk-bargain/index.js
@@ -27,6 +27,7 @@ const REALM_REWARD_RULES = [
 ];
 const DEFAULT_AVATAR = `${AVATAR_IMAGE_BASE_PATH}/default.png`;
 const DEFAULT_HERO_IMAGE = buildCloudAssetUrl('background', 'activity-20251127-3.jpg');
+const DEFAULT_HERO_HEIGHT_RPX = 1000;
 
 function resolveNavHeight() {
   const app = getApp();
@@ -50,6 +51,7 @@ function normalizeBargainConfig(config = {}) {
   const vipBonuses = Array.isArray(config.vipBonuses) ? config.vipBonuses : [];
   const displaySegments = Array.isArray(config.displaySegments) ? config.displaySegments : [];
   const floorPrice = Number.isFinite(config.floorPrice) ? Math.max(0, config.floorPrice) : 998;
+  const heroHeightRpx = Number.isFinite(config.heroHeightRpx) ? Math.max(420, Math.floor(config.heroHeightRpx)) : DEFAULT_HERO_HEIGHT_RPX;
   return {
     startPrice,
     baseAttempts,
@@ -62,7 +64,8 @@ function normalizeBargainConfig(config = {}) {
     perks,
     vipBonuses,
     displaySegments,
-    floorPrice
+    floorPrice,
+    heroHeightRpx
   };
 }
 
@@ -268,6 +271,7 @@ Page({
     activeSegmentIndex: -1,
     showRules: false,
     heroImage: DEFAULT_HERO_IMAGE,
+    heroHeightRpx: DEFAULT_HERO_HEIGHT_RPX,
     perks: [],
     mapLocation: DEFAULT_LOCATION,
     shareContext: null,
@@ -425,6 +429,7 @@ Page({
       countdownTarget,
       countdown: countdownTarget ? formatCountdownText(countdownTarget) : '敬请期待',
       heroImage: bargain.heroImage || DEFAULT_HERO_IMAGE,
+      heroHeightRpx: bargain.heroHeightRpx || DEFAULT_HERO_HEIGHT_RPX,
       perks: bargain.perks,
       mapLocation,
       shareContext,

--- a/miniprogram/pages/activities/bhk-bargain/index.js
+++ b/miniprogram/pages/activities/bhk-bargain/index.js
@@ -30,6 +30,7 @@ const DEFAULT_HERO_IMAGE = buildCloudAssetUrl('background', 'activity-20251127-3
 const DEFAULT_HERO_HEIGHT_RPX = 1000;
 const DEFAULT_PAGE_BACKGROUND_COLOR = '#050814';
 const DEFAULT_CARD_BACKGROUND_COLOR = 'rgba(13, 18, 35, 0.9)';
+const DEFAULT_HERO_MASK_ENABLED = true;
 
 function resolveNavHeight() {
   const app = getApp();
@@ -56,6 +57,7 @@ function normalizeBargainConfig(config = {}) {
   const heroHeightRpx = Number.isFinite(config.heroHeightRpx) ? Math.max(420, Math.floor(config.heroHeightRpx)) : DEFAULT_HERO_HEIGHT_RPX;
   const pageBackgroundColor = (typeof config.pageBackgroundColor === 'string' && config.pageBackgroundColor.trim()) || DEFAULT_PAGE_BACKGROUND_COLOR;
   const cardBackgroundColor = (typeof config.cardBackgroundColor === 'string' && config.cardBackgroundColor.trim()) || DEFAULT_CARD_BACKGROUND_COLOR;
+  const heroMaskEnabled = typeof config.heroMaskEnabled === 'boolean' ? config.heroMaskEnabled : DEFAULT_HERO_MASK_ENABLED;
   return {
     startPrice,
     baseAttempts,
@@ -71,7 +73,8 @@ function normalizeBargainConfig(config = {}) {
     floorPrice,
     heroHeightRpx,
     pageBackgroundColor,
-    cardBackgroundColor
+    cardBackgroundColor,
+    heroMaskEnabled
   };
 }
 
@@ -280,6 +283,7 @@ Page({
     heroHeightRpx: DEFAULT_HERO_HEIGHT_RPX,
     pageBackgroundColor: DEFAULT_PAGE_BACKGROUND_COLOR,
     cardBackgroundColor: DEFAULT_CARD_BACKGROUND_COLOR,
+    heroMaskEnabled: DEFAULT_HERO_MASK_ENABLED,
     perks: [],
     mapLocation: DEFAULT_LOCATION,
     shareContext: null,
@@ -440,6 +444,7 @@ Page({
       heroHeightRpx: bargain.heroHeightRpx || DEFAULT_HERO_HEIGHT_RPX,
       pageBackgroundColor: bargain.pageBackgroundColor || DEFAULT_PAGE_BACKGROUND_COLOR,
       cardBackgroundColor: bargain.cardBackgroundColor || DEFAULT_CARD_BACKGROUND_COLOR,
+      heroMaskEnabled: typeof bargain.heroMaskEnabled === 'boolean' ? bargain.heroMaskEnabled : DEFAULT_HERO_MASK_ENABLED,
       perks: bargain.perks,
       mapLocation,
       shareContext,

--- a/miniprogram/pages/activities/bhk-bargain/index.js
+++ b/miniprogram/pages/activities/bhk-bargain/index.js
@@ -28,6 +28,8 @@ const REALM_REWARD_RULES = [
 const DEFAULT_AVATAR = `${AVATAR_IMAGE_BASE_PATH}/default.png`;
 const DEFAULT_HERO_IMAGE = buildCloudAssetUrl('background', 'activity-20251127-3.jpg');
 const DEFAULT_HERO_HEIGHT_RPX = 1000;
+const DEFAULT_PAGE_BACKGROUND_COLOR = '#050814';
+const DEFAULT_CARD_BACKGROUND_COLOR = 'rgba(13, 18, 35, 0.9)';
 
 function resolveNavHeight() {
   const app = getApp();
@@ -52,6 +54,8 @@ function normalizeBargainConfig(config = {}) {
   const displaySegments = Array.isArray(config.displaySegments) ? config.displaySegments : [];
   const floorPrice = Number.isFinite(config.floorPrice) ? Math.max(0, config.floorPrice) : 998;
   const heroHeightRpx = Number.isFinite(config.heroHeightRpx) ? Math.max(420, Math.floor(config.heroHeightRpx)) : DEFAULT_HERO_HEIGHT_RPX;
+  const pageBackgroundColor = (typeof config.pageBackgroundColor === 'string' && config.pageBackgroundColor.trim()) || DEFAULT_PAGE_BACKGROUND_COLOR;
+  const cardBackgroundColor = (typeof config.cardBackgroundColor === 'string' && config.cardBackgroundColor.trim()) || DEFAULT_CARD_BACKGROUND_COLOR;
   return {
     startPrice,
     baseAttempts,
@@ -65,7 +69,9 @@ function normalizeBargainConfig(config = {}) {
     vipBonuses,
     displaySegments,
     floorPrice,
-    heroHeightRpx
+    heroHeightRpx,
+    pageBackgroundColor,
+    cardBackgroundColor
   };
 }
 
@@ -272,6 +278,8 @@ Page({
     showRules: false,
     heroImage: DEFAULT_HERO_IMAGE,
     heroHeightRpx: DEFAULT_HERO_HEIGHT_RPX,
+    pageBackgroundColor: DEFAULT_PAGE_BACKGROUND_COLOR,
+    cardBackgroundColor: DEFAULT_CARD_BACKGROUND_COLOR,
     perks: [],
     mapLocation: DEFAULT_LOCATION,
     shareContext: null,
@@ -430,6 +438,8 @@ Page({
       countdown: countdownTarget ? formatCountdownText(countdownTarget) : '敬请期待',
       heroImage: bargain.heroImage || DEFAULT_HERO_IMAGE,
       heroHeightRpx: bargain.heroHeightRpx || DEFAULT_HERO_HEIGHT_RPX,
+      pageBackgroundColor: bargain.pageBackgroundColor || DEFAULT_PAGE_BACKGROUND_COLOR,
+      cardBackgroundColor: bargain.cardBackgroundColor || DEFAULT_CARD_BACKGROUND_COLOR,
       perks: bargain.perks,
       mapLocation,
       shareContext,

--- a/miniprogram/pages/activities/bhk-bargain/index.wxml
+++ b/miniprogram/pages/activities/bhk-bargain/index.wxml
@@ -1,7 +1,7 @@
 <custom-nav title="" theme="transparent"></custom-nav>
 <view class="bhk-hero" style="margin-top: -{{navHeight}}px; height: {{heroHeightRpx}}rpx;">
   <image class="bhk-hero__image" src="{{heroImage}}" mode="aspectFill"></image>
-  <view class="bhk-hero__mask"></view>
+  <view wx:if="{{heroMaskEnabled}}" class="bhk-hero__mask"></view>
 </view>
 
 <view class="bhk-page" style="background: {{pageBackgroundColor}};">

--- a/miniprogram/pages/activities/bhk-bargain/index.wxml
+++ b/miniprogram/pages/activities/bhk-bargain/index.wxml
@@ -4,12 +4,12 @@
   <view class="bhk-hero__mask"></view>
 </view>
 
-<view class="bhk-page">
+<view class="bhk-page" style="background: {{pageBackgroundColor}};">
   <block wx:if="{{loading}}">
-    <view class="bhk-card bhk-state">活动情报加载中...</view>
+    <view class="bhk-card bhk-state" style="background: {{cardBackgroundColor}};">活动情报加载中...</view>
   </block>
   <block wx:elif="{{!activity}}">
-    <view class="bhk-card bhk-state bhk-state--error">
+    <view class="bhk-card bhk-state bhk-state--error" style="background: {{cardBackgroundColor}};">
       {{singlePageMode ? '查看活动详情点击右下角，前往小程序' : '活动暂不可用，请稍后再试'}}
     </view>
   </block>
@@ -37,7 +37,7 @@
         </view>
       </view>
     </view>
-    <view class="bhk-card bhk-turntable">
+    <view class="bhk-card bhk-turntable" style="background: {{cardBackgroundColor}};">
       <view class="bhk-price-card__row">
         <text class="bhk-price-card__original">原价 ¥{{basePrice}}</text><text class="bhk-price-card__reduce">已减 ¥{{totalDiscount}}</text>
         <text class="bhk-price-card__current {{floorReached ? 'bhk-price-card__current--floor' : ''}}">{{floorReached ? '价格触底' : '当前票价'}} ¥{{currentPrice}}</text>
@@ -103,7 +103,7 @@
       </view>
     </view>
 
-    <view class="bhk-card bhk-share">
+    <view class="bhk-card bhk-share" style="background: {{cardBackgroundColor}};">
       <view class="bhk-section-title">分享助力</view>
       <view class="bhk-share__desc">“被助力”<text style="color:skyblue;">次数不限</text>，但“助力他人”只有<text style="color: tomato;">1</text>次，请斟酌使用，使用后双方各得1次砍价数。</view>
       <view class="bhk-share__helpers" wx:if="{{shareContext && shareContext.helpers && shareContext.helpers.length}}">
@@ -161,7 +161,7 @@
       <view wx:if="{{shareTimelineMessage}}" class="bhk-share__hint">{{shareTimelineMessage}}</view>
     </view>
 
-    <view class="bhk-card bhk-info">
+    <view class="bhk-card bhk-info" style="background: {{cardBackgroundColor}};">
       <view class="bhk-section-title">礼遇与规则</view>
       <view class="bhk-info__list">
         <view class="bhk-info__item">持"感恩节活动"会员权益任意时间到店使用。</view>

--- a/miniprogram/pages/activities/bhk-bargain/index.wxml
+++ b/miniprogram/pages/activities/bhk-bargain/index.wxml
@@ -1,5 +1,5 @@
 <custom-nav title="" theme="transparent"></custom-nav>
-<view class="bhk-hero" style="margin-top: -{{navHeight}}px;">
+<view class="bhk-hero" style="margin-top: -{{navHeight}}px; height: {{heroHeightRpx}}rpx;">
   <image class="bhk-hero__image" src="{{heroImage}}" mode="aspectFill"></image>
   <view class="bhk-hero__mask"></view>
 </view>

--- a/miniprogram/pages/activities/bhk-bargain/index.wxss
+++ b/miniprogram/pages/activities/bhk-bargain/index.wxss
@@ -1,7 +1,7 @@
 .bhk-hero {
   position: relative;
   width: 100%;
-  height: 460rpx;
+  height: 1000rpx;
   overflow: hidden;
 }
 
@@ -27,7 +27,7 @@
   display: flex;
   flex-direction: column;
   gap: 24rpx;
-  margin-top: -300rpx;
+  margin-top: 0;
   padding: 24rpx;
   padding-bottom: calc(100rpx + env(safe-area-inset-bottom));
   min-height: 100vh;

--- a/miniprogram/subpackages/admin/activities/index.js
+++ b/miniprogram/subpackages/admin/activities/index.js
@@ -206,6 +206,7 @@ function buildEditorForm(activity) {
       heroHeightRpx: '1000',
       pageBackgroundColor: '#050814',
       cardBackgroundColor: 'rgba(13, 18, 35, 0.9)',
+      heroMaskEnabled: 'true',
       sortOrder: '0'
     };
   }
@@ -260,6 +261,10 @@ function buildEditorForm(activity) {
       activity.bargainSettings && typeof activity.bargainSettings.cardBackgroundColor === 'string'
         ? activity.bargainSettings.cardBackgroundColor
         : 'rgba(13, 18, 35, 0.9)',
+    heroMaskEnabled:
+      activity.bargainSettings && typeof activity.bargainSettings.heroMaskEnabled === 'boolean'
+        ? `${activity.bargainSettings.heroMaskEnabled}`
+        : 'true',
     sortOrder: `${Number(activity.sortOrder || 0)}`
   };
 }
@@ -424,6 +429,14 @@ Page({
     this.setData({ [`editorForm.${field}`]: value });
   },
 
+
+  handleHeroMaskEnabledChange(event) {
+    const index = Number(event.detail.value);
+    this.setData({
+      'editorForm.heroMaskEnabled': index === 1 ? 'false' : 'true'
+    });
+  },
+
   handleEditorTimeChange(event) {
     const { field } = event.currentTarget.dataset || {};
     if (!field) {
@@ -494,7 +507,8 @@ Page({
         heroImagePath: (form.heroImagePath || '').trim(),
         heroHeightRpx: Number(form.heroHeightRpx || 1000),
         pageBackgroundColor: (form.pageBackgroundColor || '').trim(),
-        cardBackgroundColor: (form.cardBackgroundColor || '').trim()
+        cardBackgroundColor: (form.cardBackgroundColor || '').trim(),
+        heroMaskEnabled: `${form.heroMaskEnabled}` !== 'false'
       };
     } else {
       payload.bargainSettings = null;

--- a/miniprogram/subpackages/admin/activities/index.js
+++ b/miniprogram/subpackages/admin/activities/index.js
@@ -202,6 +202,8 @@ function buildEditorForm(activity) {
       bargainStock: '15',
       bargainItems: formBargainItems,
       coverImage: '',
+      heroImagePath: '/assets/background/articalday.jpg',
+      heroHeightRpx: '1000',
       sortOrder: '0'
     };
   }
@@ -240,6 +242,14 @@ function buildEditorForm(activity) {
         : '15',
     bargainItems: formBargainItems,
     coverImage: activity.coverImage || '',
+    heroImagePath:
+      activity.bargainSettings && typeof activity.bargainSettings.heroImagePath === 'string'
+        ? activity.bargainSettings.heroImagePath
+        : '/assets/background/articalday.jpg',
+    heroHeightRpx:
+      activity.bargainSettings && Number.isFinite(activity.bargainSettings.heroHeightRpx)
+        ? `${activity.bargainSettings.heroHeightRpx}`
+        : '1000',
     sortOrder: `${Number(activity.sortOrder || 0)}`
   };
 }
@@ -470,7 +480,9 @@ Page({
         floorPrice: Number(form.bargainFloorPrice || 998),
         shareRewardAttempts: Number(form.shareRewardAttempts || 1),
         stock: Number(form.bargainStock || 15),
-        bargainItems: normalizedItems
+        bargainItems: normalizedItems,
+        heroImagePath: (form.heroImagePath || '').trim(),
+        heroHeightRpx: Number(form.heroHeightRpx || 1000)
       };
     } else {
       payload.bargainSettings = null;

--- a/miniprogram/subpackages/admin/activities/index.js
+++ b/miniprogram/subpackages/admin/activities/index.js
@@ -204,6 +204,8 @@ function buildEditorForm(activity) {
       coverImage: '',
       heroImagePath: '/assets/background/articalday.jpg',
       heroHeightRpx: '1000',
+      pageBackgroundColor: '#050814',
+      cardBackgroundColor: 'rgba(13, 18, 35, 0.9)',
       sortOrder: '0'
     };
   }
@@ -250,6 +252,14 @@ function buildEditorForm(activity) {
       activity.bargainSettings && Number.isFinite(activity.bargainSettings.heroHeightRpx)
         ? `${activity.bargainSettings.heroHeightRpx}`
         : '1000',
+    pageBackgroundColor:
+      activity.bargainSettings && typeof activity.bargainSettings.pageBackgroundColor === 'string'
+        ? activity.bargainSettings.pageBackgroundColor
+        : '#050814',
+    cardBackgroundColor:
+      activity.bargainSettings && typeof activity.bargainSettings.cardBackgroundColor === 'string'
+        ? activity.bargainSettings.cardBackgroundColor
+        : 'rgba(13, 18, 35, 0.9)',
     sortOrder: `${Number(activity.sortOrder || 0)}`
   };
 }
@@ -482,7 +492,9 @@ Page({
         stock: Number(form.bargainStock || 15),
         bargainItems: normalizedItems,
         heroImagePath: (form.heroImagePath || '').trim(),
-        heroHeightRpx: Number(form.heroHeightRpx || 1000)
+        heroHeightRpx: Number(form.heroHeightRpx || 1000),
+        pageBackgroundColor: (form.pageBackgroundColor || '').trim(),
+        cardBackgroundColor: (form.cardBackgroundColor || '').trim()
       };
     } else {
       payload.bargainSettings = null;

--- a/miniprogram/subpackages/admin/activities/index.wxml
+++ b/miniprogram/subpackages/admin/activities/index.wxml
@@ -248,6 +248,15 @@
         <text class="form-label">门票总数</text>
         <input class="form-input" type="number" value="{{editorForm.bargainStock}}" data-field="bargainStock" bindinput="handleEditorInput" />
       </view>
+
+      <view wx:if="{{editorForm.activityType === 'bargain'}}" class="form-row">
+        <text class="form-label">头图云存储相对路径</text>
+        <input class="form-input" value="{{editorForm.heroImagePath}}" data-field="heroImagePath" bindinput="handleEditorInput" placeholder="/assets/background/articalday.jpg" />
+      </view>
+      <view wx:if="{{editorForm.activityType === 'bargain'}}" class="form-row">
+        <text class="form-label">头图高度(rpx)</text>
+        <input class="form-input" type="number" value="{{editorForm.heroHeightRpx}}" data-field="heroHeightRpx" bindinput="handleEditorInput" />
+      </view>
       <view wx:if="{{editorForm.activityType === 'bargain'}}" class="form-row form-row--full">
         <text class="form-label">砍价项配置（概率总和100%）</text>
         <view class="bargain-items">

--- a/miniprogram/subpackages/admin/activities/index.wxml
+++ b/miniprogram/subpackages/admin/activities/index.wxml
@@ -257,6 +257,14 @@
         <text class="form-label">头图高度(rpx)</text>
         <input class="form-input" type="number" value="{{editorForm.heroHeightRpx}}" data-field="heroHeightRpx" bindinput="handleEditorInput" />
       </view>
+      <view wx:if="{{editorForm.activityType === 'bargain'}}" class="form-row">
+        <text class="form-label">页面背景色</text>
+        <input class="form-input" value="{{editorForm.pageBackgroundColor}}" data-field="pageBackgroundColor" bindinput="handleEditorInput" placeholder="#050814 / rgba(...)" />
+      </view>
+      <view wx:if="{{editorForm.activityType === 'bargain'}}" class="form-row">
+        <text class="form-label">卡片背景色</text>
+        <input class="form-input" value="{{editorForm.cardBackgroundColor}}" data-field="cardBackgroundColor" bindinput="handleEditorInput" placeholder="rgba(13, 18, 35, 0.9)" />
+      </view>
       <view wx:if="{{editorForm.activityType === 'bargain'}}" class="form-row form-row--full">
         <text class="form-label">砍价项配置（概率总和100%）</text>
         <view class="bargain-items">

--- a/miniprogram/subpackages/admin/activities/index.wxml
+++ b/miniprogram/subpackages/admin/activities/index.wxml
@@ -265,6 +265,12 @@
         <text class="form-label">卡片背景色</text>
         <input class="form-input" value="{{editorForm.cardBackgroundColor}}" data-field="cardBackgroundColor" bindinput="handleEditorInput" placeholder="rgba(13, 18, 35, 0.9)" />
       </view>
+      <view wx:if="{{editorForm.activityType === 'bargain'}}" class="form-row">
+        <text class="form-label">头图遮罩</text>
+        <picker mode="selector" range="{{['开启','关闭']}}" value="{{editorForm.heroMaskEnabled === 'false' ? 1 : 0}}" bindchange="handleHeroMaskEnabledChange">
+          <view class="picker-value">{{editorForm.heroMaskEnabled === 'false' ? '关闭' : '开启'}}</view>
+        </picker>
+      </view>
       <view wx:if="{{editorForm.activityType === 'bargain'}}" class="form-row form-row--full">
         <text class="form-label">砍价项配置（概率总和100%）</text>
         <view class="bargain-items">


### PR DESCRIPTION
### Motivation
- 音乐会砍价活动需展示 3:4 比例的头图并完整露出，正文应从头图下方开始显示以保证视觉一致性。 
- 希望将头图高度设为默认值并允许运营在后台活动管理中配置头图高度与云存储相对路径，便于按活动调整素材及展示。 

### Description
- 前台页面 `miniprogram/pages/activities/bhk-bargain/*` 新增默认常量 `DEFAULT_HERO_HEIGHT_RPX` 并在 `normalizeBargainConfig` / 页面 `data` 中按 `heroHeightRpx` 透传与应用，页面模板中将 `.bhk-hero` 高度改为 `{{heroHeightRpx}}rpx`，样式默认改为 `1000rpx` 并移除了上方负 margin，使正文从头图下方开始。 
- 管理后台 `miniprogram/subpackages/admin/activities/*` 在活动编辑表单中新增两个字段：`heroImagePath`（头图云存储相对路径）与 `heroHeightRpx`（头图高度 rpx），并在保存时将它们写入 `payload.bargainSettings`。 
- 云函数 `cloudfunctions/activities/index.js` 的 `buildBhkBargainConfig` 和 `resolveBargainActivityRuntime` 增加 `heroHeightRpx` 支持，且若 `bargainSettings.heroImagePath` 存在会用 `buildCloudAssetUrl` 拼接为完整云上地址。 
- 已将变更提交到分支并生成对应 PR 描述（涉及文件列表见提交/变更摘要）。

### Testing
- 运行了与砍价相关的单测：`npm test -- --runInBand __tests__/activities/bargain.test.js`，测试用例全部通过（6 个通过）。
- 由于仓库启用的全局覆盖率阈值，测试命令最终退出码为非零，但用例本身通过且与本次改动逻辑无直接冲突。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11bc8c9cbc832c88d3014ee80d373e)