### PR TITLE
feat: add bargain quiz reward (admin-configurable +1 spin)

### DIFF
--- a/cloudfunctions/activities/index.js
+++ b/cloudfunctions/activities/index.js
@@ -109,6 +109,8 @@ exports.main = async (event = {}) => {
       return divineHandBhkBargain(event || {});
     case 'bargainConfirmPurchase':
       return confirmBhkBargainPurchase(event || {});
+    case 'bargainAnswerQuiz':
+      return answerBhkBargainQuiz(event || {});
     default:
       throw new Error(`Unknown action: ${action}`);
   }
@@ -1190,6 +1192,18 @@ function buildBargainPayload(config, session, overrides = {}) {
   return { ...payload, ...overrides };
 }
 
+function normalizeQuizConfig(settings = {}) {
+  const quiz = settings && typeof settings.quizReward === 'object' ? settings.quizReward : {};
+  const enabled = Boolean(quiz.enabled);
+  const question = typeof quiz.question === 'string' ? quiz.question.trim() : '';
+  const options = Array.isArray(quiz.options)
+    ? quiz.options.map((item) => (typeof item === 'string' ? item.trim() : '')).filter(Boolean).slice(0, 6)
+    : [];
+  const answerIndex = Number.isFinite(quiz.answerIndex) ? Math.floor(quiz.answerIndex) : -1;
+  const valid = enabled && question && options.length >= 2 && answerIndex >= 0 && answerIndex < options.length;
+  return { enabled, question, options, answerIndex, valid };
+}
+
 async function getBhkBargainStatus(event = {}) {
   const { activityId, config, activityDoc } = await resolveBargainActivityRuntime(event);
   const shareId = typeof event.shareId === 'string' ? event.shareId.trim() : '';
@@ -1233,11 +1247,67 @@ async function getBhkBargainStatus(event = {}) {
       .catch(() => null);
   }
 
+  const quizConfig = normalizeQuizConfig(activityDoc && activityDoc.bargainSettings);
   return buildBargainPayload(config, normalizedSession, {
     activityDoc,
     shareContext,
+    quizReward: {
+      enabled: quizConfig.valid,
+      question: quizConfig.valid ? quizConfig.question : '',
+      options: quizConfig.valid ? quizConfig.options : [],
+      rewarded: Boolean(normalizedSession.quizRewarded)
+    },
     stockRemaining: stockState.stockRemaining,
     totalStock: stockState.totalStock
+  });
+}
+
+async function answerBhkBargainQuiz(event = {}) {
+  const { activityId, config, activityDoc } = await resolveBargainActivityRuntime(event);
+  const quizConfig = normalizeQuizConfig(activityDoc && activityDoc.bargainSettings);
+  if (!quizConfig.valid) {
+    throw new Error('答题奖励未开启');
+  }
+  const selectedIndex = Number(event.selectedIndex);
+  if (!Number.isFinite(selectedIndex)) {
+    throw new Error('请选择答案');
+  }
+  const { memberBoost, realmName, openid, profile, profileComplete } = await resolveMemberBoost(config);
+  const docId = `${activityId}_${openid}`;
+  await getOrCreateBargainSession(config, { memberBoost, memberRealm: realmName, openid, memberProfile: profile, profileComplete, activityId });
+  const stockState = await getBargainStock(config, activityId);
+  const now = typeof db.serverDate === 'function' ? db.serverDate() : new Date();
+  let finalSession = null;
+  await db.runTransaction(async (transaction) => {
+    const ref = transaction.collection(BHK_BARGAIN_COLLECTION).doc(docId);
+    const snapshot = await ref.get().catch(() => null);
+    if (!snapshot || !snapshot.data) {
+      throw new Error('答题会话不存在');
+    }
+    const record = normalizeBargainSession(snapshot.data, config, { memberBoost, memberRealm: realmName }, openid);
+    const correct = Math.floor(selectedIndex) === quizConfig.answerIndex;
+    if (correct && !record.quizRewarded) {
+      record.quizRewarded = true;
+      record.remainingSpins = Math.max(0, (record.remainingSpins || 0) + 1);
+    }
+    record.updatedAt = now;
+    await ref.update({ data: record });
+    finalSession = record;
+  });
+  return buildBargainPayload(config, { ...finalSession, stockRemaining: stockState.stockRemaining }, {
+    activityDoc,
+    stockRemaining: stockState.stockRemaining,
+    totalStock: stockState.totalStock,
+    quizReward: {
+      enabled: true,
+      question: quizConfig.question,
+      options: quizConfig.options,
+      rewarded: Boolean(finalSession && finalSession.quizRewarded)
+    },
+    quizResult: {
+      correct: Math.floor(selectedIndex) === quizConfig.answerIndex,
+      rewarded: Boolean(finalSession && finalSession.quizRewarded)
+    }
   });
 }
 

--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -9475,6 +9475,14 @@ function normalizeBargainSettings(settings = {}, activityType = 'standard') {
     typeof source.activityTag1Enabled === 'boolean' ? source.activityTag1Enabled : source.activityTag1Enabled !== 'false';
   const activityTag2Enabled =
     typeof source.activityTag2Enabled === 'boolean' ? source.activityTag2Enabled : source.activityTag2Enabled !== 'false';
+  const sourceQuizReward = source.quizReward && typeof source.quizReward === 'object' ? source.quizReward : {};
+  const quizRewardEnabled =
+    typeof sourceQuizReward.enabled === 'boolean' ? sourceQuizReward.enabled : sourceQuizReward.enabled === 'true';
+  const quizQuestion = trimToString(sourceQuizReward.question);
+  const quizOptions = Array.isArray(sourceQuizReward.options)
+    ? sourceQuizReward.options.map((item) => trimToString(item)).filter(Boolean).slice(0, 6)
+    : [];
+  const quizAnswerIndex = Number(sourceQuizReward.answerIndex);
   const value = {
     startPrice: Number.isFinite(startPrice) ? Math.max(0, Math.floor(startPrice)) : 1500,
     floorPrice: Number.isFinite(floorPrice) ? Math.max(0, Math.floor(floorPrice)) : 998,
@@ -9491,6 +9499,12 @@ function normalizeBargainSettings(settings = {}, activityType = 'standard') {
     activityTag1Enabled,
     activityTag2,
     activityTag2Enabled,
+    quizReward: {
+      enabled: quizRewardEnabled,
+      question: quizQuestion,
+      options: quizOptions,
+      answerIndex: Number.isFinite(quizAnswerIndex) ? Math.floor(quizAnswerIndex) : 0
+    },
     ticketingMode: 'paid-ticket'
   };
   const defaultItems = [
@@ -9518,6 +9532,23 @@ function normalizeBargainSettings(settings = {}, activityType = 'standard') {
   }
   if (value.floorPrice > value.startPrice) {
     value.floorPrice = value.startPrice;
+  }
+  if (value.quizReward.enabled) {
+    if (!value.quizReward.question) {
+      throw new Error('答题奖励题目不能为空');
+    }
+    if (!Array.isArray(value.quizReward.options) || value.quizReward.options.length < 2) {
+      throw new Error('答题奖励选项至少2个');
+    }
+    if (
+      !Number.isInteger(value.quizReward.answerIndex) ||
+      value.quizReward.answerIndex < 0 ||
+      value.quizReward.answerIndex >= value.quizReward.options.length
+    ) {
+      throw new Error('答题奖励答案配置无效');
+    }
+  } else {
+    value.quizReward = { enabled: false, question: '', options: [], answerIndex: 0 };
   }
   return value;
 }

--- a/docs/bargain-quiz-reward-design.md
+++ b/docs/bargain-quiz-reward-design.md
@@ -1,0 +1,52 @@
+# 砍价活动答题奖励（+1 次砍价）设计、实现与部署说明
+
+## 目标
+- 前台在 `bhk-price-card__perk` 最下方新增“答题增加砍价次数”入口。
+- 后台可配置开关、题目、选项、答案（单选题）。
+- 答对后奖励 1 次砍价，且同一用户同一活动仅能领取一次；答错可重复作答。
+
+## 数据结构（activity.bargainSettings）
+新增：
+```json
+"quizReward": {
+  "enabled": true,
+  "question": "BHK56 品鉴会主打哪一类体验？",
+  "options": ["雪茄品鉴", "高尔夫", "马术"],
+  "answerIndex": 0
+}
+```
+
+## 前台交互
+1. 当 `quizReward.enabled=true` 且配置合法时，`bhk-price-card__perks` 末尾显示答题奖励项。
+2. 点击后弹出选项面板。
+3. 选择答案后调用 `bargainAnswerQuiz`：
+   - 正确且未奖励：`remainingSpins +1`，提示“回答正确，已+1次砍价”。
+   - 正确但已奖励：不重复奖励。
+   - 错误：提示“回答错误，可重试”，不封禁重复答题。
+
+## 后端规则
+- 新增云函数 action: `bargainAnswerQuiz`。
+- 在 `bargainStatus` 返回中附带 `quizReward`（不下发正确答案）。
+- 事务内校验并更新会话记录 `bhkBargainRecords`：
+  - 记录 `quizRewarded=true` 防重复奖励。
+
+## 管理后台
+- 砍价活动编辑表单新增：
+  - 答题奖励开关；
+  - 题目；
+  - 选项（每行一项）；
+  - 正确答案下标（从 0 开始）。
+
+## 部署步骤（详细）
+1. 云函数部署：上传并部署 `cloudfunctions/activities`（云端安装依赖）。
+2. 小程序代码上传：确保 `miniprogram/pages/activities/bhk-bargain`、`miniprogram/services/api.js`、`miniprogram/subpackages/admin/activities` 已更新。
+3. 管理后台发布：进入活动管理，编辑砍价活动并开启答题奖励，填写题目/选项/答案。
+4. 验证：
+   - 前台出现“答题奖励”行；
+   - 首次答对后砍价次数 +1；
+   - 再次答对不再增加；
+   - 答错可重复作答。
+
+## 回滚方案
+- 后台将 `quizReward.enabled` 改为 `false`，前台入口立即隐藏；
+- 如需彻底回滚代码，回退本次版本并重新部署云函数与小程序。

--- a/miniprogram/pages/activities/bhk-bargain/index.js
+++ b/miniprogram/pages/activities/bhk-bargain/index.js
@@ -362,7 +362,8 @@ Page({
     shareTimelineSupported: true,
     shareTimelineMessage: '',
     singlePageMode: false,
-    bannerSubtitle: ''
+    bannerSubtitle: '',
+    quizReward: { enabled: false, question: '', options: [], rewarded: false }
   },
 
   onLoad(options = {}) {
@@ -524,11 +525,38 @@ Page({
       infoSectionItems: toMultilineItems(bargain.infoSectionContent),
       mapLocation,
       shareContext,
+      quizReward: extras.quizReward || this.data.quizReward,
       memberId: session.memberId || this.data.memberId,
       ticketOwned,
       bannerSubtitle: buildBannerSubtitle(bargain, stockRemaining)
     });
     this.startCountdown();
+  },
+
+
+  async handleQuizRewardTap() {
+    const quizReward = this.data.quizReward || {};
+    if (!quizReward.enabled) { return; }
+    if (quizReward.rewarded) { wx.showToast({ title: '答题奖励已领取', icon: 'none' }); return; }
+    const options = Array.isArray(quizReward.options) ? quizReward.options : [];
+    if (options.length < 2) { wx.showToast({ title: '题目配置异常', icon: 'none' }); return; }
+    wx.showActionSheet({
+      itemList: options,
+      success: async (res) => {
+        wx.showLoading({ title: '提交中...', mask: true });
+        try {
+          const response = await ActivityService.bargainAnswerQuiz(this.activityId, Number(res.tapIndex));
+          const activity = response && response.activity ? response.activity : this.data.activity;
+          const bargain = normalizeBargainConfig(response && response.bargainConfig);
+          const session = this.normalizeSession(response && response.session, bargain);
+          this.applySession(session, bargain, activity, { quizReward: response && response.quizReward, shareContext: response && response.shareContext });
+          const correct = Boolean(response && response.quizResult && response.quizResult.correct);
+          wx.showToast({ title: correct ? '回答正确，已+1次砍价' : '回答错误，可重试', icon: 'none' });
+        } catch (error) {
+          wx.showToast({ title: (error && (error.errMsg || error.message)) || '答题失败', icon: 'none' });
+        } finally { wx.hideLoading(); }
+      }
+    });
   },
 
   handlePlayHeroVideo() {
@@ -741,6 +769,7 @@ Page({
       const session = this.normalizeSession(response && response.session, bargain);
       this.applySession(session, bargain, activity, {
         shareContext: response && response.shareContext,
+        quizReward: response && response.quizReward,
         ticketOwned: this.data.ticketOwned,
         stockRemaining: this.data.stockRemaining
       });
@@ -911,6 +940,7 @@ Page({
       const session = this.normalizeSession(response && response.session, bargain);
       this.applySession(session, bargain, activity, {
         shareContext: response && response.shareContext,
+        quizReward: response && response.quizReward,
         ticketOwned: this.data.ticketOwned,
         stockRemaining: this.data.stockRemaining
       });

--- a/miniprogram/pages/activities/bhk-bargain/index.wxml
+++ b/miniprogram/pages/activities/bhk-bargain/index.wxml
@@ -136,6 +136,9 @@
       </view>
       <view class="bhk-price-card__perks" wx:if="{{perks.length}}">
         <view class="bhk-price-card__perk" wx:for="{{perks}}" wx:key="perk">{{item}}</view>
+        <view wx:if="{{quizReward.enabled}}" class="bhk-price-card__perk" bindtap="handleQuizRewardTap">
+          {{quizReward.rewarded ? '答题奖励：已获得1次砍价次数' : '答题奖励：答对1题可+1次砍价（点击答题）'}}
+        </view>
       </view>
     </view>
 

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -955,6 +955,13 @@ export const AdminService = {
       pageSize
     });
   },
+  async bargainAnswerQuiz(id, selectedIndex) {
+    return callFunction({
+      action: 'bargainAnswerQuiz',
+      id,
+      selectedIndex
+    });
+  },
   async getMemberDetail(memberId, options = {}) {
     const payload = {
       action: 'getMemberDetail',

--- a/miniprogram/subpackages/admin/activities/index.js
+++ b/miniprogram/subpackages/admin/activities/index.js
@@ -213,6 +213,10 @@ function buildEditorForm(activity) {
       activityTag1Enabled: 'true',
       activityTag2: '',
       activityTag2Enabled: 'true',
+      quizRewardEnabled: 'false',
+      quizQuestion: '',
+      quizOptionsText: '',
+      quizAnswerIndex: '0',
       sortOrder: '0'
     };
   }
@@ -295,6 +299,22 @@ function buildEditorForm(activity) {
       activity.bargainSettings && typeof activity.bargainSettings.activityTag2Enabled === 'boolean'
         ? `${activity.bargainSettings.activityTag2Enabled}`
         : 'true',
+    quizRewardEnabled:
+      activity.bargainSettings && activity.bargainSettings.quizReward && typeof activity.bargainSettings.quizReward.enabled === 'boolean'
+        ? `${activity.bargainSettings.quizReward.enabled}`
+        : 'false',
+    quizQuestion:
+      activity.bargainSettings && activity.bargainSettings.quizReward && typeof activity.bargainSettings.quizReward.question === 'string'
+        ? activity.bargainSettings.quizReward.question
+        : '',
+    quizOptionsText:
+      activity.bargainSettings && activity.bargainSettings.quizReward && Array.isArray(activity.bargainSettings.quizReward.options)
+        ? activity.bargainSettings.quizReward.options.join('\n')
+        : '',
+    quizAnswerIndex:
+      activity.bargainSettings && activity.bargainSettings.quizReward && Number.isFinite(activity.bargainSettings.quizReward.answerIndex)
+        ? `${activity.bargainSettings.quizReward.answerIndex}`
+        : '0',
     sortOrder: `${Number(activity.sortOrder || 0)}`
   };
 }
@@ -564,7 +584,13 @@ Page({
         activityTag1: (form.activityTag1 || '').trim(),
         activityTag1Enabled: `${form.activityTag1Enabled}` !== 'false',
         activityTag2: (form.activityTag2 || '').trim(),
-        activityTag2Enabled: `${form.activityTag2Enabled}` !== 'false'
+        activityTag2Enabled: `${form.activityTag2Enabled}` !== 'false',
+        quizReward: {
+          enabled: `${form.quizRewardEnabled}` !== 'false',
+          question: (form.quizQuestion || '').trim(),
+          options: (form.quizOptionsText || '').split('\n').map((i) => i.trim()).filter(Boolean),
+          answerIndex: Number(form.quizAnswerIndex || 0)
+        }
       };
     } else {
       payload.bargainSettings = null;

--- a/miniprogram/subpackages/admin/activities/index.js
+++ b/miniprogram/subpackages/admin/activities/index.js
@@ -506,6 +506,12 @@ Page({
       'editorForm.activityTag2Enabled': index === 1 ? 'false' : 'true'
     });
   },
+  handleQuizRewardEnabledChange(event) {
+    const index = Number(event.detail.value);
+    this.setData({
+      'editorForm.quizRewardEnabled': index === 1 ? 'false' : 'true'
+    });
+  },
 
   handleEditorTimeChange(event) {
     const { field } = event.currentTarget.dataset || {};
@@ -592,6 +598,21 @@ Page({
           answerIndex: Number(form.quizAnswerIndex || 0)
         }
       };
+      if (payload.bargainSettings.quizReward.enabled) {
+        const { question, options, answerIndex } = payload.bargainSettings.quizReward;
+        if (!question) {
+          wx.showToast({ title: '请输入答题题目', icon: 'none' });
+          return;
+        }
+        if (!Array.isArray(options) || options.length < 2) {
+          wx.showToast({ title: '答题选项至少2个', icon: 'none' });
+          return;
+        }
+        if (!Number.isInteger(answerIndex) || answerIndex < 0 || answerIndex >= options.length) {
+          wx.showToast({ title: '正确答案下标不合法', icon: 'none' });
+          return;
+        }
+      }
     } else {
       payload.bargainSettings = null;
     }

--- a/miniprogram/subpackages/admin/activities/index.wxml
+++ b/miniprogram/subpackages/admin/activities/index.wxml
@@ -328,7 +328,7 @@
       </view>
       <view wx:if="{{editorForm.activityType === 'bargain'}}" class="form-row">
         <text class="form-label">答题奖励开关</text>
-        <picker mode="selector" range="{{['开启','关闭']}}" value="{{editorForm.quizRewardEnabled === 'false' ? 1 : 0}}" data-field="quizRewardEnabled" bindchange="handleEditorInput">
+        <picker mode="selector" range="{{['开启','关闭']}}" value="{{editorForm.quizRewardEnabled === 'false' ? 1 : 0}}" bindchange="handleQuizRewardEnabledChange">
           <view class="picker-value">{{editorForm.quizRewardEnabled === 'false' ? '关闭' : '开启'}}</view>
         </picker>
       </view>

--- a/miniprogram/subpackages/admin/activities/index.wxml
+++ b/miniprogram/subpackages/admin/activities/index.wxml
@@ -326,6 +326,24 @@
           </view>
         </view>
       </view>
+      <view wx:if="{{editorForm.activityType === 'bargain'}}" class="form-row">
+        <text class="form-label">答题奖励开关</text>
+        <picker mode="selector" range="{{['开启','关闭']}}" value="{{editorForm.quizRewardEnabled === 'false' ? 1 : 0}}" data-field="quizRewardEnabled" bindchange="handleEditorInput">
+          <view class="picker-value">{{editorForm.quizRewardEnabled === 'false' ? '关闭' : '开启'}}</view>
+        </picker>
+      </view>
+      <view wx:if="{{editorForm.activityType === 'bargain' && editorForm.quizRewardEnabled !== 'false'}}" class="form-row form-row--full">
+        <text class="form-label">题目</text>
+        <input class="form-input" value="{{editorForm.quizQuestion}}" data-field="quizQuestion" bindinput="handleEditorInput" placeholder="请输入选择题题干" />
+      </view>
+      <view wx:if="{{editorForm.activityType === 'bargain' && editorForm.quizRewardEnabled !== 'false'}}" class="form-row form-row--full">
+        <text class="form-label">选项（每行一个）</text>
+        <textarea class="form-textarea" value="{{editorForm.quizOptionsText}}" data-field="quizOptionsText" bindinput="handleEditorInput" placeholder="A选项\nB选项\nC选项"></textarea>
+      </view>
+      <view wx:if="{{editorForm.activityType === 'bargain' && editorForm.quizRewardEnabled !== 'false'}}" class="form-row">
+        <text class="form-label">正确答案下标（从0开始）</text>
+        <input class="form-input" type="number" value="{{editorForm.quizAnswerIndex}}" data-field="quizAnswerIndex" bindinput="handleEditorInput" />
+      </view>
       <view class="form-row">
         <text class="form-label">发布状态</text>
         <picker


### PR DESCRIPTION
### Motivation

- Provide an optional quiz-based reward that grants users +1 bargain attempt when they answer a configured single-choice question correctly. 
- Allow operations to control the feature from the activity admin UI so question/options/answer and enable/disable are editable per-activity. 
- Prevent duplicate rewards for the same user while allowing retry on incorrect answers.

### Description

- Added cloud function flow: introduced `normalizeQuizConfig` and new action `bargainAnswerQuiz` in `cloudfunctions/activities/index.js` which validates config, checks answers in a transaction, sets `quizRewarded` on the user session, and grants `remainingSpins +1` only once on first correct answer. 
- Surface quiz state in status API: `getBhkBargainStatus` now includes a `quizReward` block (without leaking the correct answer) so frontend can show/hide the perk row. 
- Frontend wire-up: added `ActivityService.bargainAnswerQuiz` in `miniprogram/services/api.js`, a visible perk item in `miniprogram/pages/activities/bhk-bargain/index.wxml`, and client handler `handleQuizRewardTap` + state binding in `miniprogram/pages/activities/bhk-bargain/index.js` to present options and submit answers. 
- Admin UI changes: extended `miniprogram/subpackages/admin/activities` (JS and WXML) to configure `bargainSettings.quizReward` with `enabled`, `question`, `options`, and `answerIndex` and persist into activity payload. 
- Documentation: added `docs/bargain-quiz-reward-design.md` describing data model, interaction, backend rules, deployment steps and rollback procedure.

### Testing

- Ran the bargain unit tests with `npm test -- __tests__/activities/bargain.test.js`, and all test cases in that suite passed. 
- Note: the `npm test` process returned non-zero due to repository-wide coverage thresholds (existing global thresholds), but the modified bargain-related tests themselves succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11f8812c40832c9b3f81386f8221dc)