### PR TITLE
Persist admin member list sort selection

### DIFF
--- a/miniprogram/subpackages/admin/members/index.js
+++ b/miniprogram/subpackages/admin/members/index.js
@@ -4,6 +4,35 @@ const { AVATAR_IMAGE_BASE_PATH } = require('../../../shared/asset-paths.js');
 
 const PAGE_SIZE = 20;
 const DEFAULT_AVATAR = `${AVATAR_IMAGE_BASE_PATH}/default.png`;
+const MEMBER_SORT_STORAGE_KEY = 'admin:members:sort';
+
+function findMemberSortOption(options, value) {
+  return options.find((option) => option.value === value) || options[0];
+}
+
+function readStoredMemberSort(options) {
+  if (typeof wx === 'undefined' || !wx || typeof wx.getStorageSync !== 'function') {
+    return options[0];
+  }
+  try {
+    const storedValue = wx.getStorageSync(MEMBER_SORT_STORAGE_KEY);
+    return findMemberSortOption(options, storedValue || '');
+  } catch (error) {
+    console.warn('[admin:members:sort:read]', error);
+    return options[0];
+  }
+}
+
+function writeStoredMemberSort(value) {
+  if (typeof wx === 'undefined' || !wx || typeof wx.setStorageSync !== 'function') {
+    return;
+  }
+  try {
+    wx.setStorageSync(MEMBER_SORT_STORAGE_KEY, value || '');
+  } catch (error) {
+    console.warn('[admin:members:sort:write]', error);
+  }
+}
 
 Page({
   data: {
@@ -26,6 +55,16 @@ Page({
     ],
     memberSortLabel: '默认排序',
     sortDropdownVisible: false
+  },
+
+  onLoad() {
+    const option = readStoredMemberSort(this.data.memberSortOptions);
+    const index = this.data.memberSortOptions.findIndex((item) => item.value === option.value);
+    this.setData({
+      memberSort: option.value || '',
+      memberSortIndex: index >= 0 ? index : 0,
+      memberSortLabel: option.label || '默认排序'
+    });
   },
 
   onShow() {
@@ -67,9 +106,11 @@ Page({
     };
     if (memberSort === this.data.memberSort) {
       this.setData(nextState);
+      writeStoredMemberSort(memberSort);
       return;
     }
     this.setData(nextState);
+    writeStoredMemberSort(memberSort);
     this.fetchMembers(true);
   },
 


### PR DESCRIPTION
### Motivation
- Keep the admin member list sort preference across app sessions so admins return to the same sort mode (e.g. 累计充值降序) after reopening the page. 
- Avoid surprising defaults and improve usability for frequent admin workflows.

### Description
- Added a storage key `admin:members:sort` and safe `readStoredMemberSort` / `writeStoredMemberSort` helpers that guard against missing `wx` APIs. 
- On page load (`onLoad`) the saved sort option is restored and the page state (`memberSort`, `memberSortIndex`, `memberSortLabel`) is initialized accordingly. 
- The selected sort option is persisted whenever the admin chooses a sort item (including re-selecting the current option) in `handleMemberSortSelect`.

### Testing
- Verified syntax with `node --check miniprogram/subpackages/admin/members/index.js`, which succeeded. 
- Ran unit tests with `npm test -- --runInBand`; tests failed due to existing `cloudfunctions/guild` test failures and coverage threshold violations unrelated to the member-list change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f56938230832caf2c040572a60eb9)