### PR TITLE
feat(admin): 砍价活动管理列表与独立监控页（按活动隔离数据）

### DIFF
--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -85,9 +85,10 @@ const DEFAULT_FEATURE_TOGGLES = {
   equipmentEnhancement: { ...DEFAULT_EQUIPMENT_ENHANCEMENT }
 };
 const THANKSGIVING_ACTIVITY_ID = '479859146924a70404e4f40e1530f51d';
+const DEFAULT_BARGAIN_RIGHT_ID = 'thanksgiving-pass';
 const BHK_BARGAIN_COLLECTION = 'bhkBargainRecords';
 const BHK_BARGAIN_STOCK_COLLECTION = 'bhkBargainStock';
-const THANKSGIVING_RIGHT_ID = 'thanksgiving-pass';
+const THANKSGIVING_RIGHT_ID = DEFAULT_BARGAIN_RIGHT_ID;
 const THANKSGIVING_DASHBOARD_LIMIT = 50;
 const DRINK_VOUCHER_RIGHT_ID = 'right_realm_qi_drink';
 const CUBANEY_VOUCHER_RIGHT_ID = 'right_realm_core_cubaney_voucher';
@@ -2950,10 +2951,13 @@ async function getThanksgivingDashboard(openid, options = {}) {
     ? Math.max(5, Math.min(THANKSGIVING_DASHBOARD_LIMIT, Math.floor(limitInput)))
     : THANKSGIVING_DASHBOARD_LIMIT;
 
-  const stockRef = db.collection(BHK_BARGAIN_STOCK_COLLECTION).doc(THANKSGIVING_ACTIVITY_ID);
+  const activityId = normalizeMemberIdValue(options.activityId) || THANKSGIVING_ACTIVITY_ID;
+  const rightId = typeof options.rightId === 'string' && options.rightId.trim() ? options.rightId.trim() : DEFAULT_BARGAIN_RIGHT_ID;
+
+  const stockRef = db.collection(BHK_BARGAIN_STOCK_COLLECTION).doc(activityId);
   const purchasedQuery = db
     .collection(BHK_BARGAIN_COLLECTION)
-    .where({ activityId: THANKSGIVING_ACTIVITY_ID, ticketOwned: true });
+    .where({ activityId, ticketOwned: true });
 
   const [stockSnapshot, orderCountResult, orderSnapshot, masterRightsMap] = await Promise.all([
     stockRef.get().catch(() => null),
@@ -2987,7 +2991,7 @@ async function getThanksgivingDashboard(openid, options = {}) {
   const rightsSnapshot = memberIds.length
     ? await db
         .collection(COLLECTIONS.MEMBER_RIGHTS)
-        .where({ memberId: _.in(memberIds), rightId: THANKSGIVING_RIGHT_ID })
+        .where({ memberId: _.in(memberIds), rightId })
         .get()
         .catch(() => ({ data: [] }))
     : { data: [] };
@@ -3041,7 +3045,7 @@ async function getThanksgivingDashboard(openid, options = {}) {
       purchasedAtLabel: formatDateTimeLabel(purchaseTime),
       rightStatus: rightEntry ? rightEntry.status : 'pending',
       rightStatusLabel: rightEntry ? rightEntry.statusLabel : '未发放',
-      rightId: rightEntry ? rightEntry.rightId : THANKSGIVING_RIGHT_ID,
+      rightId: rightEntry ? rightEntry.rightId : rightId,
       ticketOwned: Boolean(record.ticketOwned || record.purchased)
     };
   });

--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -67,6 +67,7 @@
         "finance-report/index",
         "data-cleanup/index",
         "thanksgiving/index",
+        "thanksgiving-dashboard/index",
         "system-switches/index"
       ]
     }

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -1411,6 +1411,9 @@ export const AdminService = {
     if (options && Number.isFinite(options.limit)) {
       payload.limit = options.limit;
     }
+    if (options && typeof options.activityId === 'string' && options.activityId.trim()) {
+      payload.activityId = options.activityId.trim();
+    }
     return callCloud(CLOUD_FUNCTIONS.ADMIN, payload);
   }
 };

--- a/miniprogram/subpackages/admin/index.js
+++ b/miniprogram/subpackages/admin/index.js
@@ -33,8 +33,8 @@ const BASE_ACTIONS = [
   },
   {
     icon: '🦃',
-    label: '感恩节活动管理',
-    description: '查看感恩节下单、库存与权益',
+    label: '砍价活动管理',
+    description: '查看砍价活动下单、库存与权益',
     url: '/subpackages/admin/thanksgiving/index'
   },
   {

--- a/miniprogram/subpackages/admin/thanksgiving-dashboard/index.js
+++ b/miniprogram/subpackages/admin/thanksgiving-dashboard/index.js
@@ -10,8 +10,9 @@ function buildRightsSummary(breakdown = []) {
 
 function normalizeOrders(orders = []) {
   if (!Array.isArray(orders)) return [];
-  return orders.map((item) => ({
+  return orders.map((item, index) => ({
     ...item,
+    orderKey: item.orderId || item.memberId || `order-${index}`,
     displayName: item.displayName || '未命名会员',
     amountLabel: item.amountLabel || '¥0.00',
     purchasedAtLabel: item.purchasedAtLabel || formatDateTime(item.purchasedAt) || '—',

--- a/miniprogram/subpackages/admin/thanksgiving-dashboard/index.js
+++ b/miniprogram/subpackages/admin/thanksgiving-dashboard/index.js
@@ -1,0 +1,74 @@
+import { AdminService } from '../../../services/api';
+import { formatDateTime } from '../../../utils/format';
+
+function buildRightsSummary(breakdown = []) {
+  return breakdown
+    .filter((item) => item && Number(item.count) > 0)
+    .map((item) => `${item.label} ${item.count}`)
+    .join(' / ');
+}
+
+function normalizeOrders(orders = []) {
+  if (!Array.isArray(orders)) return [];
+  return orders.map((item) => ({
+    ...item,
+    displayName: item.displayName || '未命名会员',
+    amountLabel: item.amountLabel || '¥0.00',
+    purchasedAtLabel: item.purchasedAtLabel || formatDateTime(item.purchasedAt) || '—',
+    rightStatusLabel: item.rightStatusLabel || '未发放'
+  }));
+}
+
+Page({
+  data: {
+    loading: true,
+    error: '',
+    activityId: '',
+    title: '砍价活动',
+    summary: { orderCount: 0, orderLimit: 0, stockRemaining: 0, totalStock: 0, sold: 0, rightsTotal: 0, rightsSummary: '', rightsBreakdown: [], updatedAtLabel: '' },
+    orders: []
+  },
+  onLoad(query = {}) {
+    const activityId = query.activityId || '';
+    const title = query.title ? decodeURIComponent(query.title) : '砍价活动';
+    this.setData({ activityId, title });
+    this.loadDashboard();
+  },
+  async loadDashboard() {
+    const { activityId } = this.data;
+    if (!activityId) {
+      this.setData({ loading: false, error: '缺少活动编号' });
+      return;
+    }
+    this.setData({ loading: true, error: '' });
+    try {
+      const dashboard = await AdminService.getThanksgivingDashboard({ activityId });
+      const summary = this.normalizeDashboard(dashboard || {});
+      this.setData({ loading: false, summary, orders: normalizeOrders(summary.orders) });
+    } catch (error) {
+      console.error('[admin/bargain-dashboard] load failed', error);
+      this.setData({ loading: false, error: (error && error.errMsg) || error.message || '加载失败，请稍后重试' });
+    }
+  },
+  handleRefresh() {
+    if (this.data.loading) return;
+    this.loadDashboard();
+  },
+  normalizeDashboard(payload = {}) {
+    const breakdown = (payload.rights && payload.rights.breakdown) || [];
+    const stock = payload.stock || {};
+    const orders = Array.isArray(payload.orders) ? payload.orders : [];
+    return {
+      orderCount: Number(payload.orderCount || 0),
+      orderLimit: Number(payload.orderLimit || orders.length || 0),
+      stockRemaining: Number.isFinite(stock.stockRemaining) ? stock.stockRemaining : 0,
+      totalStock: Number.isFinite(stock.totalStock) ? stock.totalStock : 0,
+      sold: Number.isFinite(stock.sold) ? stock.sold : 0,
+      rightsTotal: (payload.rights && Number(payload.rights.total)) || 0,
+      rightsSummary: buildRightsSummary(breakdown),
+      rightsBreakdown: breakdown,
+      updatedAtLabel: payload.updatedAtLabel || formatDateTime(payload.updatedAt),
+      orders
+    };
+  }
+});

--- a/miniprogram/subpackages/admin/thanksgiving-dashboard/index.json
+++ b/miniprogram/subpackages/admin/thanksgiving-dashboard/index.json
@@ -1,5 +1,5 @@
 {
-  "navigationBarTitleText": "砍价活动管理",
+  "navigationBarTitleText": "砍价活动监控",
   "usingComponents": {
     "custom-nav": "/components/custom-nav/custom-nav",
     "custom-nav-placeholder": "/components/custom-nav-placeholder/custom-nav-placeholder"

--- a/miniprogram/subpackages/admin/thanksgiving-dashboard/index.wxml
+++ b/miniprogram/subpackages/admin/thanksgiving-dashboard/index.wxml
@@ -1,0 +1,63 @@
+<custom-nav title="砍价活动管理" theme="dark"></custom-nav>
+<view class="page">
+  <view class="hero">
+    <view class="hero-text">
+      <view class="hero-title">{{title}} 活动监控</view>
+      <view class="hero-subtitle">实时查看下单数、库存与权益发放状态</view>
+      <view wx:if="{{summary.updatedAtLabel}}" class="hero-updated">更新于 {{summary.updatedAtLabel}}</view>
+    </view>
+    <button class="refresh-btn" bindtap="handleRefresh" loading="{{loading}}">{{loading ? '刷新中…' : '刷新数据'}}</button>
+  </view>
+
+  <view class="summary-grid">
+    <view class="summary-card">
+      <view class="summary-label">实时下单数</view>
+      <view class="summary-value">{{summary.orderCount || 0}}</view>
+      <view class="summary-desc">展示最近 {{summary.orderLimit || 0}} 笔下单明细</view>
+    </view>
+    <view class="summary-card">
+      <view class="summary-label">库存</view>
+      <view class="summary-value">{{summary.stockRemaining}} / {{summary.totalStock}}</view>
+      <view class="summary-desc">已售 {{summary.sold}}</view>
+    </view>
+    <view class="summary-card">
+      <view class="summary-label">权益使用</view>
+      <view class="summary-value">{{summary.rightsTotal}}</view>
+      <view class="summary-desc">{{summary.rightsSummary || '未发放'}}</view>
+    </view>
+  </view>
+
+  <view class="section">
+    <view class="section-title">权益使用状态</view>
+    <view wx:if="{{summary.rightsBreakdown.length}}" class="pill-row">
+      <view wx:for="{{summary.rightsBreakdown}}" wx:key="status" class="pill">
+        <text class="pill-count">{{item.count}}</text>
+        <text class="pill-label">{{item.label}}</text>
+      </view>
+    </view>
+    <view wx:else class="empty-text">暂未发放活动权益</view>
+  </view>
+
+  <view class="section">
+    <view class="section-title">实时下单明细</view>
+    <view wx:if="{{orders.length}}" class="order-list">
+      <view wx:for="{{orders}}" wx:key="{{item.orderId || item.memberId || index}}" class="order-card">
+        <view class="order-header">
+          <view class="order-member">{{item.displayName}}</view>
+          <view class="order-amount">{{item.amountLabel || '¥0.00'}}</view>
+        </view>
+        <view class="order-meta">会员 ID：{{item.memberId}}</view>
+        <view wx:if="{{item.mobile}}" class="order-meta">手机号：{{item.mobile}}</view>
+        <view class="order-meta">下单时间：{{item.purchasedAtLabel || '—'}}</view>
+        <view class="order-meta">订单号：{{item.orderId || '待补全'}}</view>
+        <view class="order-tags">
+          <view class="tag solid">权益：{{item.rightStatusLabel}}</view>
+          <view class="tag" wx:if="{{item.ticketOwned}}">已落地购票</view>
+        </view>
+      </view>
+    </view>
+    <view wx:else class="empty-text">暂无购票记录，等待新的实时订单。</view>
+  </view>
+
+  <view wx:if="{{error}}" class="error-banner">{{error}}</view>
+</view>

--- a/miniprogram/subpackages/admin/thanksgiving-dashboard/index.wxml
+++ b/miniprogram/subpackages/admin/thanksgiving-dashboard/index.wxml
@@ -41,7 +41,7 @@
   <view class="section">
     <view class="section-title">实时下单明细</view>
     <view wx:if="{{orders.length}}" class="order-list">
-      <view wx:for="{{orders}}" wx:key="{{item.orderId || item.memberId || index}}" class="order-card">
+      <view wx:for="{{orders}}" wx:key="orderKey" class="order-card">
         <view class="order-header">
           <view class="order-member">{{item.displayName}}</view>
           <view class="order-amount">{{item.amountLabel || '¥0.00'}}</view>

--- a/miniprogram/subpackages/admin/thanksgiving-dashboard/index.wxss
+++ b/miniprogram/subpackages/admin/thanksgiving-dashboard/index.wxss
@@ -1,0 +1,192 @@
+.page {
+  padding: 24rpx;
+  background: #0b0c10;
+  min-height: 100vh;
+  color: #f5f7fb;
+}
+
+.hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24rpx;
+  margin-bottom: 24rpx;
+  border-radius: 16rpx;
+  background: linear-gradient(135deg, #1f2833, #0b1d2c);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.hero-text {
+  display: flex;
+  flex-direction: column;
+  gap: 8rpx;
+}
+
+.hero-title {
+  font-size: 34rpx;
+  font-weight: 700;
+}
+
+.hero-subtitle {
+  font-size: 26rpx;
+  color: #9fb3c8;
+}
+
+.hero-updated {
+  font-size: 22rpx;
+  color: #7fd1de;
+}
+
+.refresh-btn {
+  background: #7fd1de;
+  color: #0b0c10;
+  font-weight: 600;
+  border-radius: 12rpx;
+  padding: 12rpx 24rpx;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16rpx;
+  margin-bottom: 24rpx;
+}
+
+.summary-card {
+  background: #121821;
+  padding: 20rpx;
+  border-radius: 16rpx;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.summary-label {
+  font-size: 24rpx;
+  color: #9fb3c8;
+}
+
+.summary-value {
+  margin-top: 8rpx;
+  font-size: 40rpx;
+  font-weight: 700;
+}
+
+.summary-desc {
+  margin-top: 6rpx;
+  font-size: 22rpx;
+  color: #9fb3c8;
+}
+
+.section {
+  background: #121821;
+  border-radius: 16rpx;
+  padding: 20rpx;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  margin-bottom: 24rpx;
+}
+
+.section-title {
+  font-size: 28rpx;
+  font-weight: 700;
+  margin-bottom: 12rpx;
+}
+
+.pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12rpx;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8rpx;
+  padding: 10rpx 14rpx;
+  border-radius: 999rpx;
+  background: rgba(127, 209, 222, 0.12);
+  color: #7fd1de;
+}
+
+.pill-count {
+  font-weight: 700;
+}
+
+.pill-label {
+  font-size: 24rpx;
+}
+
+.order-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16rpx;
+}
+
+.order-card {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12rpx;
+  padding: 16rpx;
+  background: #0f1620;
+}
+
+.order-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8rpx;
+}
+
+.order-member {
+  font-size: 28rpx;
+  font-weight: 700;
+}
+
+.order-amount {
+  font-size: 28rpx;
+  color: #ffd166;
+}
+
+.order-meta {
+  font-size: 24rpx;
+  color: #9fb3c8;
+  margin-top: 6rpx;
+}
+
+.order-tags {
+  display: flex;
+  gap: 10rpx;
+  flex-wrap: wrap;
+  margin-top: 12rpx;
+}
+
+.tag {
+  padding: 8rpx 12rpx;
+  border-radius: 10rpx;
+  background: rgba(255, 255, 255, 0.06);
+  color: #dce4f2;
+  font-size: 22rpx;
+}
+
+.tag.solid {
+  background: linear-gradient(120deg, #7fd1de, #5fb6c4);
+  color: #0b0c10;
+  font-weight: 700;
+}
+
+.empty-text {
+  font-size: 24rpx;
+  color: #9fb3c8;
+}
+
+.error-banner {
+  margin-top: 12rpx;
+  padding: 12rpx 16rpx;
+  border-radius: 12rpx;
+  background: rgba(255, 102, 102, 0.18);
+  color: #ffcdd2;
+  border: 1px solid rgba(255, 102, 102, 0.35);
+}
+
+@media (max-width: 750px) {
+  .summary-grid {
+    grid-template-columns: repeat(1, 1fr);
+  }
+}

--- a/miniprogram/subpackages/admin/thanksgiving/index.js
+++ b/miniprogram/subpackages/admin/thanksgiving/index.js
@@ -10,9 +10,14 @@ function normalizeActivities(list = []) {
       status: item.status || 'draft',
       statusLabel: item.statusLabel || '草稿',
       periodLabel: item.periodLabel || '未设置活动时间',
+      activityType: item.activityType || 'standard',
       template: item.template || '',
       summary: item.summary || ''
     }));
+}
+
+function isBargainActivity(activity = {}) {
+  return activity.activityType === 'bargain' || activity.template === 'thanksgiving-bargain' || activity.template === 'concert-bargain';
 }
 
 Page({
@@ -31,7 +36,7 @@ Page({
     try {
       const result = await AdminService.listActivities({ includeArchived: true });
       const all = normalizeActivities(result && result.activities);
-      const activities = all.filter((item) => item.template === 'thanksgiving-bargain' || item.status !== 'archived');
+      const activities = all.filter((item) => isBargainActivity(item));
       this.setData({ loading: false, activities });
     } catch (error) {
       console.error('[admin/bargain] load activities failed', error);

--- a/miniprogram/subpackages/admin/thanksgiving/index.js
+++ b/miniprogram/subpackages/admin/thanksgiving/index.js
@@ -1,88 +1,56 @@
 import { AdminService } from '../../../services/api';
-import { formatDateTime } from '../../../utils/format';
 
-function buildRightsSummary(breakdown = []) {
-  const parts = breakdown
-    .filter((item) => item && Number(item.count) > 0)
-    .map((item) => `${item.label} ${item.count}`);
-  return parts.join(' / ');
-}
-
-function normalizeOrders(orders = []) {
-  if (!Array.isArray(orders)) {
-    return [];
-  }
-  return orders.map((item) => ({
-    ...item,
-    displayName: item.displayName || '未命名会员',
-    amountLabel: item.amountLabel || '¥0.00',
-    purchasedAtLabel: item.purchasedAtLabel || formatDateTime(item.purchasedAt) || '—',
-    rightStatusLabel: item.rightStatusLabel || '未发放'
-  }));
+function normalizeActivities(list = []) {
+  if (!Array.isArray(list)) return [];
+  return list
+    .filter((item) => item && item.id)
+    .map((item) => ({
+      id: item.id,
+      title: item.title || '未命名砍价活动',
+      status: item.status || 'draft',
+      statusLabel: item.statusLabel || '草稿',
+      periodLabel: item.periodLabel || '未设置活动时间',
+      template: item.template || '',
+      summary: item.summary || ''
+    }));
 }
 
 Page({
   data: {
     loading: true,
     error: '',
-    summary: {
-      orderCount: 0,
-      orderLimit: 0,
-      stockRemaining: 0,
-      totalStock: 0,
-      sold: 0,
-      rightsTotal: 0,
-      rightsSummary: '',
-      rightsBreakdown: [],
-      updatedAtLabel: ''
-    },
-    orders: []
+    activities: []
   },
 
   onLoad() {
-    this.loadDashboard();
+    this.loadActivities();
   },
 
-  async loadDashboard() {
+  async loadActivities() {
     this.setData({ loading: true, error: '' });
     try {
-      const dashboard = await AdminService.getThanksgivingDashboard();
-      const summary = this.normalizeDashboard(dashboard || {});
-      this.setData({
-        loading: false,
-        summary,
-        orders: normalizeOrders(summary.orders)
-      });
+      const result = await AdminService.listActivities({ includeArchived: true });
+      const all = normalizeActivities(result && result.activities);
+      const activities = all.filter((item) => item.template === 'thanksgiving-bargain' || item.status !== 'archived');
+      this.setData({ loading: false, activities });
     } catch (error) {
-      console.error('[admin/thanksgiving] load dashboard failed', error);
-      this.setData({
-        loading: false,
-        error: (error && error.errMsg) || error.message || '加载失败，请稍后重试'
-      });
+      console.error('[admin/bargain] load activities failed', error);
+      this.setData({ loading: false, error: (error && error.errMsg) || error.message || '加载失败，请稍后重试' });
     }
   },
 
   handleRefresh() {
     if (this.data.loading) return;
-    this.loadDashboard();
+    this.loadActivities();
   },
 
-  normalizeDashboard(payload = {}) {
-    const breakdown = (payload.rights && payload.rights.breakdown) || [];
-    const summaryText = buildRightsSummary(breakdown);
-    const stock = payload.stock || {};
-    const orders = Array.isArray(payload.orders) ? payload.orders : [];
-    return {
-      orderCount: Number(payload.orderCount || 0),
-      orderLimit: Number(payload.orderLimit || orders.length || 0),
-      stockRemaining: Number.isFinite(stock.stockRemaining) ? stock.stockRemaining : 0,
-      totalStock: Number.isFinite(stock.totalStock) ? stock.totalStock : 0,
-      sold: Number.isFinite(stock.sold) ? stock.sold : 0,
-      rightsTotal: (payload.rights && Number(payload.rights.total)) || 0,
-      rightsSummary: summaryText,
-      rightsBreakdown: breakdown,
-      updatedAtLabel: payload.updatedAtLabel || formatDateTime(payload.updatedAt),
-      orders
-    };
+  handleActivityTap(event) {
+    const { id, title } = event.currentTarget.dataset || {};
+    if (!id) return;
+    wx.navigateTo({
+      url: `/subpackages/admin/thanksgiving-dashboard/index?activityId=${encodeURIComponent(id)}&title=${encodeURIComponent(
+        title || '砍价活动'
+      )}`
+    });
   }
 });

--- a/miniprogram/subpackages/admin/thanksgiving/index.wxml
+++ b/miniprogram/subpackages/admin/thanksgiving/index.wxml
@@ -1,62 +1,27 @@
-<custom-nav title="感恩节活动管理" theme="dark"></custom-nav>
+<custom-nav title="砍价活动管理" theme="dark"></custom-nav>
 <view class="page">
   <view class="hero">
     <view class="hero-text">
-      <view class="hero-title">BHK 感恩节活动监控</view>
-      <view class="hero-subtitle">实时查看下单数、库存与权益发放状态</view>
-      <view wx:if="{{summary.updatedAtLabel}}" class="hero-updated">更新于 {{summary.updatedAtLabel}}</view>
+      <view class="hero-title">砍价活动列表</view>
+      <view class="hero-subtitle">选择活动进入独立的活动监控页面</view>
     </view>
-    <button class="refresh-btn" bindtap="handleRefresh" loading="{{loading}}">{{loading ? '刷新中…' : '刷新数据'}}</button>
-  </view>
-
-  <view class="summary-grid">
-    <view class="summary-card">
-      <view class="summary-label">实时下单数</view>
-      <view class="summary-value">{{summary.orderCount || 0}}</view>
-      <view class="summary-desc">展示最近 {{summary.orderLimit || 0}} 笔下单明细</view>
-    </view>
-    <view class="summary-card">
-      <view class="summary-label">库存</view>
-      <view class="summary-value">{{summary.stockRemaining}} / {{summary.totalStock}}</view>
-      <view class="summary-desc">已售 {{summary.sold}}</view>
-    </view>
-    <view class="summary-card">
-      <view class="summary-label">权益使用</view>
-      <view class="summary-value">{{summary.rightsTotal}}</view>
-      <view class="summary-desc">{{summary.rightsSummary || '未发放'}}</view>
-    </view>
+    <button class="refresh-btn" bindtap="handleRefresh" loading="{{loading}}">{{loading ? '刷新中…' : '刷新列表'}}</button>
   </view>
 
   <view class="section">
-    <view class="section-title">权益使用状态</view>
-    <view wx:if="{{summary.rightsBreakdown.length}}" class="pill-row">
-      <view wx:for="{{summary.rightsBreakdown}}" wx:key="status" class="pill">
-        <text class="pill-count">{{item.count}}</text>
-        <text class="pill-label">{{item.label}}</text>
-      </view>
-    </view>
-    <view wx:else class="empty-text">暂未发放感恩节通行证权益</view>
-  </view>
-
-  <view class="section">
-    <view class="section-title">实时下单明细</view>
-    <view wx:if="{{orders.length}}" class="order-list">
-      <view wx:for="{{orders}}" wx:key="{{item.orderId || item.memberId || index}}" class="order-card">
+    <view class="section-title">活动列表</view>
+    <view wx:if="{{activities.length}}" class="order-list">
+      <view wx:for="{{activities}}" wx:key="id" class="order-card" data-id="{{item.id}}" data-title="{{item.title}}" bindtap="handleActivityTap">
         <view class="order-header">
-          <view class="order-member">{{item.displayName}}</view>
-          <view class="order-amount">{{item.amountLabel || '¥0.00'}}</view>
+          <view class="order-member">{{item.title}}</view>
+          <view class="tag solid">{{item.statusLabel}}</view>
         </view>
-        <view class="order-meta">会员 ID：{{item.memberId}}</view>
-        <view wx:if="{{item.mobile}}" class="order-meta">手机号：{{item.mobile}}</view>
-        <view class="order-meta">下单时间：{{item.purchasedAtLabel || '—'}}</view>
-        <view class="order-meta">订单号：{{item.orderId || '待补全'}}</view>
-        <view class="order-tags">
-          <view class="tag solid">权益：{{item.rightStatusLabel}}</view>
-          <view class="tag" wx:if="{{item.ticketOwned}}">已落地购票</view>
-        </view>
+        <view class="order-meta">活动 ID：{{item.id}}</view>
+        <view class="order-meta">时间：{{item.periodLabel}}</view>
+        <view wx:if="{{item.summary}}" class="order-meta">简介：{{item.summary}}</view>
       </view>
     </view>
-    <view wx:else class="empty-text">暂无购票记录，等待新的实时订单。</view>
+    <view wx:else class="empty-text">暂无可查看的砍价活动。</view>
   </view>
 
   <view wx:if="{{error}}" class="error-banner">{{error}}</view>


### PR DESCRIPTION
### Motivation
- 将单一的“感恩节活动监控”拆分为活动列表与每个活动独立的监控页，以便按活动隔离监控数据并支持多活动场景。 
- 保持现有 BHK 感恩节监控功能不变，但让数据查询按活动 `activityId` 进行独立呈现。 
- 在后台主入口中用更通用的“砍价活动管理”替换原“感恩节活动管理”入口以反映功能范围拓展。 

### Description
- 在管理端将入口文本由“感恩节活动管理”改为“砍价活动管理”，并更新说明文案（`miniprogram/subpackages/admin/index.js`）。
- 把原 `thanksgiving` 页改造成“砍价活动列表”页，拉取活动列表并支持点击进入对应活动的监控页（`miniprogram/subpackages/admin/thanksgiving/*`）。
- 新增独立监控页面 `thanksgiving-dashboard`（`miniprogram/subpackages/admin/thanksgiving-dashboard/*`），UI 与原监控页相同，但通过查询字符串接收 `activityId` 和 `title`，并将 `activityId` 传给后端以加载该活动的数据。
- 前端 `AdminService.getThanksgivingDashboard` 新增对 `activityId` 的透传（`miniprogram/services/api.js`），云函数 `getThanksgivingDashboard` 支持按 `activityId` 查询库存与订单并可接收可配置的 `rightId`（`cloudfunctions/admin/index.js`），向后兼容默认行为仍使用原常量。 
- 将新页面注册到 `app.json` 的 admin 子包路由中（`miniprogram/app.json`）。

### Testing
- 已执行 `node -e "JSON.parse(require('fs').readFileSync('miniprogram/app.json','utf8'))"` 验证 `app.json` 格式正确，命令返回成功。 
- 已使用 `rg` 搜索验证关键符号与字符串变更（如 `DEFAULT_BARGAIN_RIGHT_ID`、`getThanksgivingDashboard(`、`砍价活动管理`）存在于预期文件中，搜索命令返回匹配项。 
- 变更已通过本地文件写入与静态 checks（`git status --short` 查看变更列表），未运行额外单元/集成测试；云端函数变更需在部署环境下进行集成验证。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1225e46130832cbf34ab0b63c5fe6d)