### PR TITLE
feat: 自动标记疑似微信审核测试充值账号

### DIFF
--- a/cloudfunctions/wallet-pay-notify/index.js
+++ b/cloudfunctions/wallet-pay-notify/index.js
@@ -11,6 +11,7 @@ cloud.init({ env: cloud.DYNAMIC_CURRENT_ENV });
 
 const db = cloud.database();
 const _ = db.command;
+const WECHAT_REVIEW_RECHARGE_AMOUNT = 500000;
 
 const WECHAT_PAYMENT_SECURITY = {
   apiV3Key: (process.env.WECHAT_PAY_API_V3_KEY || '').trim()
@@ -159,11 +160,19 @@ async function handleSuccessfulTransaction(transactionId, payload) {
 
     if (record.status !== 'success') {
       const experienceGain = calculateExperienceGain(amount);
+      const memberDoc = await transaction.collection(COLLECTIONS.MEMBERS).doc(record.memberId).get().catch(() => null);
+      const member = memberDoc && memberDoc.data ? memberDoc.data : {};
       const memberUpdates = {
         cashBalance: _.inc(amount),
         totalRecharge: _.inc(amount),
         updatedAt: now
       };
+      if (Number(amount) === WECHAT_REVIEW_RECHARGE_AMOUNT) {
+        const roles = Array.isArray(member.roles) ? member.roles.filter(Boolean) : [];
+        if (!roles.includes('test')) {
+          memberUpdates.roles = Array.from(new Set([...roles, 'test']));
+        }
+      }
       if (experienceGain > 0) {
         memberUpdates.experience = _.inc(experienceGain);
       }

--- a/cloudfunctions/wallet/index.js
+++ b/cloudfunctions/wallet/index.js
@@ -16,6 +16,7 @@ cloud.init({ env: cloud.DYNAMIC_CURRENT_ENV });
 
 const db = cloud.database();
 const _ = db.command;
+const WECHAT_REVIEW_RECHARGE_AMOUNT = 500000;
 
 const proxyHelpers = createProxyHelpers(cloud, { loggerTag: 'wallet' });
 
@@ -791,6 +792,17 @@ function resolveTransactionType(type, amount) {
   return 'unknown';
 }
 
+function buildTestRoleUpdate(member, amount) {
+  if (Number(amount) !== WECHAT_REVIEW_RECHARGE_AMOUNT) {
+    return null;
+  }
+  const roles = Array.isArray(member && member.roles) ? member.roles.filter(Boolean) : [];
+  if (roles.includes('test')) {
+    return null;
+  }
+  return Array.from(new Set([...roles, 'test']));
+}
+
 async function createRecharge(openid, amount) {
   const featureToggles = await loadFeatureToggles();
   if (!featureToggles.cashierEnabled) {
@@ -1229,11 +1241,17 @@ async function completeRecharge(openid, transactionId) {
       }
     });
 
+    const memberDoc = await transaction.collection(COLLECTIONS.MEMBERS).doc(openid).get().catch(() => null);
+    const member = memberDoc && memberDoc.data ? memberDoc.data : {};
     const memberUpdate = {
       cashBalance: _.inc(amount),
       totalRecharge: _.inc(amount),
       updatedAt: new Date()
     };
+    const testRoles = buildTestRoleUpdate(member, amount);
+    if (testRoles) {
+      memberUpdate.roles = testRoles;
+    }
     if (experienceGain > 0) {
       memberUpdate.experience = _.inc(experienceGain);
     }


### PR DESCRIPTION
### Motivation
- 小程序提审会出现微信测试账号并触发固定 ¥5000 充值，这些流水会污染统计并给后台清理带来麻烦。

### Description
- 新增常量 `WECHAT_REVIEW_RECHARGE_AMOUNT = 500000` 用于统一识别疑似微信审核充值阈值。 
- 在 `cloudfunctions/wallet/index.js` 中新增 `buildTestRoleUpdate` 辅助方法，并在 `completeRecharge` 入账流程中读取会员当前角色后在命中阈值时自动追加 `test` 角色。 
- 在 `cloudfunctions/wallet-pay-notify/index.js` 的支付回调成功入账流程中同步加入相同的读取/标记逻辑，确保微信异步通知路径也会打标。 
- 使用去重逻辑合并角色且仅在用户尚未包含 `test` 时才添加，避免重复写入。 

### Testing
- 运行类型检查：`node --check cloudfunctions/wallet/index.js && node --check cloudfunctions/wallet-pay-notify/index.js`，两处检查通过。 
- 变更已保存并通过本地文件检查，没有发现语法错误。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a122d5c52a8832cb7805772ce882d16)