### PR TITLE
fix: 砍价购票流水名称改为权益名优先并补充排查文档

### DIFF
--- a/cloudfunctions/activities/index.js
+++ b/cloudfunctions/activities/index.js
@@ -920,7 +920,7 @@ function normalizeBargainSession(record = {}, config = {}, overrides = {}, openi
   return { ...normalized, ...overrides };
 }
 
-async function ensureThanksgivingChargeOrder(openid, sessionDocId, amountInCents = 0) {
+async function ensureThanksgivingChargeOrder(openid, sessionDocId, amountInCents = 0, options = {}) {
   const normalizedAmount = Math.max(0, Math.round(Number(amountInCents || 0)));
   if (!openid || !sessionDocId || !normalizedAmount) {
     return null;
@@ -928,6 +928,16 @@ async function ensureThanksgivingChargeOrder(openid, sessionDocId, amountInCents
 
   const now = new Date();
   let chargeOrderId = '';
+
+  const rewardRightName =
+    typeof options.rewardRightName === 'string' && options.rewardRightName.trim()
+      ? options.rewardRightName.trim()
+      : '';
+  const activityName =
+    typeof options.activityName === 'string' && options.activityName.trim()
+      ? options.activityName.trim()
+      : '';
+  const fallbackRemark = rewardRightName || activityName || THANKSGIVING_TICKET_REMARK;
 
   await db.runTransaction(async (transaction) => {
     const sessionRef = transaction.collection(BHK_BARGAIN_COLLECTION).doc(sessionDocId);
@@ -958,13 +968,13 @@ async function ensureThanksgivingChargeOrder(openid, sessionDocId, amountInCents
     const balanceBefore = resolveCashBalance(member);
     const balanceAfter = balanceBefore - normalizedAmount;
     const debtIncurred = balanceAfter < 0;
-    const walletRemark = THANKSGIVING_TICKET_REMARK;
+    const walletRemark = fallbackRemark;
 
     const orderPayload = {
       status: 'paid',
       items: [
         {
-          name: THANKSGIVING_TICKET_REMARK,
+          name: walletRemark,
           price: normalizedAmount,
           quantity: 1,
           amount: normalizedAmount,
@@ -1767,7 +1777,10 @@ async function confirmBhkBargainPurchase(event = {}) {
     Math.max(0, Math.round(Number(normalizedSession.currentPrice || 0) * 100)) ||
     Math.max(0, Math.round(Number(config.floorPrice || 0) * 100));
 
-  await ensureThanksgivingChargeOrder(openid, sessionDocId, normalizedChargeAmount);
+  await ensureThanksgivingChargeOrder(openid, sessionDocId, normalizedChargeAmount, {
+    rewardRightName: config && config.rewardRightEnabled ? config.rewardRightName : '',
+    activityName: activityDoc && typeof activityDoc.title === 'string' ? activityDoc.title : ''
+  });
 
   const shareContext = await buildShareContext(
     config,

--- a/docs/bhk-bargain-payment-reconcile-fix.md
+++ b/docs/bhk-bargain-payment-reconcile-fix.md
@@ -123,3 +123,27 @@
 - 开发者工具 WXML 树出现 `<components/custom-nav/custom-nav>` 节点；
 - 顶部显示统一的左箭头半透明圆形返回按钮；
 - 内容区自动拥有 nav placeholder 顶部留白，不再贴顶遮挡。
+
+## 新增修复：砍价购票后钱包流水名称错误
+
+### 问题现象
+- 用户在砍价活动完成购票后，钱包消费流水 `remark` 仍显示固定文案「感恩节活动门票」。
+- 该文案与活动配置不一致，无法准确反映当前活动发放的权益名称。
+
+### 根因
+- `cloudfunctions/activities` 中创建消费流水时，`walletRemark` 被固定为常量 `THANKSGIVING_TICKET_REMARK`。
+- 即使活动后台已配置 `rewardRightName`（活动权益名称），消费流水也不会读取该配置。
+
+### 修复策略
+1. 为 `ensureThanksgivingChargeOrder` 增加 `options` 入参，接收：
+   - `rewardRightName`
+   - `activityName`
+2. 统一流水文案优先级：
+   - 优先使用活动发放的权益名称 `rewardRightName`
+   - 若为空则回退活动名称 `activityName`
+   - 若仍为空再回退历史默认值 `THANKSGIVING_TICKET_REMARK`
+3. 在 `bargainConfirmPurchase` 调用处传入运行时活动配置与活动标题，确保流水名称随活动配置动态变化。
+
+### 结果
+- 钱包消费流水、订单条目名称、灵石流水描述将与活动权益配置保持一致；
+- 当未配置权益名称时，自动显示活动名称，符合“权益名优先、活动名兜底”的业务规则。


### PR DESCRIPTION
### Motivation
- 线上表现为砍价活动购票后，钱包消费流水与订单条目名称始终写死为常量 `THANKSGIVING_TICKET_REMARK`，无法反映活动配置的权益名称。 
- 预期是流水显示活动发放的权益名称，若未配置权益名称则回退显示活动名称，从而使账单与活动配置一致性得到保障。 
- 需同时把变更记录到排查文档，便于运维与客服回溯问题与验证修复效果。 

### Description
- 修改 `cloudfunctions/activities/index.js` 中 `ensureThanksgivingChargeOrder` 的签名为 `ensureThanksgivingChargeOrder(openid, sessionDocId, amountInCents = 0, options = {})` 并接收 `rewardRightName` 与 `activityName`。 
- 在函数内部新增 `fallbackRemark` 生成逻辑，优先使用 `rewardRightName`，其次使用 `activityName`，最后回退 `THANKSGIVING_TICKET_REMARK`，并将该文案用于 charge order 的 `items[].name`、order `remark` 以及钱包/灵石流水的 `remark`/`description`，保证三处一致。 
- 在砍价确认流程调用处传入运行时配置：如果 `config.rewardRightEnabled` 则传 `config.rewardRightName`，并传入 `activityDoc.title` 作为活动名兜底。 
- 更新文档 `docs/bhk-bargain-payment-reconcile-fix.md`，新增“砍价购票后钱包流水名称错误”章节，记录现象、根因、修复策略与结果。 

### Testing
- 运行单元测试 `npx jest __tests__/activities/bargain.test.js`, 结果通过：Test Suites: 1 passed, Tests: 6 passed. 
- 变更已保存并提交; 变更范围仅限 `cloudfunctions/activities/index.js` 与 `docs/bhk-bargain-payment-reconcile-fix.md`。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149088d02c832cb4c0347d32cf9751)