### PR TITLE
fix(bargain): accept global coordinates for activity map popup

### DIFF
--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -9361,6 +9361,14 @@ function normalizeActivityPayload(input = {}, options = {}) {
   if (has('location')) {
     result.location = trimToString(input.location);
   }
+  if (has('locationLat')) {
+    const lat = Number(input.locationLat);
+    result.locationLat = Number.isFinite(lat) ? lat : null;
+  }
+  if (has('locationLng')) {
+    const lng = Number(input.locationLng);
+    result.locationLng = Number.isFinite(lng) ? lng : null;
+  }
 
   if (has('coverImage')) {
     result.coverImage = trimToString(input.coverImage);

--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -9585,6 +9585,8 @@ function decorateActivityRecord(doc = {}) {
     endTime: toIsoString(doc.endTime),
     priceLabel: trimToString(doc.priceLabel),
     location: trimToString(doc.location),
+    locationLat: Number.isFinite(Number(doc.locationLat)) ? Number(doc.locationLat) : null,
+    locationLng: Number.isFinite(Number(doc.locationLng)) ? Number(doc.locationLng) : null,
     coverImage: trimToString(doc.coverImage),
     highlight: trimToString(doc.highlight),
     notes: normalizeMultilineString(doc.notes),

--- a/miniprogram/pages/activities/bhk-bargain/index.js
+++ b/miniprogram/pages/activities/bhk-bargain/index.js
@@ -435,15 +435,10 @@ Page({
     const hasValidCoords =
       Number.isFinite(latitude) &&
       Number.isFinite(longitude) &&
-      longitude > 115 &&
-      longitude < 118 &&
-      latitude > 39 &&
-      latitude < 41;
-    const isLegacyShanghai = /上海|长宁/.test(`${address}${name}`);
-
-    if (isLegacyShanghai) {
-      return DEFAULT_LOCATION;
-    }
+      longitude >= -180 &&
+      longitude <= 180 &&
+      latitude >= -90 &&
+      latitude <= 90;
 
     if (hasValidCoords) {
       return { name: name || DEFAULT_LOCATION.name, address: address || DEFAULT_LOCATION.address, latitude, longitude };

--- a/miniprogram/subpackages/admin/activities/index.js
+++ b/miniprogram/subpackages/admin/activities/index.js
@@ -146,6 +146,8 @@ function decorateActivity(activity) {
     timeRangeLabel,
     priceLabel: activity.priceLabel || '',
     location: activity.location || '',
+    locationLat: Number.isFinite(activity.locationLat) ? activity.locationLat : null,
+    locationLng: Number.isFinite(activity.locationLng) ? activity.locationLng : null,
     highlight: activity.highlight || '',
     notes: activity.notes || '',
     perks,
@@ -195,6 +197,8 @@ function buildEditorForm(activity) {
       endTime: '23:59',
       priceLabel: '',
       location: '',
+      locationLat: '',
+      locationLng: '',
       highlight: '',
       perksText: '',
       notes: '',
@@ -237,6 +241,8 @@ function buildEditorForm(activity) {
     endTime: formatTimePart(activity.endTime),
     priceLabel: activity.priceLabel || '',
     location: activity.location || '',
+    locationLat: Number.isFinite(activity.locationLat) ? `${activity.locationLat}` : '',
+    locationLng: Number.isFinite(activity.locationLng) ? `${activity.locationLng}` : '',
     highlight: activity.highlight || '',
     perksText: Array.isArray(activity.perks) ? activity.perks.join('\n') : '',
     notes: activity.notes || '',
@@ -583,6 +589,8 @@ Page({
       endTime: combineDateTime(form.endDate, form.endTime),
       priceLabel: form.priceLabel.trim(),
       location: form.location.trim(),
+      locationLat: form.locationLat === '' ? null : Number(form.locationLat),
+      locationLng: form.locationLng === '' ? null : Number(form.locationLng),
       highlight: form.highlight.trim(),
       notes: form.notes,
       coverImage: form.coverImage.trim(),
@@ -658,6 +666,12 @@ Page({
         payload[key] = null;
       }
     });
+    if (!Number.isFinite(payload.locationLat)) {
+      payload.locationLat = null;
+    }
+    if (!Number.isFinite(payload.locationLng)) {
+      payload.locationLng = null;
+    }
 
     this.setData({ editorSaving: true });
     try {

--- a/miniprogram/subpackages/admin/activities/index.wxml
+++ b/miniprogram/subpackages/admin/activities/index.wxml
@@ -148,6 +148,16 @@
           bindinput="handleEditorInput"
         />
       </view>
+      <view class="form-row form-row--split">
+        <view class="form-item">
+          <text class="form-label">纬度</text>
+          <input class="form-input" placeholder="如 39.8943" value="{{editorForm.locationLat}}" data-field="locationLat" bindinput="handleEditorInput" />
+        </view>
+        <view class="form-item">
+          <text class="form-label">经度</text>
+          <input class="form-input" placeholder="如 116.5146" value="{{editorForm.locationLng}}" data-field="locationLng" bindinput="handleEditorInput" />
+        </view>
+      </view>
       <view class="form-row">
         <text class="form-label">亮点</text>
         <input


### PR DESCRIPTION
### Motivation
- The bargain activity page opened incorrect map positions because `normalizeMapLocation` previously restricted valid coordinates to a small city range and applied a legacy address fallback, causing valid backend-provided locations to be ignored.

### Description
- Update `normalizeMapLocation` in `miniprogram/pages/activities/bhk-bargain/index.js` to accept any valid latitude/longitude within global ranges (`latitude: -90..90`, `longitude: -180..180`) and remove the legacy city-keyword forced fallback, while still falling back to `DEFAULT_LOCATION` when coordinates are missing or invalid.

### Testing
- Ran `npm test -- --runInBand`; the overall suite fails due to unrelated `guild` test/coverage issues, while the bargain-specific test `__tests__/activities/bargain.test.js` passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a121af5e64c832c921ffc0f1b4ccdfa)