### PR TITLE
修复砍价活动支付成功后页面卡在 loading

### DIFF
--- a/miniprogram/pages/activities/bhk-bargain/index.js
+++ b/miniprogram/pages/activities/bhk-bargain/index.js
@@ -451,10 +451,11 @@ Page({
   },
 
   normalizeMapLocation(activity = {}) {
-    const address = activity.locationAddress || activity.location || DEFAULT_LOCATION.address;
-    const name = activity.locationName || activity.location || DEFAULT_LOCATION.name;
-    const latitude = Number(activity.locationLat);
-    const longitude = Number(activity.locationLng);
+    const safeActivity = activity && typeof activity === 'object' ? activity : {};
+    const address = safeActivity.locationAddress || safeActivity.location || DEFAULT_LOCATION.address;
+    const name = safeActivity.locationName || safeActivity.location || DEFAULT_LOCATION.name;
+    const latitude = Number(safeActivity.locationLat);
+    const longitude = Number(safeActivity.locationLng);
     const hasValidCoords =
       Number.isFinite(latitude) &&
       Number.isFinite(longitude) &&


### PR DESCRIPTION
### Motivation
- 支付成功后页面会再次拉取活动状态并进入 `applySession -> normalizeMapLocation`，当后端返回 `activity` 为 `null` 或非对象时会抛出异常，导致页面 `loading` 状态无法被后续 `setData` 关闭，从而卡在 loading。

### Description
- 在 `miniprogram/pages/activities/bhk-bargain/index.js` 的 `normalizeMapLocation(activity = {})` 中加入防御性处理，使用 `const safeActivity = activity && typeof activity === 'object' ? activity : {};` 以避免直接读取 `activity` 字段时报错。 
- 保持原有坐标与地址校验逻辑不变，只有在 `activity` 非对象时回退到安全默认值。

### Testing
- 运行 `npm test -- __tests__/activities/bargain.test.js`，测试用例全部通过但命令返回非零是因为仓库全局 coverage 阈值未达标；测试用例本身通过。 
- 运行 `npx jest __tests__/activities/bargain.test.js --coverage=false`，所有相关测试通过。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149ed9dac0832c9229b1ef1f7fa480)