### PR TITLE
Resolve bargain activities regardless of publish status

### DIFF
--- a/cloudfunctions/activities/index.js
+++ b/cloudfunctions/activities/index.js
@@ -372,7 +372,7 @@ async function resolveBargainActivityRuntime(event = {}) {
     .then((res) => (res && res.data) || null)
     .catch(() => null);
 
-  if (doc && doc.status === 'published' && doc.activityType === 'bargain') {
+  if (doc && doc.activityType === 'bargain') {
     const settings = (doc.bargainSettings && typeof doc.bargainSettings === 'object') ? doc.bargainSettings : {};
     const config = buildBhkBargainConfig();
     config.startPrice = Number.isFinite(settings.startPrice) ? settings.startPrice : config.startPrice;


### PR DESCRIPTION
### Motivation
- Allow runtime resolution and preview of bargain activities even when their `status` is not `published` by removing the publish gating in `resolveBargainActivityRuntime`.

### Description
- Removed the `doc.status === 'published'` requirement from the `if` condition in `resolveBargainActivityRuntime`, so the function will execute for any document with `activityType === 'bargain'` and continue to build the bargain config from `bargainSettings`.

### Testing
- Ran `npm test` (unit tests and lint); the automated test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1516fa70d4832cba76fa5a7ed0f912)