### PR TITLE
feat(wallet): mark non-release recharge orders as test

### DIFF
--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -5966,47 +5966,58 @@ async function reconcileMemberLevelRewardsAfterExperienceRollback(memberId, leve
 async function listTestMembers() {
   const collection = db.collection(COLLECTIONS.MEMBERS);
   const pageSize = 100;
-  let skip = 0;
-  const members = [];
+  const membersMap = new Map();
 
-  while (true) {
-    let snapshot;
-    try {
-      snapshot = await collection
-        .where({ roles: _.all(['test']) })
-        .orderBy('_id', 'asc')
-        .skip(skip)
-        .limit(pageSize)
-        .field({ _id: true, roles: true })
-        .get();
-    } catch (error) {
-      if (isNotFoundError(error)) {
+  async function collectMembersByFilter(filter) {
+    let skip = 0;
+    while (true) {
+      let snapshot;
+      try {
+        snapshot = await collection
+          .where(filter)
+          .orderBy('_id', 'asc')
+          .skip(skip)
+          .limit(pageSize)
+          .field({ _id: true, roles: true, isTestUser: true })
+          .get();
+      } catch (error) {
+        if (isNotFoundError(error)) {
+          break;
+        }
+        console.error('[admin] list test members failed', filter, error);
         break;
       }
-      console.error('[admin] list test members failed', error);
-      break;
-    }
 
-    const docs = (snapshot && Array.isArray(snapshot.data)) ? snapshot.data : [];
-    if (!docs.length) {
-      break;
-    }
-
-    docs.forEach((doc) => {
-      const id = normalizeMemberIdValue(doc && doc._id);
-      const roles = Array.isArray(doc && doc.roles) ? doc.roles.filter(Boolean) : [];
-      if (id && roles.includes('test') && !roles.some((role) => ADMIN_ROLES.includes(role))) {
-        members.push({ _id: id, roles });
+      const docs = snapshot && Array.isArray(snapshot.data) ? snapshot.data : [];
+      if (!docs.length) {
+        break;
       }
-    });
 
-    if (docs.length < pageSize) {
-      break;
+      docs.forEach((doc) => {
+        const id = normalizeMemberIdValue(doc && doc._id);
+        const roles = Array.isArray(doc && doc.roles) ? doc.roles.filter(Boolean) : [];
+        const isTestUser = Boolean(doc && doc.isTestUser);
+        if (!id || roles.some((role) => ADMIN_ROLES.includes(role))) {
+          return;
+        }
+        if (roles.includes('test') || isTestUser) {
+          membersMap.set(id, { _id: id, roles, isTestUser });
+        }
+      });
+
+      if (docs.length < pageSize) {
+        break;
+      }
+      skip += pageSize;
     }
-    skip += pageSize;
   }
 
-  return members;
+  // 兼容旧逻辑：roles 含 test 的账号
+  await collectMembersByFilter({ roles: _.all(['test']) });
+  // 新逻辑：充值流程标记过 isTestUser 的账号
+  await collectMembersByFilter({ isTestUser: true });
+
+  return Array.from(membersMap.values());
 }
 
 async function summarizeTestMemberAssociations(memberIds) {

--- a/cloudfunctions/nodejs-layer/node_modules/common-config/index.js
+++ b/cloudfunctions/nodejs-layer/node_modules/common-config/index.js
@@ -89,7 +89,9 @@ const EXCLUDED_TRANSACTION_STATUSES = Object.freeze([
   'failed',
   'cancelled',
   'refunded',
-  'closed'
+  'closed',
+  // 新增：测试订单状态，不计入财务统计
+  'test'
 ]);
 
 const DEFAULT_ADMIN_ROLES = Object.freeze(['admin', 'developer']);

--- a/cloudfunctions/wallet/index.js
+++ b/cloudfunctions/wallet/index.js
@@ -19,6 +19,9 @@ const _ = db.command;
 
 const proxyHelpers = createProxyHelpers(cloud, { loggerTag: 'wallet' });
 
+// 新增：用于识别测试环境（审核/体验/开发版）
+const TEST_ENVIRONMENTS = new Set(['develop', 'trial']);
+
 const FEATURE_TOGGLE_DOC_ID = 'feature_toggles';
 const DEFAULT_IMMORTAL_TOURNAMENT = {
   enabled: false,
@@ -606,7 +609,7 @@ exports.main = async (event, context) => {
     case 'summary':
       return getSummary(targetMemberId);
     case 'createRecharge':
-      return createRecharge(targetMemberId, event.amount);
+      return createRecharge(targetMemberId, event.amount, event);
     case 'completeRecharge':
       return completeRecharge(targetMemberId, event.transactionId);
     case 'failRecharge':
@@ -791,7 +794,7 @@ function resolveTransactionType(type, amount) {
   return 'unknown';
 }
 
-async function createRecharge(openid, amount) {
+async function createRecharge(openid, amount, event = {}) {
   const featureToggles = await loadFeatureToggles();
   if (!featureToggles.cashierEnabled) {
     throw new Error('线上充值暂不可用，请前往收款台线下充值');
@@ -822,12 +825,20 @@ async function createRecharge(openid, amount) {
     throw error;
   }
   const now = new Date();
+  // 根据请求携带的 envVersion 判断是否测试环境，
+  // 如果非 release，则将订单标记为测试订单，记录 clientEnvVersion。
+  const clientEnvVersion =
+    (event && event.clientEnvVersion) || (event && event.clientEnv && event.clientEnv.envVersion) || '';
+  const isTestOrder = TEST_ENVIRONMENTS.has(String(clientEnvVersion || '').toLowerCase());
   const record = await db.collection(COLLECTIONS.WALLET_TRANSACTIONS).add({
     data: {
       memberId: openid,
       amount: normalizedAmount,
       type: 'recharge',
-      status: 'pending',
+      // 非正式环境的充值订单标记为 test，其它为 pending
+      status: isTestOrder ? 'test' : 'pending',
+      isTestOrder,
+      clientEnvVersion: clientEnvVersion || '',
       createdAt: now,
       updatedAt: now,
       remark: '余额充值'
@@ -1160,6 +1171,17 @@ async function failRecharge(openid, transactionId, options = {}) {
       throw new Error('记录类型错误');
     }
     const currentStatus = normalizeTransactionStatus(record.status);
+    // 如果是测试订单，直接更新为 test 状态，不再更改余额
+    if (record.isTestOrder || currentStatus === 'test') {
+      await recordRef.update({
+        data: {
+          status: 'test',
+          updatedAt: now,
+          remark: '测试环境充值取消'
+        }
+      });
+      return;
+    }
     if (currentStatus === 'success') {
       outcome = { success: false, status: 'success' };
       return;
@@ -1213,6 +1235,35 @@ async function completeRecharge(openid, transactionId) {
     }
     if (record.type !== 'recharge') {
       throw new Error('记录类型错误');
+    }
+    const now = new Date();
+    // 新增：如果是测试订单，则仅更新状态，不增加余额
+    if (record.isTestOrder || record.status === 'test') {
+      await transactionRef.update({
+        data: {
+          status: 'test', // 保持 test 状态
+          updatedAt: now,
+          succeededAt: now,
+          remark: '测试环境充值，不计入余额'
+        }
+      });
+      // 标记用户为测试账号，方便后台清理
+      await db
+        .collection(COLLECTIONS.MEMBERS)
+        .doc(openid)
+        .set(
+          {
+            data: {
+              isTestUser: true,
+              testReason: '在测试环境创建充值',
+              updatedAt: now
+            }
+          },
+          { merge: true }
+        )
+        .catch(() => null);
+      result = { success: true, status: 'test' };
+      return;
     }
     if (record.status === 'success') {
       result = { success: true, message: '充值已完成' };


### PR DESCRIPTION
### Motivation
- 为了避免审核/体验/开发等非正式环境的充值影响线上财务和用户余额，需要在充值流程中识别测试环境并将对应订单标记为测试订单以便排除统计和后续清理。 

### Description
- 在 `cloudfunctions/wallet/index.js` 顶部新增 `TEST_ENVIRONMENTS` 常量并将 `main` 中对 `createRecharge` 的调用改为透传 `event`。 
- 修改 `createRecharge`（签名为 `createRecharge(openid, amount, event = {})`）以读取 `clientEnvVersion`（兼容 `clientEnv.envVersion`），计算 `isTestOrder`，并在新增充值记录时写入 `status: 'test'`（若为测试环境）、`isTestOrder` 和 `clientEnvVersion` 字段。 
- 修改 `completeRecharge` 在遇到测试订单时仅更新交易状态/备注并不增加会员余额，同时将会员标记为 `isTestUser: true` 并写入 `testReason` 便于后台清理。 
- 修改 `failRecharge` 在遇到测试订单时直接将交易置为 `test` 并写入取消备注，避免进入普通失败/扣账流程。 
- 在公共配置 `cloudfunctions/nodejs-layer/node_modules/common-config/index.js` 中将 `'test'` 加入 `EXCLUDED_TRANSACTION_STATUSES` 以在统计中排除测试订单。 

### Testing
- 没有运行自动化测试套件；本次变更通过静态检查与差异查看验证（查看了 `git diff` / 文件内容变更）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1231465140832c87d1d7189f13ea57)