### PR TITLE
feat: prevent direct access to disabled home entries

### DIFF
--- a/miniprogram/pages/activities/index.js
+++ b/miniprogram/pages/activities/index.js
@@ -1,5 +1,6 @@
 import { ActivityService } from '../../services/api';
 import { decorateActivity } from '../../shared/activity';
+const { ensureHomeEntryEnabled } = require('../../utils/home-entry-guard');
 
 function resolveActivityRoute(activity = {}) {
   if (!activity || typeof activity !== 'object') {
@@ -14,12 +15,23 @@ function resolveActivityRoute(activity = {}) {
 
 Page({
   data: {
+    homeEntryBlocked: false,
     loading: true,
     activities: [],
     error: ''
   },
 
+  onLoad() {
+    if (!ensureHomeEntryEnabled('activities')) {
+      this.setData({ homeEntryBlocked: true });
+      return;
+    }
+  },
+
   onShow() {
+    if (this.data.homeEntryBlocked) {
+      return;
+    }
     this.fetchActivities();
   },
 

--- a/miniprogram/pages/mall/index.js
+++ b/miniprogram/pages/mall/index.js
@@ -1,11 +1,13 @@
 import { StoneService } from '../../services/api';
 import { formatStones } from '../../utils/format';
+const { ensureHomeEntryEnabled } = require('../../utils/home-entry-guard');
 
 const DEFAULT_CATEGORY_KEY = 'general';
 const DEFAULT_CATEGORY_LABEL = '奇珍异宝';
 
 Page({
   data: {
+    homeEntryBlocked: false,
     loading: true,
     items: [],
     categories: [],
@@ -20,7 +22,17 @@ Page({
     error: ''
   },
 
+  onLoad() {
+    if (!ensureHomeEntryEnabled('mall')) {
+      this.setData({ homeEntryBlocked: true });
+      return;
+    }
+  },
+
   onShow() {
+    if (this.data.homeEntryBlocked) {
+      return;
+    }
     this.bootstrap();
   },
 

--- a/miniprogram/pages/pve/pve.js
+++ b/miniprogram/pages/pve/pve.js
@@ -1,4 +1,5 @@
 import { PveService } from '../../services/api';
+const { ensureHomeEntryEnabled } = require('../../utils/home-entry-guard');
 
 function normalizeEquipmentLootEntries(lootList = []) {
   if (!Array.isArray(lootList) || !lootList.length) {
@@ -100,6 +101,7 @@ function decorateSecretRealmProfile(profile = {}) {
 
 Page({
   data: {
+    homeEntryBlocked: false,
     loading: true,
     profile: null,
     battleResult: null,
@@ -107,7 +109,17 @@ Page({
     selectedEnemyId: ''
   },
 
+  onLoad() {
+    if (!ensureHomeEntryEnabled('secretRealm')) {
+      this.setData({ homeEntryBlocked: true });
+      return;
+    }
+  },
+
   onShow() {
+    if (this.data.homeEntryBlocked) {
+      return;
+    }
     this.fetchProfile();
   },
 

--- a/miniprogram/pages/pvp/index.js
+++ b/miniprogram/pages/pvp/index.js
@@ -1,6 +1,7 @@
 import { MemberService, PvpService } from '../../services/api';
 const { SHARE_COVER_IMAGE_URL } = require('../../shared/common.js');
 const { buildCloudAssetUrl } = require('../../shared/asset-paths.js');
+const { ensureHomeEntryEnabled } = require('../../utils/home-entry-guard');
 const {
   decorateLeaderboardEntries,
   DEFAULT_AVATAR: DEFAULT_LEADERBOARD_AVATAR
@@ -31,6 +32,7 @@ function sanitizeLeaderboardPreview(entries) {
 
 Page({
   data: {
+    homeEntryBlocked: false,
     loading: true,
     profile: null,
     season: null,
@@ -49,6 +51,10 @@ Page({
   },
 
   onLoad(options = {}) {
+    if (!ensureHomeEntryEnabled('pvp')) {
+      this.setData({ homeEntryBlocked: true });
+      return;
+    }
     this._ensureMemberPromise = null;
     const nextState = {};
     if (options.targetId) {
@@ -73,6 +79,9 @@ Page({
   },
 
   onShow() {
+    if (this.data.homeEntryBlocked) {
+      return;
+    }
     const globalBattle = app && app.globalData ? app.globalData.lastPvpBattle : null;
     if (globalBattle) {
       this.setData({ battleResult: globalBattle.battle || null });

--- a/miniprogram/pages/rights/rights.js
+++ b/miniprogram/pages/rights/rights.js
@@ -1,15 +1,27 @@
 import { MemberService, ReservationService } from '../../services/api';
 import { formatDate } from '../../utils/format';
+const { ensureHomeEntryEnabled } = require('../../utils/home-entry-guard');
 
 Page({
   data: {
+    homeEntryBlocked: false,
     loading: true,
     rights: [],
     member: null,
     redeemingRightId: ''
   },
 
+  onLoad() {
+    if (!ensureHomeEntryEnabled('rights')) {
+      this.setData({ homeEntryBlocked: true });
+      return;
+    }
+  },
+
   onShow() {
+    if (this.data.homeEntryBlocked) {
+      return;
+    }
     this.fetchRights();
   },
 

--- a/miniprogram/pages/trading/index.js
+++ b/miniprogram/pages/trading/index.js
@@ -1,6 +1,7 @@
 import { TradingService, PveService } from '../../services/api';
 import { formatStones } from '../../utils/format';
 import { sanitizeEquipmentProfile, buildEquipmentIconPaths } from '../../utils/equipment';
+const { ensureHomeEntryEnabled } = require('../../utils/home-entry-guard');
 
 const LISTING_STATUS_LABELS = {
   active: '在售',
@@ -579,6 +580,7 @@ function buildBidDisplay(bid, config, detailLookup = null) {
 
 Page({
   data: {
+    homeEntryBlocked: false,
     loading: false,
     error: '',
     activeTab: 'market',
@@ -621,6 +623,10 @@ Page({
   },
 
   onLoad() {
+    if (!ensureHomeEntryEnabled('trading')) {
+      this.setData({ homeEntryBlocked: true });
+      return;
+    }
     this.fetchDashboard();
   },
 

--- a/miniprogram/subpackages/guild/index/index.js
+++ b/miniprogram/subpackages/guild/index/index.js
@@ -1,4 +1,5 @@
 import { GuildService } from '../../../services/api';
+const { ensureHomeEntryEnabled } = require('../../../utils/home-entry-guard');
 const {
   resolveGuildActionTicket,
   decorateGuildLeaderboardEntries,
@@ -115,6 +116,7 @@ function decorateMembership(membership) {
 
 Page({
   data: {
+    homeEntryBlocked: false,
     loading: true,
     error: '',
     guild: null,
@@ -129,7 +131,17 @@ Page({
     donationSelectedAmount: DONATION_PRESETS[0],
     donationOptions: DONATION_OPTIONS
   },
+  onLoad() {
+    if (!ensureHomeEntryEnabled('guild')) {
+      this.setData({ homeEntryBlocked: true });
+      return;
+    }
+  },
+
   onShow() {
+    if (this.data.homeEntryBlocked) {
+      return;
+    }
     this.loadOverview();
   },
   onPullDownRefresh() {

--- a/miniprogram/utils/home-entry-guard.js
+++ b/miniprogram/utils/home-entry-guard.js
@@ -57,7 +57,7 @@ function blockAndBack() {
     if (getCurrentPages().length > 1) {
       wx.navigateBack({ delta: 1 });
     } else {
-      wx.switchTab({ url: '/pages/index/index' });
+      wx.reLaunch({ url: '/pages/index/index' });
     }
   }, 150);
 }

--- a/miniprogram/utils/home-entry-guard.js
+++ b/miniprogram/utils/home-entry-guard.js
@@ -1,0 +1,76 @@
+const HOME_ENTRIES_STORAGE_KEY = 'home-entries-visibility';
+
+const DEFAULT_HOME_ENTRY_VISIBILITY = Object.freeze({
+  activities: true,
+  mall: true,
+  secretRealm: false,
+  rights: true,
+  guild: false,
+  pvp: false,
+  trading: false
+});
+
+function toBoolean(value, defaultValue = false) {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value !== 0 : defaultValue;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) return defaultValue;
+    if (['false', '0', 'off', 'no', '关闭', '否', '禁用', '停用', 'disabled'].includes(normalized)) return false;
+    if (['true', '1', 'on', 'yes', '开启', '启用', 'enable', 'enabled'].includes(normalized)) return true;
+    return defaultValue;
+  }
+  return value == null ? defaultValue : !!value;
+}
+
+function normalizeHomeEntries(entries) {
+  const source = entries && typeof entries === 'object' ? entries : {};
+  return Object.keys(DEFAULT_HOME_ENTRY_VISIBILITY).reduce((acc, key) => {
+    acc[key] = toBoolean(source[key], DEFAULT_HOME_ENTRY_VISIBILITY[key]);
+    return acc;
+  }, {});
+}
+
+function loadHomeEntries() {
+  let source = null;
+  try {
+    const app = getApp();
+    source = app && app.globalData ? app.globalData.homeEntries : null;
+  } catch (error) {}
+  if (source && typeof source === 'object') {
+    return normalizeHomeEntries(source);
+  }
+  try {
+    const cached = wx.getStorageSync(HOME_ENTRIES_STORAGE_KEY);
+    if (cached && typeof cached === 'string') {
+      return normalizeHomeEntries(JSON.parse(cached));
+    }
+    return normalizeHomeEntries(cached);
+  } catch (error) {
+    return normalizeHomeEntries(null);
+  }
+}
+
+function blockAndBack() {
+  wx.showToast({ title: '该入口暂未开放', icon: 'none' });
+  setTimeout(() => {
+    if (getCurrentPages().length > 1) {
+      wx.navigateBack({ delta: 1 });
+    } else {
+      wx.switchTab({ url: '/pages/index/index' });
+    }
+  }, 150);
+}
+
+function ensureHomeEntryEnabled(key) {
+  const entries = loadHomeEntries();
+  const enabled = entries[key] !== false;
+  if (!enabled) {
+    blockAndBack();
+  }
+  return enabled;
+}
+
+module.exports = {
+  ensureHomeEntryEnabled
+};


### PR DESCRIPTION
### Motivation
- The homepage visibility flags only hid entry icons but did not block direct URL access to target pages, allowing disabled features to be opened directly.
- The intent is to ensure a system switch that disables a homepage entry both hides its icon and prevents any direct navigation to the corresponding page.
- Implement a small, shared guard so individual pages can short-circuit loading logic when an entry is disabled.

### Description
- Added a new utility `miniprogram/utils/home-entry-guard.js` which reads `app.globalData.homeEntries` and local cache `home-entries-visibility` and exposes `ensureHomeEntryEnabled(key)` to check an entry's status. 
- When an entry is disabled the guard shows a toast and navigates back or to the home tab to block access (`blockAndBack` behavior). 
- Integrated the guard by calling `ensureHomeEntryEnabled` in page lifecycle handlers and adding a `homeEntryBlocked` short-circuit to stop business logic on these pages: `pages/activities/index`, `pages/mall/index`, `pages/pve/pve`, `pages/rights/rights`, `subpackages/guild/index/index`, `pages/pvp/index`, and `pages/trading/index`.
- The pages now set `homeEntryBlocked` to `true` when blocked and skip data loading when that flag is set, preventing direct URL access to disabled features.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1524b66254832cbcbaf070cb9f8c3f)