### PR TITLE
feat: 支持砍价活动礼遇与规则模块后台开关和实时文案

### DIFF
--- a/cloudfunctions/activities/index.js
+++ b/cloudfunctions/activities/index.js
@@ -236,6 +236,9 @@ function buildBhkBargainConfig() {
     pageBackgroundColor: '#050814',
     cardBackgroundColor: 'rgba(13, 18, 35, 0.9)',
     heroMaskEnabled: true,
+    infoSectionEnabled: true,
+    infoSectionContent:
+      '持"感恩节活动"会员权益任意时间到店使用。\n软饮畅饮，伴手礼 BHK56 雪茄一支。\n余票与倒计时实时更新，售罄即止。\n票券不可转售或退款。\n购票消费可同时提升修为和灵石。\n本次活动是修仙晋升的大好机会，不容错过！',
     mysteryLabel: '???',
     perks: [
         '基础砍价：3次',
@@ -335,6 +338,11 @@ async function resolveBargainActivityRuntime(event = {}) {
       ? settings.cardBackgroundColor.trim()
       : config.cardBackgroundColor;
     config.heroMaskEnabled = typeof settings.heroMaskEnabled === 'boolean' ? settings.heroMaskEnabled : config.heroMaskEnabled;
+    config.infoSectionEnabled = typeof settings.infoSectionEnabled === 'boolean' ? settings.infoSectionEnabled : config.infoSectionEnabled;
+    config.infoSectionContent =
+      typeof settings.infoSectionContent === 'string' && settings.infoSectionContent.trim()
+        ? settings.infoSectionContent.trim()
+        : config.infoSectionContent;
     config.endsAt = doc.endTime || config.endsAt;
     return { activityId, activityDoc: doc, config };
   }

--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -9466,6 +9466,9 @@ function normalizeBargainSettings(settings = {}, activityType = 'standard') {
   const pageBackgroundColor = trimToString(source.pageBackgroundColor) || '#050814';
   const cardBackgroundColor = trimToString(source.cardBackgroundColor) || 'rgba(13, 18, 35, 0.9)';
   const heroMaskEnabled = typeof source.heroMaskEnabled === 'boolean' ? source.heroMaskEnabled : source.heroMaskEnabled !== 'false';
+  const infoSectionEnabled =
+    typeof source.infoSectionEnabled === 'boolean' ? source.infoSectionEnabled : source.infoSectionEnabled !== 'false';
+  const infoSectionContent = normalizeMultilineString(source.infoSectionContent);
   const value = {
     startPrice: Number.isFinite(startPrice) ? Math.max(0, Math.floor(startPrice)) : 1500,
     floorPrice: Number.isFinite(floorPrice) ? Math.max(0, Math.floor(floorPrice)) : 998,
@@ -9476,6 +9479,8 @@ function normalizeBargainSettings(settings = {}, activityType = 'standard') {
     pageBackgroundColor,
     cardBackgroundColor,
     heroMaskEnabled,
+    infoSectionEnabled,
+    infoSectionContent,
     ticketingMode: 'paid-ticket'
   };
   const defaultItems = [

--- a/miniprogram/pages/activities/bhk-bargain/index.js
+++ b/miniprogram/pages/activities/bhk-bargain/index.js
@@ -31,6 +31,15 @@ const DEFAULT_HERO_HEIGHT_RPX = 1000;
 const DEFAULT_PAGE_BACKGROUND_COLOR = '#050814';
 const DEFAULT_CARD_BACKGROUND_COLOR = 'rgba(13, 18, 35, 0.9)';
 const DEFAULT_HERO_MASK_ENABLED = true;
+const DEFAULT_INFO_SECTION_ENABLED = true;
+const DEFAULT_INFO_SECTION_CONTENT = [
+  '持"感恩节活动"会员权益任意时间到店使用。',
+  '软饮畅饮，伴手礼 BHK56 雪茄一支。',
+  '余票与倒计时实时更新，售罄即止。',
+  '票券不可转售或退款。',
+  '购票消费可同时提升修为和灵石。',
+  '本次活动是修仙晋升的大好机会，不容错过！'
+];
 
 function resolveNavHeight() {
   const app = getApp();
@@ -58,6 +67,12 @@ function normalizeBargainConfig(config = {}) {
   const pageBackgroundColor = (typeof config.pageBackgroundColor === 'string' && config.pageBackgroundColor.trim()) || DEFAULT_PAGE_BACKGROUND_COLOR;
   const cardBackgroundColor = (typeof config.cardBackgroundColor === 'string' && config.cardBackgroundColor.trim()) || DEFAULT_CARD_BACKGROUND_COLOR;
   const heroMaskEnabled = typeof config.heroMaskEnabled === 'boolean' ? config.heroMaskEnabled : DEFAULT_HERO_MASK_ENABLED;
+  const infoSectionEnabled =
+    typeof config.infoSectionEnabled === 'boolean' ? config.infoSectionEnabled : DEFAULT_INFO_SECTION_ENABLED;
+  const infoSectionContent =
+    typeof config.infoSectionContent === 'string' && config.infoSectionContent.trim()
+      ? config.infoSectionContent.trim()
+      : DEFAULT_INFO_SECTION_CONTENT.join('\n');
   return {
     startPrice,
     baseAttempts,
@@ -74,8 +89,20 @@ function normalizeBargainConfig(config = {}) {
     heroHeightRpx,
     pageBackgroundColor,
     cardBackgroundColor,
-    heroMaskEnabled
+    heroMaskEnabled,
+    infoSectionEnabled,
+    infoSectionContent
   };
+}
+
+function toMultilineItems(text = '') {
+  if (typeof text !== 'string') {
+    return [];
+  }
+  return text
+    .split(/\r?\n+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
 }
 
 function formatCountdownText(targetTimestamp) {
@@ -301,6 +328,8 @@ Page({
     cardBackgroundColor: DEFAULT_CARD_BACKGROUND_COLOR,
     heroMaskEnabled: DEFAULT_HERO_MASK_ENABLED,
     perks: [],
+    infoSectionEnabled: DEFAULT_INFO_SECTION_ENABLED,
+    infoSectionItems: DEFAULT_INFO_SECTION_CONTENT,
     mapLocation: DEFAULT_LOCATION,
     shareContext: null,
     memberId: '',
@@ -466,6 +495,8 @@ Page({
       cardBackgroundColor: bargain.cardBackgroundColor || DEFAULT_CARD_BACKGROUND_COLOR,
       heroMaskEnabled: typeof bargain.heroMaskEnabled === 'boolean' ? bargain.heroMaskEnabled : DEFAULT_HERO_MASK_ENABLED,
       perks: bargain.perks,
+      infoSectionEnabled: typeof bargain.infoSectionEnabled === 'boolean' ? bargain.infoSectionEnabled : DEFAULT_INFO_SECTION_ENABLED,
+      infoSectionItems: toMultilineItems(bargain.infoSectionContent),
       mapLocation,
       shareContext,
       memberId: session.memberId || this.data.memberId,

--- a/miniprogram/pages/activities/bhk-bargain/index.wxml
+++ b/miniprogram/pages/activities/bhk-bargain/index.wxml
@@ -197,15 +197,10 @@
       <view wx:if="{{shareTimelineMessage}}" class="bhk-share__hint">{{shareTimelineMessage}}</view>
     </view>
 
-    <view class="bhk-card bhk-info" style="background: {{cardBackgroundColor}};">
+    <view wx:if="{{infoSectionEnabled && infoSectionItems.length}}" class="bhk-card bhk-info" style="background: {{cardBackgroundColor}};">
       <view class="bhk-section-title">礼遇与规则</view>
       <view class="bhk-info__list">
-        <view class="bhk-info__item">持"感恩节活动"会员权益任意时间到店使用。</view>
-        <view class="bhk-info__item">软饮畅饮，伴手礼 BHK56 雪茄一支。</view>
-        <view class="bhk-info__item">余票与倒计时实时更新，售罄即止。</view>
-        <view class="bhk-info__item">票券不可转售或退款。</view>
-        <view class="bhk-info__item">购票消费可同时提升修为和灵石。</view>
-        <view class="bhk-info__item">本次活动是修仙晋升的<text style="color:tomato;">大好机会，不容错过！</text></view>
+        <view class="bhk-info__item" wx:for="{{infoSectionItems}}" wx:key="index">{{item}}</view>
       </view>
     </view>
   </block>

--- a/miniprogram/subpackages/admin/activities/index.js
+++ b/miniprogram/subpackages/admin/activities/index.js
@@ -207,6 +207,8 @@ function buildEditorForm(activity) {
       pageBackgroundColor: '#050814',
       cardBackgroundColor: 'rgba(13, 18, 35, 0.9)',
       heroMaskEnabled: 'true',
+      infoSectionEnabled: 'true',
+      infoSectionContent: '',
       sortOrder: '0'
     };
   }
@@ -265,6 +267,14 @@ function buildEditorForm(activity) {
       activity.bargainSettings && typeof activity.bargainSettings.heroMaskEnabled === 'boolean'
         ? `${activity.bargainSettings.heroMaskEnabled}`
         : 'true',
+    infoSectionEnabled:
+      activity.bargainSettings && typeof activity.bargainSettings.infoSectionEnabled === 'boolean'
+        ? `${activity.bargainSettings.infoSectionEnabled}`
+        : 'true',
+    infoSectionContent:
+      activity.bargainSettings && typeof activity.bargainSettings.infoSectionContent === 'string'
+        ? activity.bargainSettings.infoSectionContent
+        : '',
     sortOrder: `${Number(activity.sortOrder || 0)}`
   };
 }
@@ -436,6 +446,12 @@ Page({
       'editorForm.heroMaskEnabled': index === 1 ? 'false' : 'true'
     });
   },
+  handleInfoSectionEnabledChange(event) {
+    const index = Number(event.detail.value);
+    this.setData({
+      'editorForm.infoSectionEnabled': index === 1 ? 'false' : 'true'
+    });
+  },
 
   handleEditorTimeChange(event) {
     const { field } = event.currentTarget.dataset || {};
@@ -508,7 +524,9 @@ Page({
         heroHeightRpx: Number(form.heroHeightRpx || 1000),
         pageBackgroundColor: (form.pageBackgroundColor || '').trim(),
         cardBackgroundColor: (form.cardBackgroundColor || '').trim(),
-        heroMaskEnabled: `${form.heroMaskEnabled}` !== 'false'
+        heroMaskEnabled: `${form.heroMaskEnabled}` !== 'false',
+        infoSectionEnabled: `${form.infoSectionEnabled}` !== 'false',
+        infoSectionContent: form.infoSectionContent || ''
       };
     } else {
       payload.bargainSettings = null;

--- a/miniprogram/subpackages/admin/activities/index.wxml
+++ b/miniprogram/subpackages/admin/activities/index.wxml
@@ -271,6 +271,22 @@
           <view class="picker-value">{{editorForm.heroMaskEnabled === 'false' ? '关闭' : '开启'}}</view>
         </picker>
       </view>
+      <view wx:if="{{editorForm.activityType === 'bargain'}}" class="form-row">
+        <text class="form-label">礼遇与规则模块</text>
+        <picker mode="selector" range="{{['开启','关闭']}}" value="{{editorForm.infoSectionEnabled === 'false' ? 1 : 0}}" bindchange="handleInfoSectionEnabledChange">
+          <view class="picker-value">{{editorForm.infoSectionEnabled === 'false' ? '关闭' : '开启'}}</view>
+        </picker>
+      </view>
+      <view wx:if="{{editorForm.activityType === 'bargain' && editorForm.infoSectionEnabled !== 'false'}}" class="form-row form-row--full">
+        <text class="form-label">礼遇与规则内容</text>
+        <textarea
+          class="form-textarea"
+          placeholder="每行填写一条前台展示文案"
+          value="{{editorForm.infoSectionContent}}"
+          data-field="infoSectionContent"
+          bindinput="handleEditorTextArea"
+        ></textarea>
+      </view>
       <view wx:if="{{editorForm.activityType === 'bargain'}}" class="form-row form-row--full">
         <text class="form-label">砍价项配置（概率总和100%）</text>
         <view class="bargain-items">


### PR DESCRIPTION
### Motivation
- 砍价活动前台“礼遇与规则”模块原为写死内容，无法通过活动后台按需开启/关闭或实时修改文案。  
- 需要将该模块配置下沉到活动的 `bargainSettings`，以便运营在后台实时控制前台展示与内容。

### Description
- 在活动配置标准化中新增字段 `infoSectionEnabled` 和 `infoSectionContent` 并在 `normalizeBargainSettings` 中进行清洗与默认处理（`cloudfunctions/admin/index.js`）。
- 在活动运行时构建与解析流程中接入上述字段并提供默认回退值（`cloudfunctions/activities/index.js` 的 `buildBhkBargainConfig` 与 `resolveBargainActivityRuntime`）。
- 在后台活动编辑界面中新增开关与多行文本输入，以便保存到 `bargainSettings`（`miniprogram/subpackages/admin/activities/index.js` 与对应 `index.wxml`）。
- 前台砍价页改为按后台配置条件渲染：仅当 `infoSectionEnabled` 为真且内容非空时展示，并把多行文本拆成条目逐行渲染（`miniprogram/pages/activities/bhk-bargain/index.js` 与 `index.wxml`）。

### Testing
- 已运行静态/diff 检查 `git diff --check`，检查通过。  
- 变更已本地添加并提交，且项目文件差异检查（`git status --short`）显示预期修改；未新增单元测试。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e2e658f8832cbe03298ba7e82fdc)