### PR TITLE
feat(activity): 支持砍价活动 Banner 标签后台配置与开关

### DIFF
--- a/cloudfunctions/activities/index.js
+++ b/cloudfunctions/activities/index.js
@@ -347,6 +347,12 @@ async function resolveBargainActivityRuntime(event = {}) {
       typeof settings.infoSectionContent === 'string' && settings.infoSectionContent.trim()
         ? settings.infoSectionContent.trim()
         : config.infoSectionContent;
+    config.activityTag1 = typeof settings.activityTag1 === 'string' ? settings.activityTag1.trim() : config.activityTag1;
+    config.activityTag2 = typeof settings.activityTag2 === 'string' ? settings.activityTag2.trim() : config.activityTag2;
+    config.activityTag1Enabled =
+      typeof settings.activityTag1Enabled === 'boolean' ? settings.activityTag1Enabled : config.activityTag1Enabled;
+    config.activityTag2Enabled =
+      typeof settings.activityTag2Enabled === 'boolean' ? settings.activityTag2Enabled : config.activityTag2Enabled;
     config.endsAt = doc.endTime || config.endsAt;
     return { activityId, activityDoc: doc, config };
   }

--- a/cloudfunctions/activities/index.js
+++ b/cloudfunctions/activities/index.js
@@ -239,6 +239,10 @@ function buildBhkBargainConfig() {
     infoSectionEnabled: true,
     infoSectionContent:
       '持"感恩节活动"会员权益任意时间到店使用。\n软饮畅饮，伴手礼 BHK56 雪茄一支。\n余票与倒计时实时更新，售罄即止。\n票券不可转售或退款。\n购票消费可同时提升修为和灵石。\n本次活动是修仙晋升的大好机会，不容错过！',
+    activityTag1: '顶级雪茄',
+    activityTag1Enabled: true,
+    activityTag2: '感恩节回馈',
+    activityTag2Enabled: true,
     mysteryLabel: '???',
     perks: [
         '基础砍价：3次',

--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -9469,6 +9469,12 @@ function normalizeBargainSettings(settings = {}, activityType = 'standard') {
   const infoSectionEnabled =
     typeof source.infoSectionEnabled === 'boolean' ? source.infoSectionEnabled : source.infoSectionEnabled !== 'false';
   const infoSectionContent = normalizeMultilineString(source.infoSectionContent);
+  const activityTag1 = trimToString(source.activityTag1);
+  const activityTag2 = trimToString(source.activityTag2);
+  const activityTag1Enabled =
+    typeof source.activityTag1Enabled === 'boolean' ? source.activityTag1Enabled : source.activityTag1Enabled !== 'false';
+  const activityTag2Enabled =
+    typeof source.activityTag2Enabled === 'boolean' ? source.activityTag2Enabled : source.activityTag2Enabled !== 'false';
   const value = {
     startPrice: Number.isFinite(startPrice) ? Math.max(0, Math.floor(startPrice)) : 1500,
     floorPrice: Number.isFinite(floorPrice) ? Math.max(0, Math.floor(floorPrice)) : 998,
@@ -9481,6 +9487,10 @@ function normalizeBargainSettings(settings = {}, activityType = 'standard') {
     heroMaskEnabled,
     infoSectionEnabled,
     infoSectionContent,
+    activityTag1,
+    activityTag1Enabled,
+    activityTag2,
+    activityTag2Enabled,
     ticketingMode: 'paid-ticket'
   };
   const defaultItems = [

--- a/miniprogram/pages/activities/bhk-bargain/index.js
+++ b/miniprogram/pages/activities/bhk-bargain/index.js
@@ -32,6 +32,8 @@ const DEFAULT_PAGE_BACKGROUND_COLOR = '#050814';
 const DEFAULT_CARD_BACKGROUND_COLOR = 'rgba(13, 18, 35, 0.9)';
 const DEFAULT_HERO_MASK_ENABLED = true;
 const DEFAULT_INFO_SECTION_ENABLED = true;
+const DEFAULT_ACTIVITY_TAG_1 = '顶级雪茄';
+const DEFAULT_ACTIVITY_TAG_2 = '感恩节回馈';
 const DEFAULT_INFO_SECTION_CONTENT = [
   '持"感恩节活动"会员权益任意时间到店使用。',
   '软饮畅饮，伴手礼 BHK56 雪茄一支。',
@@ -73,6 +75,10 @@ function normalizeBargainConfig(config = {}) {
     typeof config.infoSectionContent === 'string' && config.infoSectionContent.trim()
       ? config.infoSectionContent.trim()
       : DEFAULT_INFO_SECTION_CONTENT.join('\n');
+  const activityTag1 = typeof config.activityTag1 === 'string' ? config.activityTag1.trim() : DEFAULT_ACTIVITY_TAG_1;
+  const activityTag2 = typeof config.activityTag2 === 'string' ? config.activityTag2.trim() : DEFAULT_ACTIVITY_TAG_2;
+  const activityTag1Enabled = typeof config.activityTag1Enabled === 'boolean' ? config.activityTag1Enabled : Boolean(activityTag1);
+  const activityTag2Enabled = typeof config.activityTag2Enabled === 'boolean' ? config.activityTag2Enabled : Boolean(activityTag2);
   return {
     startPrice,
     baseAttempts,
@@ -91,7 +97,11 @@ function normalizeBargainConfig(config = {}) {
     cardBackgroundColor,
     heroMaskEnabled,
     infoSectionEnabled,
-    infoSectionContent
+    infoSectionContent,
+    activityTag1,
+    activityTag2,
+    activityTag1Enabled,
+    activityTag2Enabled
   };
 }
 
@@ -278,6 +288,20 @@ function resolveTimelineCapability() {
   return { supported: true, envVersion };
 }
 
+
+
+function buildBannerSubtitle(bargain = {}, stockRemaining = 0) {
+  const tags = [];
+  if (bargain.activityTag1Enabled && bargain.activityTag1) {
+    tags.push(bargain.activityTag1);
+  }
+  tags.push(`限量 ${bargain.stock || stockRemaining || 0} 席`);
+  if (bargain.activityTag2Enabled && bargain.activityTag2) {
+    tags.push(bargain.activityTag2);
+  }
+  return tags.join(' · ');
+}
+
 function isCloudPermissionDenied(error) {
   const code = typeof error === 'object' && error ? error.errCode : null;
   const message = (error && (error.errMsg || error.message || '')) || '';
@@ -337,7 +361,8 @@ Page({
     ticketOwned: false,
     shareTimelineSupported: true,
     shareTimelineMessage: '',
-    singlePageMode: false
+    singlePageMode: false,
+    bannerSubtitle: ''
   },
 
   onLoad(options = {}) {
@@ -500,7 +525,8 @@ Page({
       mapLocation,
       shareContext,
       memberId: session.memberId || this.data.memberId,
-      ticketOwned
+      ticketOwned,
+      bannerSubtitle: buildBannerSubtitle(bargain, stockRemaining)
     });
     this.startCountdown();
   },

--- a/miniprogram/pages/activities/bhk-bargain/index.wxml
+++ b/miniprogram/pages/activities/bhk-bargain/index.wxml
@@ -55,7 +55,7 @@
       <view class="bhk-banner__content">
         <view wx:if="{{ticketOwned}}" class="bhk-banner__badge">已获得通行证</view>
         <view class="bhk-banner__title">{{activity.title || '感恩节 · BHK56 品鉴会'}}</view>
-        <view class="bhk-banner__subtitle">顶级雪茄 · 限量 {{bargain.stock || stockRemaining || 0}} 席 · 感恩节回馈</view>
+        <view class="bhk-banner__subtitle">{{bannerSubtitle}}</view>
         <view class="bhk-banner__pill-row">
           <view class="bhk-banner__pill" style="width: 230rpx;">剩余时间：{{countdown}}</view>
           <view class="bhk-banner__pill bhk-banner__pill--accent">余票：{{stockRemaining}}/{{bargain.stock}}</view>

--- a/miniprogram/subpackages/admin/activities/index.js
+++ b/miniprogram/subpackages/admin/activities/index.js
@@ -209,6 +209,10 @@ function buildEditorForm(activity) {
       heroMaskEnabled: 'true',
       infoSectionEnabled: 'true',
       infoSectionContent: '',
+      activityTag1: '',
+      activityTag1Enabled: 'true',
+      activityTag2: '',
+      activityTag2Enabled: 'true',
       sortOrder: '0'
     };
   }
@@ -275,6 +279,22 @@ function buildEditorForm(activity) {
       activity.bargainSettings && typeof activity.bargainSettings.infoSectionContent === 'string'
         ? activity.bargainSettings.infoSectionContent
         : '',
+    activityTag1:
+      activity.bargainSettings && typeof activity.bargainSettings.activityTag1 === 'string'
+        ? activity.bargainSettings.activityTag1
+        : '',
+    activityTag1Enabled:
+      activity.bargainSettings && typeof activity.bargainSettings.activityTag1Enabled === 'boolean'
+        ? `${activity.bargainSettings.activityTag1Enabled}`
+        : 'true',
+    activityTag2:
+      activity.bargainSettings && typeof activity.bargainSettings.activityTag2 === 'string'
+        ? activity.bargainSettings.activityTag2
+        : '',
+    activityTag2Enabled:
+      activity.bargainSettings && typeof activity.bargainSettings.activityTag2Enabled === 'boolean'
+        ? `${activity.bargainSettings.activityTag2Enabled}`
+        : 'true',
     sortOrder: `${Number(activity.sortOrder || 0)}`
   };
 }
@@ -453,6 +473,20 @@ Page({
     });
   },
 
+  handleActivityTag1EnabledChange(event) {
+    const index = Number(event.detail.value);
+    this.setData({
+      'editorForm.activityTag1Enabled': index === 1 ? 'false' : 'true'
+    });
+  },
+
+  handleActivityTag2EnabledChange(event) {
+    const index = Number(event.detail.value);
+    this.setData({
+      'editorForm.activityTag2Enabled': index === 1 ? 'false' : 'true'
+    });
+  },
+
   handleEditorTimeChange(event) {
     const { field } = event.currentTarget.dataset || {};
     if (!field) {
@@ -526,7 +560,11 @@ Page({
         cardBackgroundColor: (form.cardBackgroundColor || '').trim(),
         heroMaskEnabled: `${form.heroMaskEnabled}` !== 'false',
         infoSectionEnabled: `${form.infoSectionEnabled}` !== 'false',
-        infoSectionContent: form.infoSectionContent || ''
+        infoSectionContent: form.infoSectionContent || '',
+        activityTag1: (form.activityTag1 || '').trim(),
+        activityTag1Enabled: `${form.activityTag1Enabled}` !== 'false',
+        activityTag2: (form.activityTag2 || '').trim(),
+        activityTag2Enabled: `${form.activityTag2Enabled}` !== 'false'
       };
     } else {
       payload.bargainSettings = null;

--- a/miniprogram/subpackages/admin/activities/index.wxml
+++ b/miniprogram/subpackages/admin/activities/index.wxml
@@ -287,6 +287,30 @@
           bindinput="handleEditorTextArea"
         ></textarea>
       </view>
+      <view wx:if="{{editorForm.activityType === 'bargain'}}" class="form-row form-row--split">
+        <view class="form-item">
+          <text class="form-label">活动标签1</text>
+          <input class="form-input" value="{{editorForm.activityTag1}}" data-field="activityTag1" bindinput="handleEditorInput" placeholder="如：顶级雪茄" />
+        </view>
+        <view class="form-item">
+          <text class="form-label">活动标签1开关</text>
+          <picker mode="selector" range="{{['开启','关闭']}}" value="{{editorForm.activityTag1Enabled === 'false' ? 1 : 0}}" bindchange="handleActivityTag1EnabledChange">
+            <view class="picker-value">{{editorForm.activityTag1Enabled === 'false' ? '关闭' : '开启'}}</view>
+          </picker>
+        </view>
+      </view>
+      <view wx:if="{{editorForm.activityType === 'bargain'}}" class="form-row form-row--split">
+        <view class="form-item">
+          <text class="form-label">活动标签2</text>
+          <input class="form-input" value="{{editorForm.activityTag2}}" data-field="activityTag2" bindinput="handleEditorInput" placeholder="如：感恩节回馈" />
+        </view>
+        <view class="form-item">
+          <text class="form-label">活动标签2开关</text>
+          <picker mode="selector" range="{{['开启','关闭']}}" value="{{editorForm.activityTag2Enabled === 'false' ? 1 : 0}}" bindchange="handleActivityTag2EnabledChange">
+            <view class="picker-value">{{editorForm.activityTag2Enabled === 'false' ? '关闭' : '开启'}}</view>
+          </picker>
+        </view>
+      </view>
       <view wx:if="{{editorForm.activityType === 'bargain'}}" class="form-row form-row--full">
         <text class="form-label">砍价项配置（概率总和100%）</text>
         <view class="bargain-items">


### PR DESCRIPTION
### Motivation
- 将页面中写死的副标题文案（“顶级雪茄” 与 “感恩节回馈”）提取为可由活动后台配置的字段，以便灵活开关和修改。 
- 避免在某一标签关闭时副标题首尾出现多余的 `·` 分隔符，保证展示格式一致。 
- 保持与现有默认活动数据兼容，提供安全的回退值。

### Description
- 在 `miniprogram/pages/activities/bhk-bargain/index.js` 中新增默认常量 `DEFAULT_ACTIVITY_TAG_1` 与 `DEFAULT_ACTIVITY_TAG_2`，并在 `normalizeBargainConfig` 中读取 `activityTag1/activityTag2` 与对应开关 `activityTag1Enabled/activityTag2Enabled`。 
- 增加 `buildBannerSubtitle(bargain, stockRemaining)` 方法用于按开关拼接副标题并用 ` · ` 连接，确保关闭时不会残留分隔符；在页面 `data` 中新增 `bannerSubtitle` 并在 `applySession` 时生成。 
- 将 WXML 中原先写死的副标题替换为 `{{bannerSubtitle}}` 渲染。 
- 在 `cloudfunctions/activities/index.js` 的默认活动配置中补充 `activityTag1/activityTag1Enabled/activityTag2/activityTag2Enabled` 默认值以便后台直接配置和兼容旧数据。 
- 修改的文件：`miniprogram/pages/activities/bhk-bargain/index.js`、`miniprogram/pages/activities/bhk-bargain/index.wxml`、`cloudfunctions/activities/index.js`。

### Testing
- 已执行仓库变更检查命令 `git -C /workspace/member status --short` 并返回修改列表（成功）。
- 已查看变更差异使用 `git -C /workspace/member diff -- <files>` 并确认期望改动（成功）。
- 已执行提交 `git commit` 并成功创建变更快照（成功）。
- 仓库中未包含自动化单元测试针对此改动的执行记录（未运行单元测试）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e6d82d84832c9b9b2b49058f4b46)