### PR TITLE
style: align member sort dropdown colors

### DIFF
--- a/miniprogram/subpackages/admin/members/index.wxss
+++ b/miniprogram/subpackages/admin/members/index.wxss
@@ -89,22 +89,22 @@ page {
   top: 124rpx;
   z-index: 20;
   overflow: hidden;
-  border: 1px solid rgba(148, 163, 184, 0.22);
+  border: 1px solid rgba(148, 163, 184, 0.28);
   border-radius: 16rpx;
-  background: #f8fafc;
-  box-shadow: 0 18rpx 42rpx rgba(15, 23, 42, 0.3);
+  background: #0f172a;
+  box-shadow: 0 18rpx 42rpx rgba(2, 6, 23, 0.45);
 }
 
 .sort-dropdown__item {
   padding: 24rpx 28rpx;
-  color: #334155;
+  color: #cbd5e1;
   font-size: 28rpx;
   line-height: 1.35;
-  background: #f8fafc;
+  background: rgba(15, 23, 42, 0.96);
 }
 
 .sort-dropdown__item + .sort-dropdown__item {
-  border-top: 1px solid rgba(226, 232, 240, 0.9);
+  border-top: 1px solid rgba(148, 163, 184, 0.16);
 }
 
 .sort-dropdown__item--active {


### PR DESCRIPTION
### Motivation
- Make the member list sort dropdown follow the page dark UI so the control visually matches the surrounding admin member list.

### Description
- Updated `miniprogram/subpackages/admin/members/index.wxss` to change `.sort-dropdown` border, background and shadow and to adjust `.sort-dropdown__item` text color, item background and divider; the active item highlight remains `#f97316`.

### Testing
- Ran `npm test -- --runInBand`; the test run failed due to existing `cloudfunctions/guild` unit tests and global coverage thresholds unrelated to this WXSS-only style change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f554afa2c832c8000f564e46ebf21)