### PR TITLE
feat(admin): 在会员列表新增“累计充值”排序功能

### DIFF
--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -837,7 +837,7 @@ function normalizeAction(action) {
 
 const ACTION_HANDLERS = {
   [ACTIONS.LIST_MEMBERS]: (openid, event) =>
-    listMembers(openid, event.keyword || '', event.page || 1, event.pageSize || 20),
+    listMembers(openid, event.keyword || '', event.page || 1, event.pageSize || 20, event.rechargeSort || ''),
   [ACTIONS.GET_MEMBER_DETAIL]: (openid, event) =>
     getMemberDetail(openid, event.memberId, event || {}),
   [ACTIONS.UPDATE_MEMBER]: (openid, event) =>
@@ -2601,10 +2601,11 @@ async function resetPvpProfilesForSeason(season, summary) {
   );
 }
 
-async function listMembers(openid, keyword, page, pageSize) {
+async function listMembers(openid, keyword, page, pageSize, rechargeSort = '') {
   await ensureAdmin(openid);
   const limit = Math.min(Math.max(pageSize, 1), 50);
   const skip = Math.max(page - 1, 0) * limit;
+  const normalizedRechargeSort = rechargeSort === 'asc' || rechargeSort === 'desc' ? rechargeSort : '';
 
   const regex = keyword
     ? db.RegExp({
@@ -2624,9 +2625,12 @@ async function listMembers(openid, keyword, page, pageSize) {
     );
   }
 
+  const orderedQuery = normalizedRechargeSort
+    ? baseQuery.orderBy('totalRecharge', normalizedRechargeSort).orderBy('createdAt', 'desc')
+    : baseQuery.orderBy('createdAt', 'desc');
+
   const [snapshot, countResult, levels] = await Promise.all([
-    baseQuery
-      .orderBy('createdAt', 'desc')
+    orderedQuery
       .skip(skip)
       .limit(limit)
       .get(),

--- a/cloudfunctions/admin/index.js
+++ b/cloudfunctions/admin/index.js
@@ -837,7 +837,7 @@ function normalizeAction(action) {
 
 const ACTION_HANDLERS = {
   [ACTIONS.LIST_MEMBERS]: (openid, event) =>
-    listMembers(openid, event.keyword || '', event.page || 1, event.pageSize || 20, event.rechargeSort || ''),
+    listMembers(openid, event.keyword || '', event.page || 1, event.pageSize || 20, event.sortBy || '', event.rechargeSort || ''),
   [ACTIONS.GET_MEMBER_DETAIL]: (openid, event) =>
     getMemberDetail(openid, event.memberId, event || {}),
   [ACTIONS.UPDATE_MEMBER]: (openid, event) =>
@@ -2601,11 +2601,35 @@ async function resetPvpProfilesForSeason(season, summary) {
   );
 }
 
-async function listMembers(openid, keyword, page, pageSize, rechargeSort = '') {
+
+function normalizeMemberListSort(sortBy = '', rechargeSort = '') {
+  if (sortBy === 'rechargeDesc' || rechargeSort === 'desc') {
+    return 'rechargeDesc';
+  }
+  if (sortBy === 'createdAtDesc') {
+    return 'createdAtDesc';
+  }
+  if (sortBy === 'updatedAtDesc') {
+    return 'updatedAtDesc';
+  }
+  return '';
+}
+
+function applyMemberListSort(query, sortBy = '') {
+  if (sortBy === 'rechargeDesc') {
+    return query.orderBy('totalRecharge', 'desc').orderBy('createdAt', 'desc');
+  }
+  if (sortBy === 'updatedAtDesc') {
+    return query.orderBy('updatedAt', 'desc').orderBy('createdAt', 'desc');
+  }
+  return query.orderBy('createdAt', 'desc');
+}
+
+async function listMembers(openid, keyword, page, pageSize, sortBy = '', rechargeSort = '') {
   await ensureAdmin(openid);
   const limit = Math.min(Math.max(pageSize, 1), 50);
   const skip = Math.max(page - 1, 0) * limit;
-  const normalizedRechargeSort = rechargeSort === 'asc' || rechargeSort === 'desc' ? rechargeSort : '';
+  const normalizedSortBy = normalizeMemberListSort(sortBy, rechargeSort);
 
   const regex = keyword
     ? db.RegExp({
@@ -2625,9 +2649,7 @@ async function listMembers(openid, keyword, page, pageSize, rechargeSort = '') {
     );
   }
 
-  const orderedQuery = normalizedRechargeSort
-    ? baseQuery.orderBy('totalRecharge', normalizedRechargeSort).orderBy('createdAt', 'desc')
-    : baseQuery.orderBy('createdAt', 'desc');
+  const orderedQuery = applyMemberListSort(baseQuery, normalizedSortBy);
 
   const [snapshot, countResult, levels] = await Promise.all([
     orderedQuery

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -947,12 +947,13 @@ export const ActivityService = {
 };
 
 export const AdminService = {
-  async listMembers({ keyword = '', page = 1, pageSize = 20 } = {}) {
+  async listMembers({ keyword = '', page = 1, pageSize = 20, rechargeSort = '' } = {}) {
     return callCloud(CLOUD_FUNCTIONS.ADMIN, {
       action: 'listMembers',
       keyword,
       page,
-      pageSize
+      pageSize,
+      rechargeSort
     });
   },
   async getMemberDetail(memberId, options = {}) {

--- a/miniprogram/services/api.js
+++ b/miniprogram/services/api.js
@@ -947,12 +947,13 @@ export const ActivityService = {
 };
 
 export const AdminService = {
-  async listMembers({ keyword = '', page = 1, pageSize = 20, rechargeSort = '' } = {}) {
+  async listMembers({ keyword = '', page = 1, pageSize = 20, sortBy = '', rechargeSort = '' } = {}) {
     return callCloud(CLOUD_FUNCTIONS.ADMIN, {
       action: 'listMembers',
       keyword,
       page,
       pageSize,
+      sortBy,
       rechargeSort
     });
   },

--- a/miniprogram/subpackages/admin/members/index.js
+++ b/miniprogram/subpackages/admin/members/index.js
@@ -15,7 +15,13 @@ Page({
     pageSize: PAGE_SIZE,
     finished: false,
     error: '',
-    defaultAvatar: DEFAULT_AVATAR
+    defaultAvatar: DEFAULT_AVATAR,
+    rechargeSort: '',
+    rechargeSortOptions: [
+      { value: '', label: '默认排序' },
+      { value: 'asc', label: '累计充值升序' },
+      { value: 'desc', label: '累计充值降序' }
+    ]
   },
 
   onShow() {
@@ -41,6 +47,14 @@ Page({
     this.fetchMembers(true);
   },
 
+  handleRechargeSortTap(event) {
+    const { value = '' } = event.currentTarget.dataset || {};
+    const rechargeSort = value === 'asc' || value === 'desc' ? value : '';
+    if (rechargeSort === this.data.rechargeSort) return;
+    this.setData({ rechargeSort });
+    this.fetchMembers(true);
+  },
+
   async fetchMembers(reset = false) {
     const nextPage = reset ? 1 : this.data.page;
     this.setData({ loading: true, error: '' });
@@ -48,7 +62,8 @@ Page({
       const response = await AdminService.listMembers({
         keyword: this.data.keyword.trim(),
         page: nextPage,
-        pageSize: this.data.pageSize
+        pageSize: this.data.pageSize,
+        rechargeSort: this.data.rechargeSort
       });
       const incoming = (response.members || []).map((member) => ({
         ...member,

--- a/miniprogram/subpackages/admin/members/index.js
+++ b/miniprogram/subpackages/admin/members/index.js
@@ -24,7 +24,8 @@ Page({
       { value: 'createdAtDesc', label: '注册时间排序' },
       { value: 'updatedAtDesc', label: '上次登录时间排序' }
     ],
-    memberSortLabel: '默认排序'
+    memberSortLabel: '默认排序',
+    sortDropdownVisible: false
   },
 
   onShow() {
@@ -50,22 +51,31 @@ Page({
     this.fetchMembers(true);
   },
 
-  handleMemberSortChange(event) {
-    const index = Number(event.detail.value || 0);
+  handleMemberSortToggle() {
+    this.setData({ sortDropdownVisible: !this.data.sortDropdownVisible });
+  },
+
+  handleMemberSortSelect(event) {
+    const index = Number(event.currentTarget.dataset.index || 0);
     const option = this.data.memberSortOptions[index] || this.data.memberSortOptions[0];
     const memberSort = option.value || '';
-    if (memberSort === this.data.memberSort) return;
-    this.setData({
+    const nextState = {
+      sortDropdownVisible: false,
       memberSort,
       memberSortIndex: index,
       memberSortLabel: option.label || '默认排序'
-    });
+    };
+    if (memberSort === this.data.memberSort) {
+      this.setData(nextState);
+      return;
+    }
+    this.setData(nextState);
     this.fetchMembers(true);
   },
 
   async fetchMembers(reset = false) {
     const nextPage = reset ? 1 : this.data.page;
-    this.setData({ loading: true, error: '' });
+    this.setData({ loading: true, error: '', sortDropdownVisible: false });
     try {
       const response = await AdminService.listMembers({
         keyword: this.data.keyword.trim(),

--- a/miniprogram/subpackages/admin/members/index.js
+++ b/miniprogram/subpackages/admin/members/index.js
@@ -17,12 +17,14 @@ Page({
     error: '',
     defaultAvatar: DEFAULT_AVATAR,
     memberSort: '',
+    memberSortIndex: 0,
     memberSortOptions: [
       { value: '', label: '默认排序' },
       { value: 'rechargeDesc', label: '累计充值降序' },
       { value: 'createdAtDesc', label: '注册时间排序' },
       { value: 'updatedAtDesc', label: '上次登录时间排序' }
-    ]
+    ],
+    memberSortLabel: '默认排序'
   },
 
   onShow() {
@@ -48,12 +50,16 @@ Page({
     this.fetchMembers(true);
   },
 
-  handleMemberSortTap(event) {
-    const { value = '' } = event.currentTarget.dataset || {};
-    const allowedSorts = ['', 'rechargeDesc', 'createdAtDesc', 'updatedAtDesc'];
-    const memberSort = allowedSorts.includes(value) ? value : '';
+  handleMemberSortChange(event) {
+    const index = Number(event.detail.value || 0);
+    const option = this.data.memberSortOptions[index] || this.data.memberSortOptions[0];
+    const memberSort = option.value || '';
     if (memberSort === this.data.memberSort) return;
-    this.setData({ memberSort });
+    this.setData({
+      memberSort,
+      memberSortIndex: index,
+      memberSortLabel: option.label || '默认排序'
+    });
     this.fetchMembers(true);
   },
 

--- a/miniprogram/subpackages/admin/members/index.js
+++ b/miniprogram/subpackages/admin/members/index.js
@@ -16,11 +16,12 @@ Page({
     finished: false,
     error: '',
     defaultAvatar: DEFAULT_AVATAR,
-    rechargeSort: '',
-    rechargeSortOptions: [
+    memberSort: '',
+    memberSortOptions: [
       { value: '', label: '默认排序' },
-      { value: 'asc', label: '累计充值升序' },
-      { value: 'desc', label: '累计充值降序' }
+      { value: 'rechargeDesc', label: '累计充值降序' },
+      { value: 'createdAtDesc', label: '注册时间排序' },
+      { value: 'updatedAtDesc', label: '上次登录时间排序' }
     ]
   },
 
@@ -47,11 +48,12 @@ Page({
     this.fetchMembers(true);
   },
 
-  handleRechargeSortTap(event) {
+  handleMemberSortTap(event) {
     const { value = '' } = event.currentTarget.dataset || {};
-    const rechargeSort = value === 'asc' || value === 'desc' ? value : '';
-    if (rechargeSort === this.data.rechargeSort) return;
-    this.setData({ rechargeSort });
+    const allowedSorts = ['', 'rechargeDesc', 'createdAtDesc', 'updatedAtDesc'];
+    const memberSort = allowedSorts.includes(value) ? value : '';
+    if (memberSort === this.data.memberSort) return;
+    this.setData({ memberSort });
     this.fetchMembers(true);
   },
 
@@ -63,7 +65,7 @@ Page({
         keyword: this.data.keyword.trim(),
         page: nextPage,
         pageSize: this.data.pageSize,
-        rechargeSort: this.data.rechargeSort
+        sortBy: this.data.memberSort
       });
       const incoming = (response.members || []).map((member) => ({
         ...member,

--- a/miniprogram/subpackages/admin/members/index.wxml
+++ b/miniprogram/subpackages/admin/members/index.wxml
@@ -14,18 +14,19 @@
 
   <view class="sort-panel">
     <view class="sort-label">会员列表排序</view>
-    <picker
-      mode="selector"
-      range="{{memberSortOptions}}"
-      range-key="label"
-      value="{{memberSortIndex}}"
-      bindchange="handleMemberSortChange"
-    >
-      <view class="sort-picker">
-        <text class="sort-picker__value">{{memberSortLabel}}</text>
-        <text class="sort-picker__arrow">⌄</text>
-      </view>
-    </picker>
+    <view class="sort-picker" bindtap="handleMemberSortToggle">
+      <text class="sort-picker__value">{{memberSortLabel}}</text>
+      <text class="sort-picker__arrow {{sortDropdownVisible ? 'sort-picker__arrow--open' : ''}}">⌄</text>
+    </view>
+    <view wx:if="{{sortDropdownVisible}}" class="sort-dropdown">
+      <view
+        wx:for="{{memberSortOptions}}"
+        wx:key="value"
+        class="sort-dropdown__item {{memberSortIndex === index ? 'sort-dropdown__item--active' : ''}}"
+        data-index="{{index}}"
+        catchtap="handleMemberSortSelect"
+      >{{item.label}}</view>
+    </view>
   </view>
 
   <view wx:if="{{loading && !members.length}}" class="loading">加载中...</view>

--- a/miniprogram/subpackages/admin/members/index.wxml
+++ b/miniprogram/subpackages/admin/members/index.wxml
@@ -12,6 +12,19 @@
     <button class="search-button" bindtap="handleSearch">搜索</button>
   </view>
 
+  <view class="sort-panel">
+    <view class="sort-label">累计充值排序</view>
+    <view class="sort-options">
+      <view
+        wx:for="{{rechargeSortOptions}}"
+        wx:key="value"
+        class="sort-chip {{rechargeSort === item.value ? 'sort-chip--active' : ''}}"
+        data-value="{{item.value}}"
+        bindtap="handleRechargeSortTap"
+      >{{item.label}}</view>
+    </view>
+  </view>
+
   <view wx:if="{{loading && !members.length}}" class="loading">加载中...</view>
   <view wx:elif="{{!members.length}}" class="empty">未找到相关会员</view>
 

--- a/miniprogram/subpackages/admin/members/index.wxml
+++ b/miniprogram/subpackages/admin/members/index.wxml
@@ -13,14 +13,14 @@
   </view>
 
   <view class="sort-panel">
-    <view class="sort-label">累计充值排序</view>
+    <view class="sort-label">会员列表排序</view>
     <view class="sort-options">
       <view
-        wx:for="{{rechargeSortOptions}}"
+        wx:for="{{memberSortOptions}}"
         wx:key="value"
-        class="sort-chip {{rechargeSort === item.value ? 'sort-chip--active' : ''}}"
+        class="sort-chip {{memberSort === item.value ? 'sort-chip--active' : ''}}"
         data-value="{{item.value}}"
-        bindtap="handleRechargeSortTap"
+        bindtap="handleMemberSortTap"
       >{{item.label}}</view>
     </view>
   </view>

--- a/miniprogram/subpackages/admin/members/index.wxml
+++ b/miniprogram/subpackages/admin/members/index.wxml
@@ -14,15 +14,18 @@
 
   <view class="sort-panel">
     <view class="sort-label">会员列表排序</view>
-    <view class="sort-options">
-      <view
-        wx:for="{{memberSortOptions}}"
-        wx:key="value"
-        class="sort-chip {{memberSort === item.value ? 'sort-chip--active' : ''}}"
-        data-value="{{item.value}}"
-        bindtap="handleMemberSortTap"
-      >{{item.label}}</view>
-    </view>
+    <picker
+      mode="selector"
+      range="{{memberSortOptions}}"
+      range-key="label"
+      value="{{memberSortIndex}}"
+      bindchange="handleMemberSortChange"
+    >
+      <view class="sort-picker">
+        <text class="sort-picker__value">{{memberSortLabel}}</text>
+        <text class="sort-picker__arrow">⌄</text>
+      </view>
+    </picker>
   </view>
 
   <view wx:if="{{loading && !members.length}}" class="loading">加载中...</view>

--- a/miniprogram/subpackages/admin/members/index.wxss
+++ b/miniprogram/subpackages/admin/members/index.wxss
@@ -54,27 +54,25 @@ page {
   color: #94a3b8;
 }
 
-.sort-options {
+.sort-picker {
   display: flex;
-  flex-wrap: wrap;
-  gap: 12rpx;
-}
-
-.sort-chip {
-  padding: 12rpx 20rpx;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 72rpx;
+  padding: 0 22rpx;
   border: 1px solid rgba(148, 163, 184, 0.28);
-  border-radius: 999rpx;
-  color: #cbd5e1;
-  font-size: 24rpx;
-  line-height: 1.4;
+  border-radius: 16rpx;
   background: rgba(30, 41, 59, 0.72);
+  color: #f8fafc;
 }
 
-.sort-chip--active {
-  color: #fff;
-  border-color: rgba(96, 165, 250, 0.7);
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.92), rgba(139, 92, 246, 0.92));
-  box-shadow: 0 10rpx 24rpx rgba(59, 130, 246, 0.22);
+.sort-picker__value {
+  font-size: 26rpx;
+}
+
+.sort-picker__arrow {
+  color: #94a3b8;
+  font-size: 28rpx;
 }
 
 .loading,

--- a/miniprogram/subpackages/admin/members/index.wxss
+++ b/miniprogram/subpackages/admin/members/index.wxss
@@ -41,6 +41,8 @@ page {
 }
 
 .sort-panel {
+  position: relative;
+  z-index: 10;
   margin: -8rpx 0 24rpx;
   padding: 20rpx;
   background: rgba(15, 23, 42, 0.62);
@@ -73,6 +75,41 @@ page {
 .sort-picker__arrow {
   color: #94a3b8;
   font-size: 28rpx;
+  transition: transform 0.2s ease;
+}
+
+.sort-picker__arrow--open {
+  transform: rotate(180deg);
+}
+
+.sort-dropdown {
+  position: absolute;
+  left: 20rpx;
+  right: 20rpx;
+  top: 124rpx;
+  z-index: 20;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 16rpx;
+  background: #f8fafc;
+  box-shadow: 0 18rpx 42rpx rgba(15, 23, 42, 0.3);
+}
+
+.sort-dropdown__item {
+  padding: 24rpx 28rpx;
+  color: #334155;
+  font-size: 28rpx;
+  line-height: 1.35;
+  background: #f8fafc;
+}
+
+.sort-dropdown__item + .sort-dropdown__item {
+  border-top: 1px solid rgba(226, 232, 240, 0.9);
+}
+
+.sort-dropdown__item--active {
+  color: #f97316;
+  font-weight: 600;
 }
 
 .loading,

--- a/miniprogram/subpackages/admin/members/index.wxss
+++ b/miniprogram/subpackages/admin/members/index.wxss
@@ -40,6 +40,43 @@ page {
   font-size: 28rpx;
 }
 
+.sort-panel {
+  margin: -8rpx 0 24rpx;
+  padding: 20rpx;
+  background: rgba(15, 23, 42, 0.62);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 18rpx;
+}
+
+.sort-label {
+  margin-bottom: 14rpx;
+  font-size: 24rpx;
+  color: #94a3b8;
+}
+
+.sort-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12rpx;
+}
+
+.sort-chip {
+  padding: 12rpx 20rpx;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 999rpx;
+  color: #cbd5e1;
+  font-size: 24rpx;
+  line-height: 1.4;
+  background: rgba(30, 41, 59, 0.72);
+}
+
+.sort-chip--active {
+  color: #fff;
+  border-color: rgba(96, 165, 250, 0.7);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.92), rgba(139, 92, 246, 0.92));
+  box-shadow: 0 10rpx 24rpx rgba(59, 130, 246, 0.22);
+}
+
 .loading,
 .empty,
 .end {


### PR DESCRIPTION
### Motivation
- 需要在管理员中心的会员列表中新增按“累计充值金额”升序/降序排序的能力，并把排序控件放在搜索框下方以便管理员快速筛选。

### Description
- 在 `miniprogram/subpackages/admin/members/index.wxml` 增加了排序面板，提供“默认排序 / 累计充值升序 / 累计充值降序”三个选项并绑定点击处理器。 
- 在 `miniprogram/subpackages/admin/members/index.js` 中添加了 `rechargeSort` 状态、`rechargeSortOptions`、`handleRechargeSortTap` 事件并在切换后刷新第一页数据；在 `fetchMembers` 中将 `rechargeSort` 传递给服务层。 
- 在 `miniprogram/subpackages/admin/members/index.wxss` 增加了排序面板与激活态样式以保持视觉一致性。 
- 在前端 API `miniprogram/services/api.js` 扩展了 `AdminService.listMembers` 的参数，向云函数传递 `rechargeSort`。 
- 在后端云函数 `cloudfunctions/admin/index.js` 中扩展了 `listMembers` 签名以接收 `rechargeSort`，并在存在有效值时用 `orderBy('totalRecharge', 'asc'|'desc')` 优先排序，且以 `createdAt desc` 作为次级稳定排序；未指定排序时保持原有按 `createdAt desc` 排序。 

### Testing
- 运行语法检查 `node --check cloudfunctions/admin/index.js`，检查通过。 
- 运行语法检查 `node --check miniprogram/subpackages/admin/members/index.js`，检查通过。 
- 运行语法检查 `node --check miniprogram/services/api.js`，检查通过.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f4747f570832ca07772c67803d92b)