### PR TITLE
fix(admin): filter admin bargain activity list by activityTemplate

### DIFF
--- a/miniprogram/subpackages/admin/thanksgiving/index.js
+++ b/miniprogram/subpackages/admin/thanksgiving/index.js
@@ -11,13 +11,17 @@ function normalizeActivities(list = []) {
       statusLabel: item.statusLabel || '草稿',
       periodLabel: item.periodLabel || '未设置活动时间',
       activityType: item.activityType || 'standard',
-      template: item.template || '',
+      activityTemplate: item.activityTemplate || item.template || '',
       summary: item.summary || ''
     }));
 }
 
 function isBargainActivity(activity = {}) {
-  return activity.activityType === 'bargain' || activity.template === 'thanksgiving-bargain' || activity.template === 'concert-bargain';
+  return (
+    activity.activityType === 'bargain' ||
+    activity.activityTemplate === 'thanksgiving-bargain' ||
+    activity.activityTemplate === 'concert-bargain'
+  );
 }
 
 Page({


### PR DESCRIPTION
### Motivation
- Fix a field mismatch where the admin bargain activity list filtered on `template` while backend activity records expose `activityTemplate`, which caused archived bargain activities to be dropped and unrelated activities to appear.

### Description
- Normalize `activityTemplate` in `miniprogram/subpackages/admin/thanksgiving/index.js` with a backward-compatible fallback to `template`, and update `isBargainActivity` to use `activityTemplate` (and `activityType`) when selecting bargain activities.

### Testing
- Verified backend decoration by inspecting `cloudfunctions/admin/index.js` to confirm `decorateActivityRecord` returns `activityTemplate` (inspection command succeeded).
- Ran `git diff -- miniprogram/subpackages/admin/thanksgiving/index.js` to validate the diff (succeeded) and committed the change (commit succeeded).
- Executed a quick Node syntax check with `node -e "new Function(require('fs').readFileSync('miniprogram/subpackages/admin/thanksgiving/index.js','utf8')); console.log('syntax ok')"` which failed due to ESM `import` usage in the file (environment limitation, not a runtime regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a122a11100c832c852f7d8addf81394)