### PR TITLE
fix: guard resolveRewardRightId against null config (frontend + cloud)

### DIFF
--- a/cloudfunctions/activities/index.js
+++ b/cloudfunctions/activities/index.js
@@ -1268,7 +1268,8 @@ async function buildShareContext(config, targetOpenId, viewerOpenId, viewerProfi
 
 
 function resolveRewardRightId(config = {}, activityId = '') {
-  const configuredId = typeof config.rewardRightId === 'string' ? config.rewardRightId.trim() : '';
+  const safeConfig = config && typeof config === 'object' ? config : {};
+  const configuredId = typeof safeConfig.rewardRightId === 'string' ? safeConfig.rewardRightId.trim() : '';
   if (configuredId && configuredId !== THANKSGIVING_RIGHT_ID) {
     return configuredId;
   }

--- a/miniprogram/pages/activities/bhk-bargain/index.js
+++ b/miniprogram/pages/activities/bhk-bargain/index.js
@@ -44,7 +44,8 @@ const DEFAULT_INFO_SECTION_CONTENT = [
 ];
 
 function resolveRewardRightId(config = {}, activityId = '') {
-  const configuredId = typeof config.rewardRightId === 'string' ? config.rewardRightId.trim() : '';
+  const safeConfig = config && typeof config === 'object' ? config : {};
+  const configuredId = typeof safeConfig.rewardRightId === 'string' ? safeConfig.rewardRightId.trim() : '';
   if (configuredId && configuredId !== DEFAULT_TICKET_RIGHT_ID) {
     return configuredId;
   }


### PR DESCRIPTION
### Motivation
- Prevent an uncaught `TypeError` when `null` is passed to `resolveRewardRightId`, which produced the frontend console error `Cannot read property 'rewardRightId' of null` and broke rights fetch.

### Description
- Add a defensive object guard `const safeConfig = config && typeof config === 'object' ? config : {};` and read `safeConfig.rewardRightId` in `resolveRewardRightId` in `miniprogram/pages/activities/bhk-bargain/index.js`.
- Apply the same defensive guard in the cloud implementation at `cloudfunctions/activities/index.js` so frontend and backend share consistent fallback behavior.

### Testing
- Verified the code change via `git diff` and line inspection to ensure the guard was added to both files.
- Searched the codebase with `rg -n "resolveRewardRightId|fetch rights failed|rewardRightId"` to confirm references; no automated unit tests were executed in this pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a1ff39d8832c98941b42b7366b1a)