### PR TITLE
Bargain activity: prefer custom doc, allow runtime for non-published bargains, tighten detail fallback

### DIFF
--- a/cloudfunctions/activities/index.js
+++ b/cloudfunctions/activities/index.js
@@ -372,7 +372,7 @@ async function resolveBargainActivityRuntime(event = {}) {
     .then((res) => (res && res.data) || null)
     .catch(() => null);
 
-  if (doc && doc.status === 'published' && doc.activityType === 'bargain') {
+  if (doc && doc.activityType === 'bargain') {
     const settings = (doc.bargainSettings && typeof doc.bargainSettings === 'object') ? doc.bargainSettings : {};
     const config = buildBhkBargainConfig();
     config.startPrice = Number.isFinite(settings.startPrice) ? settings.startPrice : config.startPrice;
@@ -597,9 +597,16 @@ async function listPublicActivities(options = {}) {
   const decorated = (snapshot.data || []).map((item) => decorateActivity(item));
 
   if (!decorated.find((item) => item && item.id === BHK_BARGAIN_ACTIVITY_ID)) {
-    const bhk = decorateActivity(buildBhkBargainActivity());
-    if (bhk) {
-      decorated.push({ ...bhk, sortOrder: Number.MAX_SAFE_INTEGER });
+    const bhkDoc = await collection
+      .doc(BHK_BARGAIN_ACTIVITY_ID)
+      .get()
+      .then((res) => (res && res.data) || null)
+      .catch(() => null);
+    if (!bhkDoc) {
+      const bhk = decorateActivity(buildBhkBargainActivity());
+      if (bhk) {
+        decorated.push({ ...bhk, sortOrder: Number.MAX_SAFE_INTEGER });
+      }
     }
   }
 
@@ -641,7 +648,7 @@ async function getActivityDetail(options = {}) {
     });
 
   if (!doc || doc.status !== 'published') {
-    if (id === BHK_BARGAIN_ACTIVITY_ID) {
+    if (!doc && id === BHK_BARGAIN_ACTIVITY_ID) {
       return {
         activity: decorateActivity(buildBhkBargainActivity()),
         bargainConfig: buildBhkBargainConfig()


### PR DESCRIPTION
### Motivation

- Allow the bargain runtime resolver to operate on bargain-type documents even if they're not published so runtime logic can be used for previews or internal processing.
- Avoid injecting the built-in BHK bargain activity into the public list when a custom activity document already exists in the database.
- Prevent `getActivityDetail` from falling back to the built-in bargain activity when a custom but unpublished document exists.

### Description

- Removed the `status === 'published'` guard from `resolveBargainActivityRuntime` so any document with `activityType === 'bargain'` will be processed by that function.
- Updated `listPublicActivities` to `GET` the `BHK_BARGAIN_ACTIVITY_ID` document and only push the built-in activity when that document does not exist, avoiding duplication when a custom doc is present.
- Changed `getActivityDetail` to return the built-in bargain activity only when the document is absent (`!doc`) for `BHK_BARGAIN_ACTIVITY_ID`, instead of when the document exists but is not published.
- Added asynchronous fetch logic and adjusted flow to respect custom bargain documents while preserving the built-in fallback when no custom doc is found.

### Testing

- Ran the repository's automated unit and integration test suite and linters against the modified files and all tests passed.
- Performed a basic smoke test of `listPublicActivities` and `getActivityDetail` paths for the `BHK_BARGAIN_ACTIVITY_ID` scenarios and observed the expected fallback and non-duplication behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1516fa70d4832cba76fa5a7ed0f912)